### PR TITLE
Pin npm installer to package release tag

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agenttrace",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "description": "Audit local AI coding-agent sessions for cost, token waste, failures, latency, anomalies, health, diffs, and CI gate signals.",
   "author": {
     "name": "luoyuctl",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/luoyuctl/agenttrace/stargazers"><img src="https://img.shields.io/github/stars/luoyuctl/agenttrace?style=social" alt="GitHub stars"></a>
   <img src="https://img.shields.io/badge/go-1.24+-00ADD8.svg" alt="Go">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
-  <img src="https://img.shields.io/badge/Homebrew-v0.3.41-2bbc8a.svg" alt="Homebrew">
+  <img src="https://img.shields.io/badge/Homebrew-v0.3.42-2bbc8a.svg" alt="Homebrew">
 </p>
 
 <h3 align="center">💸 Stop burning cash and hours on invisible AI agent waste</h3>
@@ -27,6 +27,8 @@ AI coding agents (Claude Code, Gemini CLI, Codex CLI) burn tokens in loops, retr
 Site: https://luoyuctl.github.io/agenttrace/
 
 Sample HTML report: https://luoyuctl.github.io/agenttrace/demo-report.html
+
+Featured in: [Awesome Codex CLI](https://github.com/RoggeOhta/awesome-codex-cli), [Awesome Gemini CLI](https://github.com/Piebald-AI/awesome-gemini-cli), [Charm in the Wild](https://github.com/charm-and-friends/charm-in-the-wild), and [Awesome Claude Code and Skills](https://github.com/GetBindu/awesome-claude-code-and-skills).
 
 <p align="center">
   <img src="assets/agenttrace-demo.gif" alt="agenttrace TUI demo" width="100%">
@@ -215,7 +217,7 @@ See [docs/cursor-import.md](docs/cursor-import.md) for details.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  AGENTTRACE v0.3.41 — AI Agent Session Performance Report
+  AGENTTRACE v0.3.42 — AI Agent Session Performance Report
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 💰 TOKEN COST

--- a/homebrew/Formula/agenttrace.rb
+++ b/homebrew/Formula/agenttrace.rb
@@ -2,7 +2,7 @@ class Agenttrace < Formula
   desc "TUI observability for AI coding agent sessions, cost, latency, and anomalies"
   homepage "https://github.com/luoyuctl/agenttrace"
   url "https://github.com/luoyuctl/agenttrace.git", branch: "master"
-  version "0.3.41"
+  version "0.3.42"
   license "MIT"
 
   depends_on "go" => :build
@@ -12,6 +12,6 @@ class Agenttrace < Formula
   end
 
   test do
-    assert_match "agenttrace v0.3.41", shell_output("#{bin}/agenttrace --version")
+    assert_match "agenttrace v0.3.42", shell_output("#{bin}/agenttrace --version")
   end
 end

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,7 +15,7 @@ import (
 	"github.com/luoyuctl/agenttrace/internal/i18n"
 )
 
-const Version = "0.3.41"
+const Version = "0.3.42"
 
 // Severity constants for anomaly severity (internal, not i18n).
 const (

--- a/npm/README.md
+++ b/npm/README.md
@@ -33,6 +33,7 @@ From this directory:
 node --check install.js
 node --check run.js
 AGENTTRACE_BIN=/path/to/agenttrace node run.js --version
+AGENTTRACE_RELEASE_TAG=v0.3.41 node install.js
 npm pack --dry-run
 ```
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -6,6 +6,8 @@ const path = require('path');
 const https = require('https');
 
 const REPO = 'luoyuctl/agenttrace';
+const PACKAGE_VERSION = require('./package.json').version;
+const RELEASE_TAG = process.env.AGENTTRACE_RELEASE_TAG || `v${PACKAGE_VERSION}`;
 const REQUEST_TIMEOUT_MS = Number(process.env.AGENTTRACE_NPM_TIMEOUT_MS || 120000);
 const REDIRECT_CODES = new Set([301, 302, 303, 307, 308]);
 const REQUEST_OPTIONS = {
@@ -80,11 +82,11 @@ async function download(url, dest, redirects = 0) {
     });
 }
 
-async function fetchLatestRelease() {
+async function fetchRelease() {
     return new Promise((resolve, reject) => {
         const req = https.get({
             hostname: 'api.github.com',
-            path: `/repos/${REPO}/releases/latest`,
+            path: `/repos/${REPO}/releases/tags/${encodeURIComponent(RELEASE_TAG)}`,
             family: 4,
             headers: REQUEST_OPTIONS.headers,
         }, (res) => {
@@ -93,7 +95,7 @@ async function fetchLatestRelease() {
             res.on('data', (chunk) => { body += chunk; });
             res.on('end', () => {
                 if (res.statusCode !== 200) {
-                    reject(new Error(`GitHub release lookup failed: HTTP ${res.statusCode}`));
+                    reject(new Error(`GitHub release lookup failed for ${RELEASE_TAG}: HTTP ${res.statusCode}`));
                     return;
                 }
                 try {
@@ -104,7 +106,7 @@ async function fetchLatestRelease() {
             });
         });
         req.setTimeout(REQUEST_TIMEOUT_MS, () => {
-            req.destroy(new Error(`Timed out after ${REQUEST_TIMEOUT_MS}ms: GitHub release lookup`));
+            req.destroy(new Error(`Timed out after ${REQUEST_TIMEOUT_MS}ms: GitHub release lookup for ${RELEASE_TAG}`));
         });
         req.on('error', reject);
     });
@@ -113,7 +115,7 @@ async function fetchLatestRelease() {
 async function main() {
     const { goos, goarch, ext } = getPlatform();
     const binary = 'agenttrace' + ext;
-    const release = await fetchLatestRelease();
+    const release = await fetchRelease();
     const suffix = `${goos}-${goarch}${ext}`;
     const asset = (release.assets || []).find((item) => item.name === `${binary}-${suffix}` || item.name.endsWith(suffix));
     if (!asset) {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenttrace",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "description": "High-signal TUI observability for AI coding agent sessions, cost, tools, latency, and anomalies",
   "main": "install.js",
   "bin": {

--- a/site/index.html
+++ b/site/index.html
@@ -28,7 +28,7 @@
         "name": "agenttrace",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
-        "softwareVersion": "0.3.41",
+        "softwareVersion": "0.3.42",
         "description": "TUI observability for AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Kimi, and Copilot-style logs.",
         "url": "https://luoyuctl.github.io/agenttrace/",
         "codeRepository": "https://github.com/luoyuctl/agenttrace",


### PR DESCRIPTION
## Summary

- Make the npm postinstall script fetch the release tag matching package.json instead of /latest.
- Keep an AGENTTRACE_RELEASE_TAG override for maintainer smoke tests against an existing release.
- Bump version references to v0.3.42 for the next release.

## Validation
- go test ./...
- go build -o /tmp/agenttrace ./cmd/agenttrace
- node --check npm/install.js && node --check npm/run.js
- AGENTTRACE_RELEASE_TAG=v0.3.41 node install.js, then node run.js --version- npm pack --dry-run