### PR TITLE
Improve localized session triage

### DIFF
--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -125,7 +125,7 @@ func CachedSession(path string, cache SessionCache) (Session, bool) {
 	}
 	s := entry.Session
 	s.Path = path
-	return s, true
+	return LocalizeSession(s), true
 }
 
 // FindSessionFilesCached discovers session files using cached directory

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1846,6 +1846,78 @@ func LoadSession(path string) (*Session, error) {
 	}, nil
 }
 
+// LocalizeSession 为缓存命中的会话重建当前语言下的诊断文案。
+func LocalizeSession(s Session) Session {
+	if metricsHaveDiagnosticData(s.Metrics) {
+		s.Anomalies = DetectAnomalies(s.Metrics)
+		s.Health = HealthScore(s.Metrics, s.Anomalies)
+	}
+	for i := range s.LoopFingerprints {
+		fp := &s.LoopFingerprints[i]
+		if fp.ToolName != "" && fp.Count > 0 {
+			fp.Detail = fmt.Sprintf(i18n.T("diag_loop_fp_detail"), fp.ToolName, fp.Count)
+		}
+	}
+	if s.ContextUtil.RiskLevel != "" {
+		s.ContextUtil.Suggestion = contextSuggestionForRisk(s.ContextUtil.RiskLevel)
+	}
+	for i := range s.LargeParams {
+		lp := &s.LargeParams[i]
+		if lp.ToolName != "" && lp.ParamSize > 0 {
+			lp.Detail = fmt.Sprintf(i18n.T("diag_large_param_args"), lp.ToolName, lp.ParamSize)
+		}
+	}
+	for i := range s.UnusedTools {
+		ut := &s.UnusedTools[i]
+		if ut.ToolName != "" && ut.CallCount > 0 {
+			ut.Detail = fmt.Sprintf(i18n.T("diag_unused_detail"), ut.ToolName, ut.CallCount)
+		}
+	}
+	for i := range s.ToolWarnings {
+		tw := &s.ToolWarnings[i]
+		if detail := localizedToolWarningDetail(*tw); detail != "" {
+			tw.Detail = detail
+		}
+	}
+	return s
+}
+
+func metricsHaveDiagnosticData(m Metrics) bool {
+	return len(m.GapsSec) > 0 ||
+		m.ToolCallsOK > 0 ||
+		m.ToolCallsFail > 0 ||
+		m.ToolCallsTotal > 0 ||
+		len(m.ReasoningLens) > 0 ||
+		m.ReasoningRedact > 0 ||
+		m.AssistantTurns > 0
+}
+
+func contextSuggestionForRisk(risk string) string {
+	switch risk {
+	case "critical":
+		return i18n.T("diag_ctx_suggestion_critical")
+	case "warning":
+		return i18n.T("diag_ctx_suggestion_warning")
+	default:
+		return i18n.T("diag_ctx_suggestion_good")
+	}
+}
+
+func localizedToolWarningDetail(tw ToolWarning) string {
+	switch tw.Pattern {
+	case "dead_loop":
+		return fmt.Sprintf(i18n.T("tool_warn_dead_loop_detail"), tw.ToolName, tw.Count)
+	case "empty_args":
+		return fmt.Sprintf(i18n.T("tool_warn_empty_args_detail"), tw.ToolName, tw.Count)
+	case "fail_retry_chain":
+		return fmt.Sprintf(i18n.T("tool_warn_fail_retry_detail"), tw.ToolName, tw.Count)
+	case "redundant":
+		return fmt.Sprintf(i18n.T("tool_warn_redundant"), tw.ToolName, tw.Count)
+	default:
+		return ""
+	}
+}
+
 func LoadAll(dir string) []Session {
 	if dir == "" {
 		return ScanAllDirs()
@@ -3729,14 +3801,12 @@ func AnalyzeContextUtilization(events []Event, model string, mcpToolCount int) C
 	switch {
 	case cu.AvailableForTask < 20000:
 		cu.RiskLevel = "critical"
-		cu.Suggestion = i18n.T("diag_ctx_suggestion_critical")
 	case cu.AvailableForTask < 50000:
 		cu.RiskLevel = "warning"
-		cu.Suggestion = i18n.T("diag_ctx_suggestion_warning")
 	default:
 		cu.RiskLevel = "good"
-		cu.Suggestion = i18n.T("diag_ctx_suggestion_good")
 	}
+	cu.Suggestion = contextSuggestionForRisk(cu.RiskLevel)
 	return cu
 }
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -411,6 +411,65 @@ func TestLoadSessionCacheSkipsOnlyBadEntries(t *testing.T) {
 	}
 }
 
+func TestCachedSessionRelocalizesLanguageDependentDiagnostics(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.ZH)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cached.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cache := SessionCache{Entries: map[string]CacheEntry{
+		path: {
+			ModTime: info.ModTime().UnixNano(),
+			Size:    info.Size(),
+			Session: Session{
+				Name: "cached",
+				Metrics: Metrics{
+					GapsSec:        []float64{61, 302},
+					AssistantTurns: 3,
+				},
+				Anomalies: []Anomaly{{Type: "hanging", Severity: SeverityHigh, Detail: "2 gap(s) >60s, max=302s"}},
+				ContextUtil: ContextUtilization{
+					RiskLevel:  "warning",
+					Suggestion: "context filling up",
+				},
+				LargeParams:      []LargeParamCall{{ToolName: "terminal", ParamSize: 12000, Detail: "terminal arguments are 12000 chars"}},
+				UnusedTools:      []UnusedToolInfo{{ToolName: "terminal", CallCount: 1, Detail: "tool 'terminal' called only 1x"}},
+				LoopFingerprints: []LoopFingerprint{{ToolName: "terminal", Count: 3, Detail: "tool 'terminal' returned same result 3x"}},
+				ToolWarnings:     []ToolWarning{{ToolName: "terminal", Pattern: "empty_args", Count: 1, Detail: "terminal called with empty arguments"}},
+			},
+		},
+	}}
+
+	got, ok := CachedSession(path, cache)
+	if !ok {
+		t.Fatalf("expected cached session")
+	}
+	for _, want := range []string{"最长", "上下文", "参数", "仅调用", "参数为空"} {
+		joined := strings.Join([]string{
+			got.Anomalies[0].Detail,
+			got.ContextUtil.Suggestion,
+			got.LargeParams[0].Detail,
+			got.UnusedTools[0].Detail,
+			got.ToolWarnings[0].Detail,
+		}, "\n")
+		if !strings.Contains(joined, want) {
+			t.Fatalf("cached session missing localized text %q:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(got.Anomalies[0].Detail, "gap(s)") || strings.Contains(got.ContextUtil.Suggestion, "context") {
+		t.Fatalf("cached session kept stale English diagnostics: %+v", got)
+	}
+}
+
 func TestAnalyze(t *testing.T) {
 	events := []Event{
 		{Role: "user", Content: "hello", SourceTool: "h", Timestamp: "2026-01-01T00:00:00Z"},
@@ -587,6 +646,29 @@ func TestReportOverviewMarkdownChineseLabels(t *testing.T) {
 	for _, unwanted := range []string{"Metric", "Recent sessions", "Tool failures", "| bad | hanging |"} {
 		if strings.Contains(out, unwanted) {
 			t.Fatalf("Chinese markdown report leaked English label %q:\n%s", unwanted, out)
+		}
+	}
+}
+
+func TestReportTextChineseLabelsAnomalySeverityAndLoopCost(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.ZH)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	out := ReportText(Metrics{
+		LoopGroups:      1,
+		LoopCostEst:     0.25,
+		LoopRetryEvents: 2,
+	}, []Anomaly{{Type: "redaction", Severity: SeverityHigh, Emoji: "!"}}, 42)
+
+	for _, want := range []string{"[严重] 思维脱敏", "循环成本", "工具循环成本", "重试事件"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("Chinese report text missing %q:\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{"[HIGH]", "redaction", "LOOP COST", "Tool Loop Cost", "Retry Events"} {
+		if strings.Contains(out, unwanted) {
+			t.Fatalf("Chinese report text leaked English label %q:\n%s", unwanted, out)
 		}
 	}
 }

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -138,7 +138,7 @@ func ReportText(m Metrics, anoms []Anomaly, h int) string {
 	w(sub)
 	if len(anoms) > 0 {
 		for _, a := range anoms {
-			wf("  %s [%s] %s: %s", a.Emoji, strings.ToUpper(a.Severity), a.Type, a.Detail)
+			wf("  %s [%s] %s: %s", a.Emoji, reportSeverityLabel(a.Severity), reportAnomalyTypeLabel(a.Type), a.Detail)
 		}
 	} else {
 		w("  " + i18n.T("no_anomalies"))
@@ -147,10 +147,10 @@ func ReportText(m Metrics, anoms []Anomaly, h int) string {
 
 	// Loop Cost
 	if m.LoopGroups > 0 {
-		w("🔄 LOOP COST")
+		w("🔄 " + i18n.T("loop_section_title"))
 		w(sub)
-		wf("  Tool Loop Cost:    $%9.4f  (%d groups)", m.LoopCostEst, m.LoopGroups)
-		wf("  Retry Events:       %d", m.LoopRetryEvents)
+		wf("  "+i18n.T("loop_tool_loop_cost"), m.LoopCostEst, m.LoopGroups)
+		wf("  "+i18n.T("loop_retry_events"), m.LoopRetryEvents)
 		w("")
 	}
 
@@ -664,6 +664,19 @@ func reportAnomalyTypeLabel(kind string) string {
 		return translated
 	}
 	return strings.ReplaceAll(kind, "_", " ")
+}
+
+func reportSeverityLabel(severity string) string {
+	switch strings.ToLower(severity) {
+	case SeverityHigh:
+		return i18n.T("severity_high")
+	case SeverityMedium:
+		return i18n.T("severity_medium")
+	case SeverityLow:
+		return i18n.T("severity_low")
+	default:
+		return strings.ToUpper(severity)
+	}
 }
 
 type overviewSummary struct {

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -296,6 +296,10 @@ var translations = map[string]map[Lang]string{
 		EN: "ANOM",
 		ZH: "异常",
 	},
+	"issue_col": {
+		EN: "ISSUE",
+		ZH: "问题",
+	},
 	"input_per_m": {
 		EN: "Input $/M",
 		ZH: "输入$/M",
@@ -942,6 +946,7 @@ var translations = map[string]map[Lang]string{
 	"anomaly_type_tool_failures":    {EN: "tool failures", ZH: "工具失败"},
 	"anomaly_type_shallow_thinking": {EN: "shallow thinking", ZH: "浅层思考"},
 	"anomaly_type_redacted":         {EN: "redacted thinking", ZH: "思维脱敏"},
+	"anomaly_type_redaction":        {EN: "redacted thinking", ZH: "思维脱敏"},
 	"anomaly_type_no_tools":         {EN: "no tools", ZH: "未使用工具"},
 	"risk_critical":                 {EN: "critical", ZH: "严重"},
 	"risk_warning":                  {EN: "warning", ZH: "警告"},

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -755,7 +755,14 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 	health := clampHealth(s.Health)
 	healthWidth := 9
 	if cols := m.table.Columns(); len(cols) > 0 {
-		healthWidth = cols[len(cols)-1].Width
+		healthIdx := len(cols) - 1
+		switch len(cols) {
+		case 13:
+			healthIdx = 11
+		case 10:
+			healthIdx = 8
+		}
+		healthWidth = cols[healthIdx].Width
 	}
 	healthCol := healthCell(health, healthWidth)
 
@@ -767,6 +774,7 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 	}
 
 	tokensStr := compactInt(met.TokensInput + met.TokensOutput)
+	issue := sessionIssueLabel(s)
 	switch len(m.table.Columns()) {
 	case 7:
 		return table.Row{
@@ -777,6 +785,22 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 			costColor(met.CostEstimated),
 			tokensStr,
 			healthCol,
+		}
+	case 13:
+		return table.Row{
+			s.Name,
+			sourceDisplay,
+			met.ModelUsed,
+			fmt.Sprintf("%d", nonNegativeInt(met.AssistantTurns)),
+			fmt.Sprintf("%d", totalToolCalls),
+			sr,
+			failStr,
+			costColor(met.CostEstimated),
+			tokensStr,
+			engine.FmtDuration(chartValue(met.DurationSec)),
+			fmt.Sprintf("%d", len(s.Anomalies)),
+			healthCol,
+			issue,
 		}
 	case 12:
 		return table.Row{
@@ -792,6 +816,19 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 			engine.FmtDuration(chartValue(met.DurationSec)),
 			fmt.Sprintf("%d", len(s.Anomalies)),
 			healthCol,
+		}
+	case 10:
+		return table.Row{
+			s.Name,
+			sourceDisplay,
+			fmt.Sprintf("%d", nonNegativeInt(met.AssistantTurns)),
+			fmt.Sprintf("%d", totalToolCalls),
+			sr,
+			failStr,
+			costColor(met.CostEstimated),
+			tokensStr,
+			healthCol,
+			issue,
 		}
 	case 8:
 		return table.Row{
@@ -957,17 +994,14 @@ func (m Model) renderListView() string {
 		sections = append(sections, filterBar)
 		extraLines += renderedLineCount(filterBar)
 	}
-	if summary := m.renderSelectedSessionSummary(contentW); summary != "" {
-		sections = append(sections, summary)
-		extraLines += renderedLineCount(summary)
-	}
 	if empty := m.renderNoVisibleSessionsState(contentW); empty != "" {
 		sections = append(sections, empty)
 		extraLines += renderedLineCount(empty)
 	}
 	tableView := m.table
+	tableView.SetWidth(contentW)
 	tableView.SetHeight(m.listTableHeight(extraLines))
-	sections = append(sections, tableView.View())
+	sections = append(sections, truncateLines(tableView.View(), contentW))
 	return m.frameContent(lipgloss.JoinVertical(lipgloss.Left, sections...))
 }
 
@@ -2165,10 +2199,11 @@ func (m *Model) adjustColumnWidths(width int) {
 	var sessW, srcW, turnsW, toolsW, succW, failW, costW, tokensW, healthW int
 
 	if width >= 170 {
-		m.setColumnsAndRefreshRows(m.wideListColumns(24, 14, 18, 5, 5, 5, 5, 8, 7, 8, 5, 9))
+		m.setColumnsAndRefreshRows(m.wideListColumns(22, 13, 18, 5, 5, 5, 5, 8, 7, 8, 5, 9, 16))
 		return
 	} else if width > 130 {
-		sessW, srcW, turnsW, toolsW, succW, failW, costW, tokensW, healthW = 20, 12, 5, 5, 5, 5, 8, 7, 9
+		m.setColumnsAndRefreshRows(m.wideListColumns(14, 8, 10, 5, 5, 5, 4, 7, 6, 5, 4, 7, 10))
+		return
 	} else if width >= 100 {
 		sessW, srcW, turnsW, toolsW, succW, failW, costW, tokensW, healthW = 17, 10, 5, 5, 5, 4, 8, 7, 8
 	} else if width >= 92 {
@@ -2190,7 +2225,7 @@ func (m *Model) adjustColumnWidths(width int) {
 	m.setColumnsAndRefreshRows(m.fullListColumns(sessW, srcW, turnsW, toolsW, succW, failW, costW, tokensW, healthW))
 }
 
-func (m *Model) wideListColumns(sessW, srcW, modelW, turnsW, toolsW, succW, failW, costW, tokensW, durationW, anomW, healthW int) []table.Column {
+func (m *Model) wideListColumns(sessW, srcW, modelW, turnsW, toolsW, succW, failW, costW, tokensW, durationW, anomW, healthW, issueW int) []table.Column {
 	return []table.Column{
 		{Title: m.sortColTitle(i18n.T("session"), "name"), Width: sessW},
 		{Title: m.sortColTitle(i18n.T("source_tool"), "source"), Width: srcW},
@@ -2204,6 +2239,7 @@ func (m *Model) wideListColumns(sessW, srcW, modelW, turnsW, toolsW, succW, fail
 		{Title: i18n.T("duration_col"), Width: durationW},
 		{Title: m.sortColTitle(i18n.T("anomaly_count_col"), "anomalies"), Width: anomW},
 		{Title: m.sortColTitle(i18n.T("health"), "health"), Width: healthW},
+		{Title: i18n.T("issue_col"), Width: issueW},
 	}
 }
 
@@ -3164,6 +3200,13 @@ func anomalyTypeLabel(kind string) string {
 		return translated
 	}
 	return strings.ReplaceAll(kind, "_", " ")
+}
+
+func sessionIssueLabel(s engine.Session) string {
+	if len(s.Anomalies) == 0 {
+		return i18n.T("list_no_major_anomaly")
+	}
+	return anomalyTypeLabel(s.Anomalies[0].Type)
 }
 
 func riskLabel(risk string) string {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -542,12 +542,12 @@ func TestStandardWidthListKeepsHeadersAndHelpReadable(t *testing.T) {
 	m.view = viewList
 
 	rendered := m.View()
-	for _, want := range []string{"SESSION", "SOURCE", "TOKENS", "HEALTH", "TOOLS", "? keys"} {
+	for _, want := range []string{"SESSION", "SOURCE", "FAIL", "ANOM", "TOKENS", "HEALTH", "? keys"} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("standard-width list missing readable label %q:\n%s", want, rendered)
 		}
 	}
-	for _, clipped := range []string{"HEAL…", "TOO…", "?: key…"} {
+	for _, clipped := range []string{"HEAL…", "?: key…"} {
 		if strings.Contains(rendered, clipped) {
 			t.Fatalf("standard-width list should avoid clipped core labels %q:\n%s", clipped, rendered)
 		}
@@ -577,27 +577,30 @@ func TestCompactListShowsTriageSortIndicators(t *testing.T) {
 func TestWideListKeepsFullOperationalColumns(t *testing.T) {
 	m := resizeForTest(t, sampleModelForTest(), 160, 36)
 	m.view = viewList
-	if got := len(m.table.Columns()); got != 9 {
+	if got := len(m.table.Columns()); got != 13 {
 		t.Fatalf("expected full columns on wide screens, got %d", got)
 	}
 	row := m.table.Rows()[0]
-	if row[2] != "8" || row[3] != "12" || row[4] != "92" || row[5] != "1" {
+	if row[3] != "8" || row[4] != "12" || row[5] != "92" || row[6] != "1" {
 		t.Fatalf("expected turns/tools/success/fail columns, got row=%v", row)
+	}
+	if row[12] != "No major anomaly" {
+		t.Fatalf("expected issue column, got row=%v", row)
 	}
 }
 
 func TestUltraWideListAddsDiagnosticColumns(t *testing.T) {
 	m := resizeForTest(t, sampleModelForTest(), 180, 36)
 	m.view = viewList
-	if got := len(m.table.Columns()); got != 12 {
+	if got := len(m.table.Columns()); got != 13 {
 		t.Fatalf("expected diagnostic columns on ultra-wide screens, got %d", got)
 	}
 	cols := m.table.Columns()
-	if cols[2].Title != "MODEL" || cols[9].Title != "DURATION" || cols[10].Title != "ANOM" {
+	if cols[2].Title != "MODEL" || cols[9].Title != "DURATION" || cols[10].Title != "ANOM" || cols[12].Title != "ISSUE" {
 		t.Fatalf("unexpected ultra-wide column titles: %+v", cols)
 	}
 	row := m.table.Rows()[0]
-	if row[2] != "gpt-5.1" || row[10] != "0" {
+	if row[2] != "gpt-5.1" || row[10] != "0" || row[12] != "No major anomaly" {
 		t.Fatalf("expected model and anomaly count columns, got row=%v", row)
 	}
 }
@@ -613,7 +616,7 @@ func TestListAndDetailClampInvalidToolCounts(t *testing.T) {
 	m.view = viewList
 
 	row := m.table.Rows()[0]
-	if row[2] != "0" || row[3] != "0" || row[4] != "N/A" {
+	if row[3] != "0" || row[4] != "0" || row[5] != "N/A" {
 		t.Fatalf("expected invalid tool counts to be clamped in list row, got row=%v", row)
 	}
 
@@ -665,12 +668,12 @@ func TestViewsClampInvalidHealthScores(t *testing.T) {
 	m.view = viewList
 
 	rows := m.table.Rows()
-	if !strings.Contains(rows[0][8], "0%") || !strings.Contains(rows[1][8], "100%") {
+	if !strings.Contains(rows[0][11], "0%") || !strings.Contains(rows[1][11], "100%") {
 		t.Fatalf("expected health scores to be clamped in list rows, rows=%+v", rows)
 	}
 	for i, row := range rows[:2] {
-		if got, max := lipgloss.Width(row[8]), m.table.Columns()[8].Width; got > max {
-			t.Fatalf("health cell %d too wide: got=%d max=%d row=%q", i, got, max, row[8])
+		if got, max := lipgloss.Width(row[11]), m.table.Columns()[11].Width; got > max {
+			t.Fatalf("health cell %d too wide: got=%d max=%d row=%q", i, got, max, row[11])
 		}
 	}
 
@@ -873,12 +876,12 @@ func TestWideListRendersStableSingleTable(t *testing.T) {
 	m := resizeForTest(t, sampleModelForTest(), 220, 36)
 	m.view = viewList
 	rendered := m.View()
-	for _, stale := range []string{"SESSION INSPECTOR", "Enter detail · d diff · w diagnostics"} {
+	for _, stale := range []string{"SESSION INSPECTOR", "Enter detail · d diff · w diagnostics", "Health 92%", "Cost $0.4200"} {
 		if strings.Contains(rendered, stale) {
 			t.Fatalf("list should not render stale split preview fragment %q", stale)
 		}
 	}
-	for _, want := range []string{"SESSION", "SOURCE", "MODEL", "DURATION", "ANOM", "session_alpha", "gpt-5.1", "issue"} {
+	for _, want := range []string{"SESSION", "SOURCE", "MODEL", "DURATION", "ANOM", "ISSUE", "session_alpha", "gpt-5.1"} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("expected wide list to include %q:\n%s", want, rendered)
 		}


### PR DESCRIPTION
## Summary

- Add an ISSUE column to wide session lists so the primary anomaly is visible without opening detail.
- Relocalize cached session diagnostics when the UI language changes, avoiding stale cached English text.
- Localize text report anomaly severity/type and loop-cost labels.

## Validation
- go test ./...
- go build -o /tmp/agenttrace ./cmd/agenttrace && /tmp/agenttrace/agenttrace --version
- /tmp/agenttrace/agenttrace --doctor
- /tmp/agenttrace/agenttrace --demo, then q to exit- git diff --check