### PR TITLE
Add Oh My Pi session parser

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -22,7 +22,7 @@
   "interface": {
     "displayName": "agenttrace",
     "shortDescription": "Audit local AI agent sessions",
-    "longDescription": "Use agenttrace to inspect local Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, OpenCode, Kimi, Copilot-style, and generic JSON/JSONL sessions for spend, token use, tool failures, latency, health, anomalies, diffs, and CI-ready gate signals.",
+    "longDescription": "Use agenttrace to inspect local Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, OpenCode, Oh My Pi, Kimi, Copilot-style, and generic JSON/JSONL sessions for spend, token use, tool failures, latency, health, anomalies, diffs, and CI-ready gate signals.",
     "developerName": "luoyuctl",
     "category": "Developer Tools",
     "capabilities": [

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 |---|---|
 | Local-first privacy | Inspect sessions without uploading prompts, code, or tool logs |
 | Fast terminal triage | Open a TUI, sort bad sessions, and jump into detail/diagnostics |
-| Cross-agent comparison | Compare Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Kimi, and more |
+| Cross-agent comparison | Compare Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Oh My Pi, Kimi, and more |
 | Cost and token evidence | See cost, token usage, cache usage, retries, loops, latency, and health in one place |
 | CI guardrails | Export JSON/Markdown/HTML and fail builds on low health or high tool failure rates |
 
@@ -60,7 +60,7 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 | Silent tool loops | repeated tool calls, retry loops, long gaps, hanging sessions |
 | Slow agents | P50/P95/P99 latency, per-tool latency ranking, timeout-like gaps |
 | Quality regressions | health score, anomaly types, shallow reasoning, redacted thinking |
-| Hard-to-compare tools | session diff across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, and more |
+| Hard-to-compare tools | session diff across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Oh My Pi, and more |
 | CI blind spots | JSON reports and health gates for average health, critical sessions, and tool failure rate |
 
 ## ✨ Features
@@ -72,7 +72,7 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 | ⚡ **Persistent Cache** | Incremental session cache avoids a full disk parse on every startup |
 | 🩺 **Doctor Mode** | `--doctor` checks detected agent dirs, cache health, and next steps |
 | ⌨️ **Command Mode** | `:health <80`, `:cost >0.1`, `:sort cost desc`, `:anomalies` |
-| 🔍 **Multi-Format Auto-Detect** | Claude Code / Codex CLI / Gemini CLI / Aider / Cursor exports / Hermes / OpenCode / OpenClaw / Kimi / Copilot-style logs |
+| 🔍 **Multi-Format Auto-Detect** | Claude Code / Codex CLI / Gemini CLI / Aider / Cursor exports / Hermes / OpenCode / OpenClaw / Oh My Pi / Kimi / Copilot-style logs |
 | 💸 **Cost & Time Waste** | How much 💰 you burned + ⏱️ time lost to loops, retries, failures |
 | 🚨 **6 Anomaly Types** | Hanging, tool failures, latency spikes, shallow thinking, redaction, zero-tool sessions |
 | 📊 **Multi-Session Comparison** | Compare across sessions and tools in one table |

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,5 +1,5 @@
 // Package engine provides the core analysis engine for agenttrace.
-// Pure Go. Supports 10 agent formats: Hermes Agent, Claude Code, Codex CLI, Gemini CLI, OpenCode, OpenClaw, Copilot CLI, Kimi CLI, Aider, Cursor.
+// Pure Go. Supports 11 agent formats: Hermes Agent, Claude Code, Codex CLI, Gemini CLI, OpenCode, OpenClaw, Copilot CLI, Kimi CLI, Oh My Pi, Aider, Cursor.
 package engine
 
 import (
@@ -51,6 +51,7 @@ var ToolDisplayNames = map[string]string{
 	"openclaw":          "OpenClaw",
 	"copilot_cli":       "Copilot CLI",
 	"kimi_cli":          "Kimi CLI",
+	"oh_my_pi":          "Oh My Pi",
 	"aider":             "Aider",
 	"cursor":            "Cursor",
 	"generic":           "Generic JSON/JSONL",
@@ -502,6 +503,10 @@ func DetectFormat(path string) FormatInfo {
 		}
 		// Claude Code transcript JSONL: top-level "type" + "sessionId"
 		typ, _ := firstLineObj["type"].(string)
+		if isOhMyPiSessionHeader(firstLineObj) {
+			fi.Format = "oh_my_pi"
+			return fi
+		}
 		if typ != "" {
 			if _, hasSess := firstLineObj["sessionId"]; hasSess {
 				fi.Format = "claude_code_jsonl"
@@ -679,6 +684,8 @@ func Parse(path string) ([]Event, error) {
 		return parseCopilotCLI(string(fi.Raw))
 	case "kimi_cli":
 		return parseKimiCLI(fi.Doc)
+	case "oh_my_pi":
+		return parseOhMyPiSessionJSONL(string(fi.Raw))
 	case "aider_chat_history":
 		return parseAiderChatHistory(string(fi.Raw))
 	case "cursor":
@@ -2035,6 +2042,7 @@ func KnownSessionDirs() []KnownSessionDir {
 		{Name: "Codex CLI archived", Path: filepath.Join(home, ".codex", "archived_sessions")},
 		{Name: "Gemini CLI", Path: filepath.Join(home, ".gemini", "sessions")},
 		{Name: "Claude Code", Path: filepath.Join(home, ".claude", "projects")},
+		{Name: "Oh My Pi", Path: filepath.Join(home, ".omp", "agent", "sessions")},
 	}
 }
 

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -198,6 +198,108 @@ All tests pass.
 	}
 }
 
+func TestParseOhMyPiSessionJSONL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	raw := makeJSONL([]interface{}{
+		map[string]interface{}{
+			"type":      "session",
+			"version":   3,
+			"id":        "1f9d2a6b9c0d1234",
+			"timestamp": "2026-02-16T10:20:30.000Z",
+			"cwd":       "/work/pi",
+		},
+		map[string]interface{}{
+			"type":      "message",
+			"id":        "u1",
+			"parentId":  nil,
+			"timestamp": "2026-02-16T10:21:00.000Z",
+			"message": map[string]interface{}{
+				"role":      "user",
+				"content":   []interface{}{map[string]interface{}{"type": "text", "text": "Inspect the failing test"}},
+				"timestamp": float64(1771237260000),
+			},
+		},
+		map[string]interface{}{
+			"type":      "message",
+			"id":        "a1",
+			"parentId":  "u1",
+			"timestamp": "2026-02-16T10:21:10.000Z",
+			"message": map[string]interface{}{
+				"role":     "assistant",
+				"provider": "anthropic",
+				"model":    "claude-sonnet-4-5",
+				"content": []interface{}{
+					map[string]interface{}{"type": "thinking", "thinking": "Need to inspect logs first."},
+					map[string]interface{}{"type": "text", "text": "I will inspect the failure."},
+					map[string]interface{}{"type": "toolCall", "id": "tc1", "name": "read", "arguments": map[string]interface{}{"path": "go.mod"}},
+				},
+				"usage": map[string]interface{}{
+					"input":      100,
+					"output":     20,
+					"cacheRead":  7,
+					"cacheWrite": 3,
+				},
+				"timestamp": float64(1771237270000),
+			},
+		},
+		map[string]interface{}{
+			"type":      "message",
+			"id":        "t1",
+			"parentId":  "a1",
+			"timestamp": "2026-02-16T10:21:12.000Z",
+			"message": map[string]interface{}{
+				"role":       "toolResult",
+				"toolCallId": "tc1",
+				"toolName":   "read",
+				"content":    []interface{}{map[string]interface{}{"type": "text", "text": "module github.com/luoyuctl/agenttrace"}},
+				"isError":    false,
+				"timestamp":  float64(1771237272000),
+			},
+		},
+	})
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := DetectFormat(path).Format; got != "oh_my_pi" {
+		t.Fatalf("oh-my-pi format: %s", got)
+	}
+	events, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := Analyze(events, "claude-sonnet-4-5")
+	if m.SourceTool != "oh_my_pi" || m.UserMessages != 1 || m.AssistantTurns != 1 || m.ToolCallsTotal != 1 || m.ToolCallsOK != 1 {
+		t.Fatalf("bad oh-my-pi metrics: %+v", m)
+	}
+	if m.ModelUsed != "claude-sonnet-4-5" || m.TokensInput != 100 || m.TokensOutput != 20 || m.TokensCacheR != 7 || m.TokensCacheW != 3 {
+		t.Fatalf("bad oh-my-pi model/usage: %+v", m)
+	}
+	if m.ReasoningBlocks != 1 || m.ToolUsage["read"] != 1 {
+		t.Fatalf("bad oh-my-pi reasoning/tool usage: %+v", m)
+	}
+}
+
+func TestParseOhMyPiSessionJSONL_InvalidHeader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.jsonl")
+	raw := makeJSONL([]interface{}{
+		map[string]interface{}{"type": "session", "version": 3, "cwd": "/work/pi"},
+		map[string]interface{}{"type": "message", "message": map[string]interface{}{"role": "user", "content": "hello"}},
+	})
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := DetectFormat(path).Format; got != "oh_my_pi" {
+		t.Fatalf("expected malformed oh-my-pi session to be detected, got %s", got)
+	}
+	if _, err := Parse(path); err == nil {
+		t.Fatalf("expected invalid oh-my-pi header to fail")
+	}
+}
+
 func TestFindSessionFilesIncludesAiderHistory(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".aider.chat.history.md")

--- a/internal/engine/parser_oh_my_pi.go
+++ b/internal/engine/parser_oh_my_pi.go
@@ -1,0 +1,274 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const ohMyPiSource = "oh_my_pi"
+
+func isOhMyPiSessionHeader(obj map[string]interface{}) bool {
+	if typ, _ := obj["type"].(string); typ != "session" {
+		return false
+	}
+	_, hasVersion := obj["version"]
+	_, hasCWD := obj["cwd"]
+	_, hasTitleSource := obj["titleSource"]
+	_, hasParent := obj["parentSession"]
+	return hasVersion || hasCWD || hasTitleSource || hasParent
+}
+
+func parseOhMyPiSessionJSONL(raw string) ([]Event, error) {
+	var metaEvents []Event
+	var events []Event
+	model := "unknown"
+	seenHeader := false
+
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		var obj map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &obj); err != nil {
+			continue
+		}
+
+		typ, _ := obj["type"].(string)
+		if !seenHeader {
+			if typ != "session" {
+				return nil, fmt.Errorf("oh_my_pi: missing session header")
+			}
+			if str(obj, "id") == "" {
+				return nil, fmt.Errorf("oh_my_pi: invalid session header")
+			}
+			seenHeader = true
+			continue
+		}
+
+		ts := str(obj, "timestamp")
+		switch typ {
+		case "message":
+			msg, ok := obj["message"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for _, ev := range ohMyPiMessageEvents(msg, ts, &model) {
+				if ev.Role == "meta" {
+					metaEvents = append(metaEvents, ev)
+				} else {
+					events = append(events, ev)
+				}
+			}
+		case "custom_message":
+			content, _, _, _ := ohMyPiContent(obj["content"])
+			if strings.TrimSpace(content) != "" {
+				events = append(events, Event{
+					Role:       "user",
+					Content:    content,
+					Timestamp:  ts,
+					ModelUsed:  model,
+					SourceTool: ohMyPiSource,
+				})
+			}
+		case "model_change":
+			if nextModel := str(obj, "model"); nextModel != "" {
+				model = nextModel
+				metaEvents = append(metaEvents, Event{
+					Role:       "meta",
+					Timestamp:  ts,
+					ModelUsed:  model,
+					SourceTool: ohMyPiSource,
+				})
+			}
+		case "branch_summary", "compaction":
+			content := strings.TrimSpace(str(obj, "summary"))
+			if content != "" {
+				events = append(events, Event{
+					Role:       "assistant",
+					Content:    content,
+					Timestamp:  ts,
+					ModelUsed:  model,
+					SourceTool: ohMyPiSource,
+				})
+			}
+		}
+	}
+
+	if !seenHeader {
+		return nil, fmt.Errorf("oh_my_pi: missing session header")
+	}
+	if len(events) == 0 {
+		return nil, fmt.Errorf("oh_my_pi: no parseable events")
+	}
+	return append(metaEvents, events...), nil
+}
+
+func ohMyPiMessageEvents(msg map[string]interface{}, entryTS string, model *string) []Event {
+	role := str(msg, "role")
+	ts := ohMyPiTimestamp(msg["timestamp"], entryTS)
+
+	if nextModel := str(msg, "model"); nextModel != "" {
+		*model = nextModel
+	}
+
+	var events []Event
+	if usage := ohMyPiUsage(msg["usage"]); len(usage) > 0 {
+		events = append(events, Event{
+			Role:       "meta",
+			Timestamp:  ts,
+			Usage:      usage,
+			ModelUsed:  *model,
+			SourceTool: ohMyPiSource,
+		})
+	}
+
+	content, reasoning, redacted, toolCalls := ohMyPiContent(msg["content"])
+	switch role {
+	case "user":
+		if content != "" {
+			events = append(events, Event{
+				Role:       "user",
+				Content:    content,
+				Timestamp:  ts,
+				ModelUsed:  *model,
+				SourceTool: ohMyPiSource,
+			})
+		}
+	case "developer":
+		if content != "" {
+			events = append(events, Event{
+				Role:       "system",
+				Content:    content,
+				Timestamp:  ts,
+				ModelUsed:  *model,
+				SourceTool: ohMyPiSource,
+			})
+		}
+	case "assistant":
+		if content != "" || reasoning != "" || len(toolCalls) > 0 {
+			events = append(events, Event{
+				Role:       "assistant",
+				Content:    content,
+				Reasoning:  reasoning,
+				Redacted:   redacted,
+				ToolCalls:  toolCalls,
+				Timestamp:  ts,
+				ModelUsed:  *model,
+				SourceTool: ohMyPiSource,
+			})
+		}
+	case "toolResult":
+		events = append(events, Event{
+			Role:       "tool",
+			Content:    content,
+			Timestamp:  ts,
+			ToolCallID: str(msg, "toolCallId"),
+			IsError:    boolValue(msg["isError"]),
+			ModelUsed:  *model,
+			SourceTool: ohMyPiSource,
+		})
+	}
+	return events
+}
+
+func ohMyPiContent(raw interface{}) (string, string, bool, []ToolCall) {
+	switch c := raw.(type) {
+	case string:
+		return c, "", false, nil
+	case []interface{}:
+		var textParts []string
+		var reasoningParts []string
+		var toolCalls []ToolCall
+		redacted := false
+		for _, item := range c {
+			block, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			switch str(block, "type") {
+			case "text":
+				if text := str(block, "text"); text != "" {
+					textParts = append(textParts, text)
+				}
+			case "thinking":
+				if thinking := str(block, "thinking"); thinking != "" {
+					reasoningParts = append(reasoningParts, thinking)
+				}
+			case "redactedThinking":
+				redacted = true
+				if data := str(block, "data"); data != "" {
+					reasoningParts = append(reasoningParts, data)
+				}
+			case "toolCall":
+				id := str(block, "id")
+				name := str(block, "name")
+				if id != "" || name != "" {
+					toolCalls = append(toolCalls, ToolCall{
+						ID:   id,
+						Name: name,
+						Args: jsonish(block["arguments"]),
+					})
+				}
+			case "image":
+				textParts = append(textParts, "[image]")
+			}
+		}
+		return strings.Join(textParts, "\n"), strings.Join(reasoningParts, "\n"), redacted, toolCalls
+	default:
+		return jsonish(raw), "", false, nil
+	}
+}
+
+func ohMyPiUsage(raw interface{}) map[string]int {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	usage := map[string]int{
+		"input_tokens":                numberAsInt(m["input"]) + numberAsInt(m["input_tokens"]),
+		"output_tokens":               numberAsInt(m["output"]) + numberAsInt(m["output_tokens"]),
+		"cache_read_input_tokens":     numberAsInt(m["cacheRead"]) + numberAsInt(m["cache_read_input_tokens"]),
+		"cache_creation_input_tokens": numberAsInt(m["cacheWrite"]) + numberAsInt(m["cache_creation_input_tokens"]),
+	}
+	for _, v := range usage {
+		if v > 0 {
+			return usage
+		}
+	}
+	return nil
+}
+
+func ohMyPiTimestamp(raw interface{}, fallback string) string {
+	if ms, ok := numberAsInt64(raw); ok && ms > 0 {
+		return time.UnixMilli(ms).UTC().Format(time.RFC3339Nano)
+	}
+	if s, ok := raw.(string); ok && s != "" {
+		return s
+	}
+	return fallback
+}
+
+func numberAsInt64(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), true
+	case json.Number:
+		i, err := n.Int64()
+		return i, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func boolValue(v interface{}) bool {
+	b, _ := v.(bool)
+	return b
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -58,7 +58,7 @@ agenttrace --overview --fail-under-health 80 --fail-on-critical --max-tool-fail-
 
 ## Supported Sources
 
-agenttrace auto-detects local sessions from Claude Code, Codex CLI, Gemini CLI, OpenCode, OpenClaw, Copilot CLI, Kimi CLI, Hermes Agent, and Aider chat history.
+agenttrace auto-detects local sessions from Claude Code, Codex CLI, Gemini CLI, OpenCode, OpenClaw, Copilot CLI, Oh My Pi, Kimi CLI, Hermes Agent, and Aider chat history.
 
 For Aider repositories, run:
 

--- a/skills/agenttrace-session-audit/SKILL.md
+++ b/skills/agenttrace-session-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agenttrace-session-audit
-description: Audit local AI coding-agent sessions with agenttrace. Use when the user asks to inspect Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, OpenCode, Kimi, Copilot-style, or generic JSON/JSONL sessions for cost, tokens, tool failures, latency, anomalies, health, diffs, or CI gates.
+description: Audit local AI coding-agent sessions with agenttrace. Use when the user asks to inspect Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, OpenCode, Oh My Pi, Kimi, Copilot-style, or generic JSON/JSONL sessions for cost, tokens, tool failures, latency, anomalies, health, diffs, or CI gates.
 license: MIT
 metadata:
   short-description: Audit AI agent session health


### PR DESCRIPTION
## Summary

- Add auto-detection and parsing for Oh My Pi session JSONL files documented in can1357/oh-my-pi docs/session.md.
- Extract user/assistant/tool events, model, token/cache usage, reasoning, tool calls, tool results, and timestamps.
- Add ~/.omp/agent/sessions to doctor/auto-discovery and update supported-source docs/skill metadata.

## Source
- Format reference: https://github.com/can1357/oh-my-pi/blob/main/docs/session.md

## Validation
- go test ./internal/engine -run 'TestParseOhMyPi|TestDetectFormat|TestFindSessionFiles'
- go test ./...
- go build -o /tmp/agenttrace ./cmd/agenttrace && /tmp/agenttrace/agenttrace --version- /tmp/agenttrace/agenttrace --doctor