### PR TITLE
Add Qwen Code session parser

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -22,7 +22,7 @@
   "interface": {
     "displayName": "agenttrace",
     "shortDescription": "Audit local AI agent sessions",
-    "longDescription": "Use agenttrace to inspect local Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, OpenCode, Oh My Pi, Kimi, Copilot-style, and generic JSON/JSONL sessions for spend, token use, tool failures, latency, health, anomalies, diffs, and CI-ready gate signals.",
+    "longDescription": "Use agenttrace to inspect local Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor, OpenCode, Oh My Pi, Kimi, Copilot-style, and generic JSON/JSONL sessions for spend, token use, tool failures, latency, health, anomalies, diffs, and CI-ready gate signals.",
     "developerName": "luoyuctl",
     "category": "Developer Tools",
     "capabilities": [

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 |---|---|
 | Local-first privacy | Inspect sessions without uploading prompts, code, or tool logs |
 | Fast terminal triage | Open a TUI, sort bad sessions, and jump into detail/diagnostics |
-| Cross-agent comparison | Compare Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Oh My Pi, Kimi, and more |
+| Cross-agent comparison | Compare Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes, OpenCode, Oh My Pi, Kimi, and more |
 | Cost and token evidence | See cost, token usage, cache usage, retries, loops, latency, and health in one place |
 | CI guardrails | Export JSON/Markdown/HTML and fail builds on low health or high tool failure rates |
 
@@ -60,7 +60,7 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 | Silent tool loops | repeated tool calls, retry loops, long gaps, hanging sessions |
 | Slow agents | P50/P95/P99 latency, per-tool latency ranking, timeout-like gaps |
 | Quality regressions | health score, anomaly types, shallow reasoning, redacted thinking |
-| Hard-to-compare tools | session diff across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Oh My Pi, and more |
+| Hard-to-compare tools | session diff across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Oh My Pi, and more |
 | CI blind spots | JSON reports and health gates for average health, critical sessions, and tool failure rate |
 
 ## ✨ Features
@@ -72,7 +72,7 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 | ⚡ **Persistent Cache** | Incremental session cache avoids a full disk parse on every startup |
 | 🩺 **Doctor Mode** | `--doctor` checks detected agent dirs, cache health, and next steps |
 | ⌨️ **Command Mode** | `:health <80`, `:cost >0.1`, `:sort cost desc`, `:anomalies` |
-| 🔍 **Multi-Format Auto-Detect** | Claude Code / Codex CLI / Gemini CLI / Aider / Cursor exports / Hermes / OpenCode / OpenClaw / Oh My Pi / Kimi / Copilot-style logs |
+| 🔍 **Multi-Format Auto-Detect** | Claude Code / Codex CLI / Gemini CLI / Qwen Code / Aider / Cursor exports / Hermes / OpenCode / OpenClaw / Oh My Pi / Kimi / Copilot-style logs |
 | 💸 **Cost & Time Waste** | How much 💰 you burned + ⏱️ time lost to loops, retries, failures |
 | 🚨 **6 Anomaly Types** | Hanging, tool failures, latency spikes, shallow thinking, redaction, zero-tool sessions |
 | 📊 **Multi-Session Comparison** | Compare across sessions and tools in one table |

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -1,6 +1,6 @@
 # agenttrace Launch Kit
 
-agenttrace is a terminal observability dashboard for AI coding agent sessions. It helps developers see where Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Kimi CLI, and Copilot-style logs waste time, tokens, and tool calls.
+agenttrace is a terminal observability dashboard for AI coding agent sessions. It helps developers see where Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Kimi CLI, and Copilot-style logs waste time, tokens, and tool calls.
 
 ## Positioning
 
@@ -28,7 +28,7 @@ Body:
 
 I built agenttrace, a single-binary TUI for inspecting AI coding agent sessions locally.
 
-It parses logs from Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Kimi CLI, and Copilot-style traces, then shows:
+It parses logs from Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Kimi CLI, and Copilot-style traces, then shows:
 
 - token and cost burn
 - tool success/failure rate
@@ -71,7 +71,7 @@ AI coding agents now need observability too.
 
 I built agenttrace: a fast terminal dashboard for local agent sessions.
 
-It shows token cost, latency, tool failures, anomalies, health score, details, diffs, JSON output, and CI health gates across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Kimi, and more.
+It shows token cost, latency, tool failures, anomalies, health score, details, diffs, JSON output, and CI health gates across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes, OpenCode, Kimi, and more.
 
 https://github.com/luoyuctl/agenttrace
 
@@ -81,7 +81,7 @@ I made a TUI tool for people using AI coding agents daily. It scans local sessio
 
 The goal is not another chat UI. It is closer to `htop`/`lazygit` for AI agent runs: fast local inspection, filtering, diagnostics, and exportable JSON.
 
-Would love feedback from anyone using Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, Hermes Agent, OpenCode, Kimi CLI, or similar tools.
+Would love feedback from anyone using Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor, Hermes Agent, OpenCode, Kimi CLI, or similar tools.
 
 Repo: https://github.com/luoyuctl/agenttrace
 
@@ -181,7 +181,7 @@ Terminal Trove draft:
 - Name: `agenttrace`
 - URL: `github.com/luoyuctl/agenttrace`
 - Tagline: `Local-first TUI observability for AI coding agent sessions.`
-- Description: `agenttrace parses local Claude Code, Codex CLI, Gemini CLI, Aider, Cursor export, Hermes, OpenCode, Kimi, and Copilot-style logs into a fast terminal dashboard for session health, cost, token usage, latency, tool failures, anomalies, diffs, and CI evidence.`
+- Description: `agenttrace parses local Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor export, Hermes, OpenCode, Kimi, and Copilot-style logs into a fast terminal dashboard for session health, cost, token usage, latency, tool failures, anomalies, diffs, and CI evidence.`
 - Standout features: `Overview, session list, detail, diagnostics, and diff views; incremental local cache; JSON, Markdown, and self-contained HTML reports with CI gates for health and tool failure rate.`
 - Who it is for: `Developers using AI coding agents who need to find expensive, stuck, slow, or low-quality sessions without uploading private logs to a hosted observability service.`
 - Primary language: `go`

--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -149,11 +149,7 @@ func FindSessionFilesCached(dir string, cache SessionCache) []string {
 	seen := make(map[string]bool)
 	var files []string
 	for _, root := range roots {
-		base := filepath.Base(root)
-		maxDepth := 4
-		if base == "projects" {
-			maxDepth = 1
-		}
+		maxDepth := maxSessionDirDepth(root)
 		for _, f := range collectSessionFilesCached(root, 0, maxDepth, cache) {
 			if !seen[f] {
 				seen[f] = true

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,5 +1,5 @@
 // Package engine provides the core analysis engine for agenttrace.
-// Pure Go. Supports 11 agent formats: Hermes Agent, Claude Code, Codex CLI, Gemini CLI, OpenCode, OpenClaw, Copilot CLI, Kimi CLI, Oh My Pi, Aider, Cursor.
+// Pure Go. Supports 12 agent formats: Hermes Agent, Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, OpenClaw, Copilot CLI, Kimi CLI, Oh My Pi, Aider, Cursor.
 package engine
 
 import (
@@ -47,6 +47,7 @@ var ToolDisplayNames = map[string]string{
 	"codex_cli":         "Codex CLI",
 	"codex_rollout":     "Codex CLI (Rollout)",
 	"gemini_cli":        "Gemini CLI",
+	"qwen_code":         "Qwen Code",
 	"opencode":          "OpenCode",
 	"openclaw":          "OpenClaw",
 	"copilot_cli":       "Copilot CLI",
@@ -503,6 +504,10 @@ func DetectFormat(path string) FormatInfo {
 		}
 		// Claude Code transcript JSONL: top-level "type" + "sessionId"
 		typ, _ := firstLineObj["type"].(string)
+		if isQwenCodeEvent(firstLineObj) {
+			fi.Format = "qwen_code"
+			return fi
+		}
 		if isOhMyPiSessionHeader(firstLineObj) {
 			fi.Format = "oh_my_pi"
 			return fi
@@ -538,6 +543,10 @@ func DetectFormat(path string) FormatInfo {
 }
 
 func detectSingleJSON(doc map[string]interface{}) string {
+	if isQwenCodeEvent(doc) || isQwenCodeJSONOutput(doc) {
+		return "qwen_code"
+	}
+
 	// OpenClaw: provider="openclaw" distinguishes from other message wrappers.
 	if provider, _ := doc["provider"].(string); provider == "openclaw" {
 		return "openclaw"
@@ -639,6 +648,9 @@ func detectJSONArray(arr []interface{}) string {
 	if isCursorGenerationArray(arr) || isCursorPromptArray(arr) {
 		return "cursor"
 	}
+	if isQwenCodeArray(arr) {
+		return "qwen_code"
+	}
 	for _, item := range arr {
 		if m, ok := item.(map[string]interface{}); ok {
 			if _, hasRole := m["role"]; hasRole {
@@ -676,6 +688,8 @@ func Parse(path string) ([]Event, error) {
 		return parseCodexRollout(string(fi.Raw))
 	case "gemini_cli":
 		return parseGeminiCLI(fi.Doc, string(fi.Raw))
+	case "qwen_code":
+		return parseQwenCode(fi.Doc, fi.Arr, string(fi.Raw))
 	case "opencode":
 		return parseOpenCode(fi.Doc)
 	case "openclaw":
@@ -2041,6 +2055,7 @@ func KnownSessionDirs() []KnownSessionDir {
 		{Name: "Codex CLI", Path: filepath.Join(home, ".codex", "sessions")},
 		{Name: "Codex CLI archived", Path: filepath.Join(home, ".codex", "archived_sessions")},
 		{Name: "Gemini CLI", Path: filepath.Join(home, ".gemini", "sessions")},
+		{Name: "Qwen Code", Path: filepath.Join(home, ".qwen", "projects")},
 		{Name: "Claude Code", Path: filepath.Join(home, ".claude", "projects")},
 		{Name: "Oh My Pi", Path: filepath.Join(home, ".omp", "agent", "sessions")},
 	}
@@ -2077,12 +2092,7 @@ func collectSessionFiles(dir string) []string {
 		t    time.Time
 	}
 	var items []entryInfo
-	base := filepath.Base(dir)
-
-	maxDepth := 4
-	if base == "projects" {
-		maxDepth = 1
-	}
+	maxDepth := maxSessionDirDepth(dir)
 
 	var walk func(string, int)
 	walk = func(d string, depth int) {
@@ -2145,6 +2155,13 @@ func ScanAllDirs() []Session {
 		return sessions[i].Metrics.SessionStart > sessions[j].Metrics.SessionStart
 	})
 	return sessions
+}
+
+func maxSessionDirDepth(dir string) int {
+	if filepath.Base(dir) == "projects" && strings.Contains(filepath.ToSlash(dir), "/.claude/") {
+		return 1
+	}
+	return 4
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -300,6 +300,221 @@ func TestParseOhMyPiSessionJSONL_InvalidHeader(t *testing.T) {
 	}
 }
 
+func TestParseQwenCodeStreamJSONL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "qwen-stream.jsonl")
+	raw := makeJSONL([]interface{}{
+		map[string]interface{}{
+			"type":       "system",
+			"subtype":    "session_start",
+			"uuid":       "sys-1",
+			"session_id": "session-1",
+			"model":      "qwen3-coder-plus",
+			"timestamp":  "2026-05-03T10:00:00Z",
+		},
+		map[string]interface{}{
+			"type":       "assistant",
+			"uuid":       "assistant-1",
+			"session_id": "session-1",
+			"timestamp":  "2026-05-03T10:00:02Z",
+			"message": map[string]interface{}{
+				"id":    "msg-1",
+				"type":  "message",
+				"role":  "assistant",
+				"model": "qwen3-coder-plus",
+				"content": []interface{}{
+					map[string]interface{}{"type": "reasoning", "text": "Need to inspect package files."},
+					map[string]interface{}{"type": "text", "text": "I'll inspect the package."},
+					map[string]interface{}{"type": "tool_use", "id": "tool-1", "name": "read_file", "input": map[string]interface{}{"path": "package.json"}},
+				},
+				"usage": map[string]interface{}{
+					"input_tokens":                120,
+					"output_tokens":               45,
+					"cache_read_input_tokens":     10,
+					"cache_creation_input_tokens": 5,
+				},
+			},
+		},
+		map[string]interface{}{
+			"type":       "user",
+			"uuid":       "user-1",
+			"session_id": "session-1",
+			"timestamp":  "2026-05-03T10:00:03Z",
+			"message": map[string]interface{}{
+				"role":    "user",
+				"content": "Please continue after inspecting it.",
+			},
+		},
+		map[string]interface{}{
+			"type":       "user",
+			"uuid":       "tool-result-1",
+			"session_id": "session-1",
+			"timestamp":  "2026-05-03T10:00:04Z",
+			"message": map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "tool_result", "tool_use_id": "tool-1", "content": "package metadata", "is_error": false},
+				},
+			},
+		},
+		map[string]interface{}{
+			"type":        "result",
+			"subtype":     "success",
+			"uuid":        "result-1",
+			"session_id":  "session-1",
+			"is_error":    false,
+			"duration_ms": 1234,
+			"result":      "I'll inspect the package.",
+			"usage": map[string]interface{}{
+				"input_tokens":  120,
+				"output_tokens": 45,
+			},
+		},
+	})
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := DetectFormat(path).Format; got != "qwen_code" {
+		t.Fatalf("qwen format: %s", got)
+	}
+	events, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := Analyze(events, "qwen3-coder-plus")
+	if m.SourceTool != "qwen_code" || m.UserMessages != 1 || m.AssistantTurns != 1 || m.ToolCallsTotal != 1 || m.ToolCallsOK != 1 {
+		t.Fatalf("bad qwen metrics: %+v", m)
+	}
+	if m.ModelUsed != "qwen3-coder-plus" || m.TokensInput != 120 || m.TokensOutput != 45 || m.TokensCacheR != 10 || m.TokensCacheW != 5 {
+		t.Fatalf("bad qwen usage/model: %+v", m)
+	}
+	if m.ReasoningBlocks != 1 || m.ToolUsage["read_file"] != 1 {
+		t.Fatalf("bad qwen reasoning/tool usage: %+v", m)
+	}
+}
+
+func TestParseQwenCodeJSONOutputArray(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "qwen-output.json")
+	raw := []interface{}{
+		map[string]interface{}{
+			"type":       "system",
+			"subtype":    "session_start",
+			"uuid":       "sys-1",
+			"session_id": "session-1",
+			"model":      "qwen3-coder-plus",
+		},
+		map[string]interface{}{
+			"type":       "result",
+			"subtype":    "success",
+			"uuid":       "result-1",
+			"session_id": "session-1",
+			"is_error":   false,
+			"result":     "The capital of France is Paris.",
+			"stats": map[string]interface{}{
+				"models": map[string]interface{}{
+					"qwen3-coder-plus": map[string]interface{}{
+						"tokens": map[string]interface{}{"input": 20, "output": 7},
+					},
+				},
+			},
+		},
+	}
+	if err := os.WriteFile(path, []byte(mustJSON(raw)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := DetectFormat(path).Format; got != "qwen_code" {
+		t.Fatalf("qwen array format: %s", got)
+	}
+	events, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := Analyze(events, "qwen3-coder-plus")
+	if m.SourceTool != "qwen_code" || m.AssistantTurns != 1 || m.TokensInput != 20 || m.TokensOutput != 7 {
+		t.Fatalf("bad qwen json metrics: %+v", m)
+	}
+}
+
+func TestParseQwenCodeJSONObjectOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "qwen-result.json")
+	raw := map[string]interface{}{
+		"response": "Done.",
+		"stats": map[string]interface{}{
+			"models": map[string]interface{}{
+				"qwen3-coder-plus": map[string]interface{}{
+					"tokens": map[string]interface{}{"input": 31, "output": 9, "cacheRead": 4},
+				},
+			},
+		},
+	}
+	if err := os.WriteFile(path, []byte(mustJSON(raw)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := DetectFormat(path).Format; got != "qwen_code" {
+		t.Fatalf("qwen object format: %s", got)
+	}
+	events, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := Analyze(events, "qwen3-coder-plus")
+	if m.SourceTool != "qwen_code" || m.AssistantTurns != 1 || m.TokensInput != 31 || m.TokensOutput != 9 || m.TokensCacheR != 4 {
+		t.Fatalf("bad qwen object metrics: %+v", m)
+	}
+}
+
+func TestParseQwenCodeStreamJSONL_NoMessages(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty-qwen.jsonl")
+	raw := makeJSONL([]interface{}{
+		map[string]interface{}{
+			"type":       "system",
+			"subtype":    "session_start",
+			"uuid":       "sys-1",
+			"session_id": "session-1",
+			"model":      "qwen3-coder-plus",
+		},
+	})
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := DetectFormat(path).Format; got != "qwen_code" {
+		t.Fatalf("qwen empty format: %s", got)
+	}
+	if _, err := Parse(path); err == nil {
+		t.Fatalf("expected qwen stream without assistant/result content to fail")
+	}
+}
+
+func TestFindSessionFilesIncludesQwenProjectChats(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	chatDir := filepath.Join(home, ".qwen", "projects", "repo", "chats")
+	if err := os.MkdirAll(chatDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(chatDir, "chat.jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := FindSessionFiles("")
+	if len(files) != 1 || files[0] != path {
+		t.Fatalf("expected qwen chat file, got %v", files)
+	}
+	cache := SessionCache{Entries: map[string]CacheEntry{}, Dirs: map[string]DirCacheEntry{}}
+	files = FindSessionFilesCached("", cache)
+	if len(files) != 1 || files[0] != path {
+		t.Fatalf("expected cached qwen chat file, got %v", files)
+	}
+}
+
 func TestFindSessionFilesIncludesAiderHistory(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".aider.chat.history.md")

--- a/internal/engine/parser_qwen_code.go
+++ b/internal/engine/parser_qwen_code.go
@@ -1,0 +1,429 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const qwenCodeSource = "qwen_code"
+
+func isQwenCodeEvent(obj map[string]interface{}) bool {
+	typ, _ := obj["type"].(string)
+	if typ != "system" && typ != "user" && typ != "assistant" && typ != "result" && typ != "stream_event" {
+		return false
+	}
+	if _, ok := obj["session_id"]; ok {
+		return true
+	}
+	if _, ok := obj["uuid"]; ok {
+		_, hasMessage := obj["message"]
+		_, hasResult := obj["result"]
+		_, hasSubtype := obj["subtype"]
+		return hasMessage || hasResult || hasSubtype
+	}
+	return false
+}
+
+func isQwenCodeJSONOutput(obj map[string]interface{}) bool {
+	if _, hasResponse := obj["response"]; !hasResponse {
+		if _, hasError := obj["error"]; !hasError {
+			return false
+		}
+	}
+	_, hasStats := obj["stats"]
+	_, hasUsage := obj["usage"]
+	return hasStats || hasUsage
+}
+
+func isQwenCodeArray(arr []interface{}) bool {
+	for _, item := range arr {
+		obj, ok := item.(map[string]interface{})
+		if ok && isQwenCodeEvent(obj) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseQwenCode(doc map[string]interface{}, arr []interface{}, raw string) ([]Event, error) {
+	var objs []map[string]interface{}
+	if len(arr) > 0 {
+		for _, item := range arr {
+			if obj, ok := item.(map[string]interface{}); ok {
+				objs = append(objs, obj)
+			}
+		}
+	} else if doc != nil {
+		if isQwenCodeJSONOutput(doc) && !isQwenCodeEvent(doc) {
+			return parseQwenCodeJSONOutput(doc)
+		}
+		objs = append(objs, doc)
+	} else {
+		for _, line := range strings.Split(raw, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			var obj map[string]interface{}
+			if err := json.Unmarshal([]byte(line), &obj); err != nil {
+				continue
+			}
+			objs = append(objs, obj)
+		}
+	}
+
+	var metaEvents []Event
+	var events []Event
+	model := "unknown"
+	hasAssistant := false
+	hasUsage := false
+
+	for _, obj := range objs {
+		if !isQwenCodeEvent(obj) {
+			continue
+		}
+		typ, _ := obj["type"].(string)
+		ts := str(obj, "timestamp")
+		switch typ {
+		case "system":
+			if nextModel := str(obj, "model"); nextModel != "" {
+				model = nextModel
+			}
+			metaEvents = append(metaEvents, Event{
+				Role:       "meta",
+				Timestamp:  ts,
+				ModelUsed:  model,
+				SourceTool: qwenCodeSource,
+			})
+		case "user":
+			msg, ok := obj["message"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for _, ev := range qwenMessageEvents(msg, ts, &model) {
+				events = append(events, ev)
+			}
+		case "assistant":
+			msg, ok := obj["message"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for _, ev := range qwenMessageEvents(msg, ts, &model) {
+				if ev.Role == "meta" {
+					metaEvents = append(metaEvents, ev)
+					if len(ev.Usage) > 0 {
+						hasUsage = true
+					}
+				} else {
+					if ev.Role == "assistant" {
+						hasAssistant = true
+					}
+					events = append(events, ev)
+				}
+			}
+		case "result":
+			if usage := qwenUsage(obj["usage"]); len(usage) > 0 && !hasUsage {
+				metaEvents = append(metaEvents, Event{
+					Role:       "meta",
+					Timestamp:  ts,
+					Usage:      usage,
+					ModelUsed:  model,
+					SourceTool: qwenCodeSource,
+				})
+				hasUsage = true
+			}
+			if usage := qwenStatsUsage(obj["stats"]); len(usage) > 0 && !hasUsage {
+				metaEvents = append(metaEvents, Event{
+					Role:       "meta",
+					Timestamp:  ts,
+					Usage:      usage,
+					ModelUsed:  model,
+					SourceTool: qwenCodeSource,
+				})
+				hasUsage = true
+			}
+			if usage := qwenModelUsage(obj["modelUsage"]); len(usage) > 0 && !hasUsage {
+				metaEvents = append(metaEvents, Event{
+					Role:       "meta",
+					Timestamp:  ts,
+					Usage:      usage,
+					ModelUsed:  model,
+					SourceTool: qwenCodeSource,
+				})
+				hasUsage = true
+			}
+			if !hasAssistant {
+				content := strings.TrimSpace(str(obj, "result"))
+				if content != "" {
+					events = append(events, Event{
+						Role:       "assistant",
+						Content:    content,
+						Timestamp:  ts,
+						ModelUsed:  model,
+						SourceTool: qwenCodeSource,
+					})
+					hasAssistant = true
+				}
+			}
+		}
+	}
+
+	if len(events) == 0 {
+		return nil, fmt.Errorf("qwen_code: no parseable events")
+	}
+	return append(metaEvents, events...), nil
+}
+
+func parseQwenCodeJSONOutput(obj map[string]interface{}) ([]Event, error) {
+	var events []Event
+	model := "unknown"
+	if usage := qwenUsage(obj["usage"]); len(usage) > 0 {
+		events = append(events, Event{Role: "meta", Usage: usage, ModelUsed: model, SourceTool: qwenCodeSource})
+	} else if usage := qwenStatsUsage(obj["stats"]); len(usage) > 0 {
+		events = append(events, Event{Role: "meta", Usage: usage, ModelUsed: model, SourceTool: qwenCodeSource})
+	}
+	if content := strings.TrimSpace(str(obj, "response")); content != "" {
+		events = append(events, Event{Role: "assistant", Content: content, ModelUsed: model, SourceTool: qwenCodeSource})
+	}
+	if len(events) == 0 {
+		return nil, fmt.Errorf("qwen_code: no parseable events")
+	}
+	return events, nil
+}
+
+func qwenMessageEvents(msg map[string]interface{}, fallbackTS string, model *string) []Event {
+	if nextModel := str(msg, "model"); nextModel != "" {
+		*model = nextModel
+	}
+	ts := str(msg, "timestamp")
+	if ts == "" {
+		ts = fallbackTS
+	}
+
+	var events []Event
+	if usage := qwenUsage(msg["usage"]); len(usage) > 0 {
+		events = append(events, Event{
+			Role:       "meta",
+			Timestamp:  ts,
+			Usage:      usage,
+			ModelUsed:  *model,
+			SourceTool: qwenCodeSource,
+		})
+	}
+
+	content, reasoning, redacted, toolCalls := qwenContent(msg["content"])
+	toolResults := qwenToolResultEvents(msg["content"], ts, *model)
+	role := str(msg, "role")
+	if role == "" {
+		role = "assistant"
+	}
+	switch role {
+	case "assistant":
+		if content != "" || reasoning != "" || len(toolCalls) > 0 {
+			events = append(events, Event{
+				Role:       "assistant",
+				Content:    content,
+				Reasoning:  reasoning,
+				Redacted:   redacted,
+				ToolCalls:  toolCalls,
+				Timestamp:  ts,
+				ModelUsed:  *model,
+				SourceTool: qwenCodeSource,
+			})
+		}
+	case "user":
+		if content != "" {
+			events = append(events, Event{
+				Role:       "user",
+				Content:    content,
+				Timestamp:  ts,
+				ModelUsed:  *model,
+				SourceTool: qwenCodeSource,
+			})
+		}
+		events = append(events, toolResults...)
+	case "tool", "tool_result", "toolResult":
+		events = append(events, Event{
+			Role:       "tool",
+			Content:    content,
+			Timestamp:  ts,
+			ToolCallID: firstNonEmpty(str(msg, "tool_call_id"), str(msg, "toolCallId")),
+			IsError:    boolValue(msg["is_error"]) || boolValue(msg["isError"]),
+			ModelUsed:  *model,
+			SourceTool: qwenCodeSource,
+		})
+	}
+	return events
+}
+
+func qwenContent(raw interface{}) (string, string, bool, []ToolCall) {
+	switch c := raw.(type) {
+	case string:
+		return c, "", false, nil
+	case []interface{}:
+		var textParts []string
+		var reasoningParts []string
+		var toolCalls []ToolCall
+		redacted := false
+		for _, item := range c {
+			block, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			switch str(block, "type") {
+			case "text":
+				if text := str(block, "text"); text != "" {
+					textParts = append(textParts, text)
+				}
+			case "thinking", "reasoning":
+				if thinking := firstNonEmpty(str(block, "thinking"), str(block, "text")); thinking != "" {
+					reasoningParts = append(reasoningParts, thinking)
+				}
+			case "redacted_thinking", "redactedThinking":
+				redacted = true
+				if data := firstNonEmpty(str(block, "data"), str(block, "text")); data != "" {
+					reasoningParts = append(reasoningParts, data)
+				}
+			case "tool_use", "toolCall", "function_call":
+				id := firstNonEmpty(str(block, "id"), str(block, "tool_call_id"), str(block, "call_id"))
+				name := str(block, "name")
+				if fn, ok := block["function"].(map[string]interface{}); ok {
+					name = firstNonEmpty(name, str(fn, "name"))
+				}
+				args := firstNonEmpty(jsonish(block["input"]), jsonish(block["arguments"]))
+				if id != "" || name != "" {
+					toolCalls = append(toolCalls, ToolCall{ID: id, Name: name, Args: args})
+				}
+			case "tool_result", "toolResult":
+				continue
+			case "image":
+				textParts = append(textParts, "[image]")
+			}
+		}
+		return strings.Join(textParts, "\n"), strings.Join(reasoningParts, "\n"), redacted, toolCalls
+	default:
+		return jsonish(raw), "", false, nil
+	}
+}
+
+func qwenToolResultEvents(raw interface{}, ts string, model string) []Event {
+	blocks, ok := raw.([]interface{})
+	if !ok {
+		return nil
+	}
+	var events []Event
+	for _, item := range blocks {
+		block, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		tp := str(block, "type")
+		if tp != "tool_result" && tp != "toolResult" {
+			continue
+		}
+		events = append(events, Event{
+			Role:       "tool",
+			Content:    extractToolResultContent(block),
+			Timestamp:  ts,
+			ToolCallID: firstNonEmpty(str(block, "tool_use_id"), str(block, "toolCallId")),
+			IsError:    boolValue(block["is_error"]) || boolValue(block["isError"]),
+			ModelUsed:  model,
+			SourceTool: qwenCodeSource,
+		})
+	}
+	return events
+}
+
+func qwenUsage(raw interface{}) map[string]int {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	usage := map[string]int{
+		"input_tokens": numberAsInt(m["input_tokens"]) +
+			numberAsInt(m["prompt_tokens"]) +
+			numberAsInt(m["input"]) +
+			numberAsInt(m["promptTokenCount"]),
+		"output_tokens": numberAsInt(m["output_tokens"]) +
+			numberAsInt(m["completion_tokens"]) +
+			numberAsInt(m["output"]) +
+			numberAsInt(m["candidatesTokenCount"]),
+		"cache_read_input_tokens": numberAsInt(m["cache_read_input_tokens"]) +
+			numberAsInt(m["cacheRead"]) +
+			numberAsInt(m["cached_tokens"]),
+		"cache_creation_input_tokens": numberAsInt(m["cache_creation_input_tokens"]) +
+			numberAsInt(m["cacheWrite"]),
+	}
+	for _, v := range usage {
+		if v > 0 {
+			return usage
+		}
+	}
+	return nil
+}
+
+func qwenStatsUsage(raw interface{}) map[string]int {
+	stats, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	models, ok := stats["models"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	usage := map[string]int{}
+	for _, rawModel := range models {
+		modelStats, ok := rawModel.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		tokens, ok := modelStats["tokens"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		usage["input_tokens"] += numberAsInt(tokens["input"]) + numberAsInt(tokens["input_tokens"])
+		usage["output_tokens"] += numberAsInt(tokens["output"]) + numberAsInt(tokens["output_tokens"])
+		usage["cache_read_input_tokens"] += numberAsInt(tokens["cacheRead"]) + numberAsInt(tokens["cache_read_input_tokens"])
+		usage["cache_creation_input_tokens"] += numberAsInt(tokens["cacheWrite"]) + numberAsInt(tokens["cache_creation_input_tokens"])
+	}
+	for _, v := range usage {
+		if v > 0 {
+			return usage
+		}
+	}
+	return nil
+}
+
+func qwenModelUsage(raw interface{}) map[string]int {
+	modelUsage, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	usage := map[string]int{}
+	for _, rawModel := range modelUsage {
+		modelStats, ok := rawModel.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		usage["input_tokens"] += numberAsInt(modelStats["inputTokens"]) + numberAsInt(modelStats["input_tokens"])
+		usage["output_tokens"] += numberAsInt(modelStats["outputTokens"]) + numberAsInt(modelStats["output_tokens"])
+		usage["cache_read_input_tokens"] += numberAsInt(modelStats["cacheReadInputTokens"]) + numberAsInt(modelStats["cache_read_input_tokens"])
+		usage["cache_creation_input_tokens"] += numberAsInt(modelStats["cacheCreationInputTokens"]) + numberAsInt(modelStats["cache_creation_input_tokens"])
+	}
+	for _, v := range usage {
+		if v > 0 {
+			return usage
+		}
+	}
+	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -58,7 +58,7 @@ agenttrace --overview --fail-under-health 80 --fail-on-critical --max-tool-fail-
 
 ## Supported Sources
 
-agenttrace auto-detects local sessions from Claude Code, Codex CLI, Gemini CLI, OpenCode, OpenClaw, Copilot CLI, Oh My Pi, Kimi CLI, Hermes Agent, and Aider chat history.
+agenttrace auto-detects local sessions from Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, OpenClaw, Copilot CLI, Oh My Pi, Kimi CLI, Hermes Agent, and Aider chat history.
 
 For Aider repositories, run:
 

--- a/skills/agenttrace-session-audit/SKILL.md
+++ b/skills/agenttrace-session-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agenttrace-session-audit
-description: Audit local AI coding-agent sessions with agenttrace. Use when the user asks to inspect Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, OpenCode, Oh My Pi, Kimi, Copilot-style, or generic JSON/JSONL sessions for cost, tokens, tool failures, latency, anomalies, health, diffs, or CI gates.
+description: Audit local AI coding-agent sessions with agenttrace. Use when the user asks to inspect Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor, OpenCode, Oh My Pi, Kimi, Copilot-style, or generic JSON/JSONL sessions for cost, tokens, tool failures, latency, anomalies, health, diffs, or CI gates.
 license: MIT
 metadata:
   short-description: Audit AI agent session health


### PR DESCRIPTION
## Summary
- add Qwen Code format detection and parser support for stream-json JSONL, JSON arrays, and JSON output objects
- discover nested ~/.qwen/projects session files without loosening Claude Code project scan depth
- update docs, launch copy, npm README, and plugin metadata to list Qwen Code

## Source
- Qwen Code headless docs: https://qwenlm.github.io/qwen-code-docs/en/users/features/headless/

## Validation
- go test ./...
- git diff --check
- go build -o /tmp/agenttrace/agenttrace ./cmd/agenttrace
- /tmp/agenttrace/agenttrace --doctor