### PR TITLE
Prepare 0.3.44 release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agenttrace",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "description": "Audit local AI coding-agent sessions for cost, token waste, failures, latency, anomalies, health, diffs, and CI gate signals.",
   "author": {
     "name": "luoyuctl",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/luoyuctl/agenttrace/stargazers"><img src="https://img.shields.io/github/stars/luoyuctl/agenttrace?style=social" alt="GitHub stars"></a>
   <img src="https://img.shields.io/badge/go-1.24+-00ADD8.svg" alt="Go">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
-  <img src="https://img.shields.io/badge/Homebrew-v0.3.43-2bbc8a.svg" alt="Homebrew">
+  <img src="https://img.shields.io/badge/Homebrew-v0.3.44-2bbc8a.svg" alt="Homebrew">
 </p>
 
 <h3 align="center">💸 Stop burning cash and hours on invisible AI agent waste</h3>
@@ -217,7 +217,7 @@ See [docs/cursor-import.md](docs/cursor-import.md) for details.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  AGENTTRACE v0.3.43 — AI Agent Session Performance Report
+  AGENTTRACE v0.3.44 — AI Agent Session Performance Report
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 💰 TOKEN COST

--- a/homebrew/Formula/agenttrace.rb
+++ b/homebrew/Formula/agenttrace.rb
@@ -2,7 +2,7 @@ class Agenttrace < Formula
   desc "TUI observability for AI coding agent sessions, cost, latency, and anomalies"
   homepage "https://github.com/luoyuctl/agenttrace"
   url "https://github.com/luoyuctl/agenttrace.git", branch: "master"
-  version "0.3.43"
+  version "0.3.44"
   license "MIT"
 
   depends_on "go" => :build
@@ -12,6 +12,6 @@ class Agenttrace < Formula
   end
 
   test do
-    assert_match "agenttrace v0.3.43", shell_output("#{bin}/agenttrace --version")
+    assert_match "agenttrace v0.3.44", shell_output("#{bin}/agenttrace --version")
   end
 end

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,7 +15,7 @@ import (
 	"github.com/luoyuctl/agenttrace/internal/i18n"
 )
 
-const Version = "0.3.43"
+const Version = "0.3.44"
 
 // Severity constants for anomaly severity (internal, not i18n).
 const (

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenttrace",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "description": "High-signal TUI observability for AI coding agent sessions, cost, tools, latency, and anomalies",
   "main": "install.js",
   "bin": {

--- a/site/index.html
+++ b/site/index.html
@@ -28,8 +28,8 @@
         "name": "agenttrace",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
-        "softwareVersion": "0.3.43",
-        "description": "TUI observability for AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, Kimi, and Copilot-style logs.",
+        "softwareVersion": "0.3.44",
+        "description": "TUI observability for AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes, OpenCode, Kimi, and Copilot-style logs.",
         "url": "https://luoyuctl.github.io/agenttrace/",
         "codeRepository": "https://github.com/luoyuctl/agenttrace",
         "license": "https://github.com/luoyuctl/agenttrace/blob/master/LICENSE",
@@ -64,7 +64,7 @@
         <div class="hero-copy">
           <h1>Find AI agent waste before it ships.</h1>
           <p>
-            agenttrace turns Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports,
+            agenttrace turns Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports,
             Hermes, OpenCode, Kimi, and Copilot-style logs into one fast local TUI.
           </p>
           <div class="hero-actions" id="install">
@@ -154,7 +154,7 @@ agenttrace --overview \
 
       <section class="formats">
         <h2>Multi-agent logs, one operational view.</h2>
-        <p>Claude Code · Codex CLI · Gemini CLI · Aider · Cursor exports · Hermes Agent · OpenCode · OpenClaw · Kimi CLI · Copilot-style traces</p>
+        <p>Claude Code · Codex CLI · Gemini CLI · Qwen Code · Aider · Cursor exports · Hermes Agent · OpenCode · OpenClaw · Kimi CLI · Copilot-style traces</p>
       </section>
 
       <section class="community">

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -10,7 +10,7 @@ License: MIT
 
 ## What it does
 
-- Parses local session logs from Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Kimi CLI, and Copilot-style traces.
+- Parses local session logs from Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Kimi CLI, Oh My Pi, and Copilot-style traces.
 - Shows token usage, estimated cost, tool success/failure rate, latency, hanging gaps, anomalies, and session health.
 - Provides a Bubble Tea terminal UI with overview, session list, detail, diagnostics, and diff views.
 - Exports JSON, Markdown, and self-contained HTML reports.


### PR DESCRIPTION
## Summary
- bump CLI, npm, plugin, Homebrew, README, and site versions to 0.3.44
- include Qwen Code in site metadata/source copy for the release

## Verification
- go test ./...
- go build -o /tmp/agenttrace-0344 ./cmd/agenttrace && /tmp/agenttrace-0344 --version
- node --check npm/install.js && node --check npm/run.js
- ruby -c homebrew/Formula/agenttrace.rb
- bash -n install.sh && bash -n scripts/record-demo.sh
- npm pack --dry-run