### PR TITLE
Improve quickstart messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ brew install luoyuctl/tap/agenttrace
 go install github.com/luoyuctl/agenttrace/cmd/agenttrace@latest
 ```
 
+### 60-second value check
+
+After installing, run the shortest path before wiring agenttrace into a real workflow:
+
+```bash
+# See the TUI without needing local agent logs
+agenttrace --demo
+
+# Confirm which local session directories and cache state agenttrace can see
+agenttrace --doctor
+
+# Preview machine-readable evidence for CI, dashboards, or PR notes
+agenttrace --demo --overview -f json
+```
+
+If those outputs show the pain you care about, try the real local scan:
+
+```bash
+agenttrace --overview \
+  --fail-under-health 80 \
+  --fail-on-critical \
+  --max-tool-fail-rate 15
+```
+
 ### Codex plugin
 
 This repo includes a Codex plugin manifest and skill so Codex can use `agenttrace` to audit local AI agent session logs:


### PR DESCRIPTION
## Summary
- Add a README 60-second value check for first-time visitors.
- Show the fastest path through demo TUI, local discovery with doctor, demo JSON output, and a real health gate command.

## User-facing value
- A first-time visitor can validate agenttrace without local logs and understand the CI/PR evidence path faster.

## Adoption rationale
- Shorter evaluation loops improve onboarding clarity and help developers decide whether agenttrace fits their workflow.

## Scope
- README.md only.
- No Go source, parser, test, release, workflow, or security/privacy file changes.

## Test plan
- `agenttrace --doctor`
- `go test ./...`
- `git diff --check`
- `go build -o /tmp/agenttrace ./cmd/agenttrace`
- `/tmp/agenttrace --demo --overview -f json`
- `markdownlint README.md docs/**/*.md || true` (markdownlint is not installed locally)

## Safety checklist
- [x] No push to master/main.
- [x] No force push.
- [x] No merge, tag, or release.
- [x] No prompt, session, token, secret, log, or private data uploaded.
- [x] Social/community content saved only as a local draft.

