### PR TITLE
Add Aider JSONL detection guard

### DIFF
--- a/internal/engine/parser_aider.go
+++ b/internal/engine/parser_aider.go
@@ -22,8 +22,12 @@ func isAiderHistoryFile(path, content string) bool {
 	if filepath.Base(path) == aiderHistoryFile {
 		return true
 	}
-	return strings.Contains(content, "# aider chat started at") &&
-		strings.Contains(content, "#### ")
+	trimmed := strings.TrimSpace(content)
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		return false
+	}
+	return strings.Contains(trimmed, "# aider chat started at") &&
+		strings.Contains(trimmed, "#### ")
 }
 
 func parseAiderChatHistory(raw string) ([]Event, error) {

--- a/internal/engine/parser_aider_test.go
+++ b/internal/engine/parser_aider_test.go
@@ -1,0 +1,27 @@
+package engine
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAiderDetectionDoesNotClaimJSONLWithEmbeddedHistory(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "codex-rollout-with-aider-text.jsonl")
+	if got := DetectFormat(path).Format; got != "codex_rollout" {
+		t.Fatalf("embedded aider text JSONL format: %s", got)
+	}
+	session, err := LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := session.Metrics
+	if m.SourceTool != "codex_cli" || m.ModelUsed != "openai" || m.UserMessages != 1 || m.AssistantTurns != 1 {
+		t.Fatalf("bad codex rollout metrics: %+v", m)
+	}
+}
+
+func TestParseAiderChatHistoryMalformed(t *testing.T) {
+	if _, err := parseAiderChatHistory(""); err == nil {
+		t.Fatal("expected malformed aider history to fail")
+	}
+}

--- a/testdata/codex-rollout-with-aider-text.jsonl
+++ b/testdata/codex-rollout-with-aider-text.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-05-03T11:00:00Z","type":"session_meta","payload":{"model_provider":"openai"}}
+{"timestamp":"2026-05-03T11:00:01Z","type":"turn_context","payload":{"model":"gpt-5.4"}}
+{"timestamp":"2026-05-03T11:00:02Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Review this fixture snippet:\n# aider chat started at 2026-05-03 10:00:00\n\n#### Fix parser detection\n\nIt should remain a Codex rollout."}]}}
+{"timestamp":"2026-05-03T11:00:03Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"The rollout parser should own this JSONL session."}]}}


### PR DESCRIPTION
## Summary
Improves Aider parser detection so JSON/JSONL agent logs that merely contain embedded Aider chat history text are not claimed as Aider sessions. This keeps Codex rollout sessions on the Codex parser and avoids inflated token/cost metrics.

## Reliability rationale
This change improves reliability, maintenance value, CI confidence, or developer experience for the affected workflow while keeping the scope narrow and reviewable.
## Scope
- Parser detection guard for Aider history sniffing
- Key field extraction remains with the owning Codex rollout parser for JSONL logs
- Normal and malformed input tests
- Synthetic redacted testdata fixture

## Test plan
- [x] go test ./...
- [x] go build -o /tmp/agenttrace ./cmd/agenttrace
- [x] agenttrace --doctor
- [x] /tmp/agenttrace --demo --overview -f json > /tmp/agenttrace-parser-after.json

## Safety
- [x] No prompt/session/token/secret uploaded
- [x] No protected files changed
- [x] One logical change only
