### PR TITLE
Improve overview anomaly severity ordering

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -169,9 +169,10 @@ type ModelOverview struct {
 
 // AnomalyTop is a lightweight anomaly reference for the overview.
 type AnomalyTop struct {
-	Session string
-	Type    string
-	Age     string // human-readable relative time
+	Session  string
+	Type     string
+	Age      string // human-readable relative time
+	Severity string `json:"-"`
 }
 
 // Overview aggregates all sessions for the dashboard.
@@ -221,20 +222,31 @@ func ComputeOverview(sessions []Session) Overview {
 		// Anomalies
 		for _, a := range s.Anomalies {
 			ov.AnomaliesTop = append(ov.AnomaliesTop, AnomalyTop{
-				Session: s.Name,
-				Type:    a.Type,
-				Age:     "now",
+				Session:  s.Name,
+				Type:     a.Type,
+				Age:      "now",
+				Severity: a.Severity,
 			})
 		}
 	}
 	// Sort anomalies by severity (high → medium → low)
-	sort.Slice(ov.AnomaliesTop, func(i, j int) bool {
-		severityOrder := map[string]int{SeverityHigh: 0, SeverityMedium: 1, SeverityLow: 2}
-		ai := severityOrder[ov.AnomaliesTop[i].Type]
-		aj := severityOrder[ov.AnomaliesTop[j].Type]
-		return ai < aj
+	sort.SliceStable(ov.AnomaliesTop, func(i, j int) bool {
+		return anomalySeverityRank(ov.AnomaliesTop[i].Severity) < anomalySeverityRank(ov.AnomaliesTop[j].Severity)
 	})
 	return ov
+}
+
+func anomalySeverityRank(severity string) int {
+	switch severity {
+	case SeverityHigh:
+		return 0
+	case SeverityMedium:
+		return 1
+	case SeverityLow:
+		return 2
+	default:
+		return 3
+	}
 }
 
 // ── Aggregate Stats (for btop-style health panel) ──

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -890,6 +890,38 @@ func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
 	}
 }
 
+func TestComputeOverviewSortsAnomaliesBySeverity(t *testing.T) {
+	sessions := []Session{
+		{
+			Name:      "low",
+			Anomalies: []Anomaly{{Type: "no_tools", Severity: SeverityLow}},
+		},
+		{
+			Name:      "unknown",
+			Anomalies: []Anomaly{{Type: "legacy"}},
+		},
+		{
+			Name:      "high",
+			Anomalies: []Anomaly{{Type: "hanging", Severity: SeverityHigh}},
+		},
+		{
+			Name:      "medium",
+			Anomalies: []Anomaly{{Type: "latency", Severity: SeverityMedium}},
+		},
+	}
+
+	got := ComputeOverview(sessions).AnomaliesTop
+	if len(got) != 4 {
+		t.Fatalf("expected four anomalies, got %d: %+v", len(got), got)
+	}
+	want := []string{"high", "medium", "low", "unknown"}
+	for i, name := range want {
+		if got[i].Session != name {
+			t.Fatalf("anomaly %d should be %q, got %+v", i, name, got)
+		}
+	}
+}
+
 func TestReportOverviewMarkdownIncludesCISummary(t *testing.T) {
 	sessions := []Session{
 		{


### PR DESCRIPTION
## Summary
- Fix overview anomaly ordering so high severity findings are listed before medium, low, and unknown severity findings.
- Keep severity as an internal sort key for `AnomalyTop` without adding it to overview JSON output.
- Add a regression test covering high/medium/low/unknown ordering.

## Reliability rationale
This change improves reliability, maintenance value, CI confidence, or developer experience for the affected workflow while keeping the scope narrow and reviewable.
## Evidence
- `ComputeOverview` previously sorted `AnomaliesTop` by `Type` while the rank map used severity values (`high`, `medium`, `low`), so most anomaly types were not actually prioritized by severity.
- Demo overview before/after diff shows `no_tools` moving after high severity findings while the JSON fields stay the same.

## Scope
- Changed only overview anomaly ranking in `internal/engine/engine.go`.
- Added one focused regression test in `internal/engine/engine_test.go`.
- No parser changes, no marketing/docs changes, no new dependencies, no privacy-impacting behavior.

## Test plan
- `go test ./internal/engine -run TestComputeOverviewSortsAnomaliesBySeverity -count=1`
- `go test ./...`
- `go test ./... -cover`
- `go build -o /tmp/agenttrace ./cmd/agenttrace`
- `agenttrace --doctor`
- `/tmp/agenttrace --doctor`
- `/tmp/agenttrace --demo --overview -f json > /tmp/agenttrace-quality-after.json`
- Built master as `/tmp/agenttrace-master`, generated `/tmp/agenttrace-quality-before.json`, and compared `jq -S` output against the branch.

## Safety checklist
- [x] Did not push to master/main.
- [x] Did not force push.
- [x] Did not merge the PR.
- [x] Did not tag or release.
- [x] Did not upload prompts, sessions, tokens, secrets, logs, or private data.
- [x] Kept this PR to one logical quality fix.
- [x] Did not add external dependencies.
- [x] Did not skip tests.

