### PR TITLE
Improve CI gate messaging

### DIFF
--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -2,6 +2,15 @@
 
 Use `agenttrace --overview` as a quality gate for AI agent sessions in pull requests or nightly jobs.
 
+The goal is to catch agent workflow regressions before they become invisible cost:
+
+- a PR's agent run starts hanging or retrying tools
+- a nightly automation job burns more tokens than usual
+- a team switches agent tools and loses session health visibility
+- a local-first project wants CI evidence without uploading prompts or raw logs to a hosted trace service
+
+Start with report-only artifacts, then turn on blocking thresholds once the team knows its normal health and tool failure range.
+
 ## Local Check
 
 ```bash
@@ -12,6 +21,23 @@ agenttrace --overview \
 ```
 
 The command exits with code `2` when a gate fails. Add `-f json -o agenttrace-overview.json` when CI should upload machine-readable data, `-f markdown -o agenttrace-overview.md` when the report should be pasted into a PR comment, or `-f html -o agenttrace-overview.html` for a self-contained visual artifact.
+
+For the first few runs, keep the job non-blocking while still collecting evidence:
+
+```bash
+agenttrace --overview -f markdown -o agenttrace-overview.md || true
+agenttrace --overview -f html -o agenttrace-overview.html || true
+```
+
+When the output matches what the team cares about, enable blocking checks:
+
+```bash
+agenttrace --overview -f json \
+  --fail-under-health 80 \
+  --fail-on-critical \
+  --max-tool-fail-rate 15 \
+  -o agenttrace-overview.json
+```
 
 ## GitHub Actions
 


### PR DESCRIPTION
## Summary
- Add a team-oriented adoption path to the CI integration guide.
- Explain when to use agenttrace as report-only evidence before enabling blocking health and tool-failure gates.
- Keep the example commands focused on existing `--overview` JSON, Markdown, HTML, and threshold flags.

## User-facing value
- Engineering teams get a safer path for trying agenttrace in CI before turning health checks into blocking gates.

## Adoption rationale
- A staged CI workflow improves documentation clarity for teams that need evidence first and enforcement later.

## Scope
- docs/ci-integration.md only.
- No Go source, parser, test, workflow, release, or security/privacy file changes.

## Test plan
- `agenttrace --doctor`
- `go test ./...`
- `git diff --check`
- `go build -o /tmp/agenttrace ./cmd/agenttrace`
- `markdownlint README.md docs/**/*.md || true` (markdownlint is not installed locally)

## Safety checklist
- [x] No push to master/main.
- [x] No force push.
- [x] No merge, tag, or release.
- [x] No prompt, session, token, secret, log, or private data uploaded.
- [x] Social/community content saved only as a local draft.

