### PR TITLE
Improve session cache clear reliability

### DIFF
--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -107,7 +108,11 @@ func SaveSessionCache(sc SessionCache) error {
 
 // ClearSessionCache removes the session cache file.
 func ClearSessionCache() error {
-	return os.Remove(sessionCachePath())
+	err := os.Remove(sessionCachePath())
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
 // CachedSession returns a parsed session only when file metadata still matches.

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -725,6 +726,61 @@ func TestLoadSessionCacheSkipsOnlyBadEntries(t *testing.T) {
 	}
 	if len(cache.Dirs) != 1 || len(cache.Dirs["/tmp"].Files) != 1 {
 		t.Fatalf("expected only good dir loaded: %+v", cache.Dirs)
+	}
+}
+
+func TestSessionCachePersistsAndClears(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	cachePath := SessionCachePath()
+	if filepath.Base(cachePath) != "sessions.json" || filepath.Base(filepath.Dir(cachePath)) != "agenttrace" {
+		t.Fatalf("unexpected cache path: %s", cachePath)
+	}
+	if err := ClearSessionCache(); err != nil {
+		t.Fatalf("clearing a missing cache should be a no-op: %v", err)
+	}
+
+	want := SessionCache{
+		Entries: map[string]CacheEntry{
+			"/tmp/session.jsonl": {
+				ModTime: 10,
+				Size:    20,
+				Session: Session{Name: "cached", Health: 88},
+			},
+		},
+		Dirs: map[string]DirCacheEntry{
+			"/tmp": {
+				ModTime: 30,
+				Files:   []string{"/tmp/session.jsonl"},
+				Dirs:    []string{"/tmp/nested"},
+			},
+		},
+	}
+	if err := SaveSessionCache(want); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+	if _, err := os.Stat(cachePath); err != nil {
+		t.Fatalf("expected cache file to exist: %v", err)
+	}
+
+	got := LoadSessionCache()
+	if got.Entries["/tmp/session.jsonl"].Session.Name != "cached" {
+		t.Fatalf("cache entry did not round-trip: %+v", got.Entries)
+	}
+	if len(got.Dirs["/tmp"].Files) != 1 || got.Dirs["/tmp"].Dirs[0] != "/tmp/nested" {
+		t.Fatalf("directory cache did not round-trip: %+v", got.Dirs)
+	}
+
+	if err := ClearSessionCache(); err != nil {
+		t.Fatalf("clear cache: %v", err)
+	}
+	if _, err := os.Stat(cachePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected cache file removed, stat err=%v", err)
+	}
+	if err := ClearSessionCache(); err != nil {
+		t.Fatalf("clearing an already removed cache should be a no-op: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Make `ClearSessionCache` idempotent by treating a missing cache file as a successful clear.
- Add a focused cache persistence test covering `SessionCachePath`, `SaveSessionCache`, `LoadSessionCache`, and `ClearSessionCache` round-trip behavior.
- Keep the behavior local to session cache handling with no parser or output format changes.

## Reliability rationale
This change improves reliability, maintenance value, CI confidence, or developer experience for the affected workflow while keeping the scope narrow and reviewable.
## Evidence
- Baseline coverage showed `SessionCachePath`, `SaveSessionCache`, and `ClearSessionCache` at 0% statement coverage.
- A new regression test initially failed because `ClearSessionCache` returned `no such file or directory` when the cache was already absent.
- After the fix, focused cache function coverage is: `SessionCachePath` 100%, `SaveSessionCache` 71.4%, `ClearSessionCache` 100%, `LoadSessionCache` 88.9%.

## Scope
- Changed only `internal/engine/cache.go` and `internal/engine/engine_test.go`.
- No new dependencies.
- No parser changes, docs changes, marketing changes, release changes, or privacy-impacting behavior.

## Test plan
- `go test ./internal/engine -run TestSessionCachePersistsAndClears -count=1`
- `go test ./...`
- `go test ./... -cover`
- `go test ./internal/engine -coverprofile=/tmp/agenttrace-cache-cover.out` plus `go tool cover -func=/tmp/agenttrace-cache-cover.out`
- `go build -o /tmp/agenttrace ./cmd/agenttrace`
- `agenttrace --doctor`
- `/tmp/agenttrace --doctor`

## Safety checklist
- [x] Did not push to master/main.
- [x] Did not force push.
- [x] Did not merge the PR.
- [x] Did not tag or release.
- [x] Did not upload prompts, sessions, tokens, secrets, logs, or private data.
- [x] Kept this PR to one logical cache reliability fix.
- [x] Did not add external dependencies.
- [x] Did not skip tests.

