### PR TITLE
Add Cursor composer message parser support

### DIFF
--- a/internal/engine/parser_cursor.go
+++ b/internal/engine/parser_cursor.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -107,6 +108,11 @@ func parseCursorExport(doc map[string]interface{}, arr []interface{}) ([]Event, 
 			if !ok {
 				continue
 			}
+			fallbackTS := cursorTimestamp(cursorFirst(m["lastUpdatedAt"], m["createdAt"]))
+			if msgEvents := cursorComposerMessageEvents(m, fallbackTS); len(msgEvents) > 0 {
+				events = append(events, msgEvents...)
+				continue
+			}
 			content := str(m, "name")
 			subtitle := str(m, "subtitle")
 			if subtitle != "" && subtitle != content {
@@ -124,7 +130,7 @@ func parseCursorExport(doc map[string]interface{}, arr []interface{}) ([]Event, 
 			events = append(events, Event{
 				Role:       "assistant",
 				Content:    content,
-				Timestamp:  cursorUnixMS(cursorFirst(m["lastUpdatedAt"], m["createdAt"])),
+				Timestamp:  fallbackTS,
 				SourceTool: cursorSource,
 			})
 		}
@@ -156,6 +162,88 @@ func cursorArray(v interface{}) []interface{} {
 	return nil
 }
 
+func cursorComposerMessageEvents(composer map[string]interface{}, fallbackTS string) []Event {
+	messages := cursorComposerMessages(composer)
+	var events []Event
+	for _, item := range messages {
+		msg, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role := cursorRole(str(msg, "role"))
+		if role == "" {
+			role = cursorRole(str(msg, "speaker"))
+		}
+		if role == "" {
+			role = cursorRole(str(msg, "type"))
+		}
+		content := cursorText(cursorFirst(msg["text"], msg["content"], msg["message"], msg["markdown"], msg["rawText"]))
+		if role == "" || content == "" {
+			continue
+		}
+		ts := cursorTimestamp(cursorFirst(msg["unixMs"], msg["timestamp"], msg["createdAt"], msg["lastUpdatedAt"]))
+		if ts == "" {
+			ts = fallbackTS
+		}
+		events = append(events, Event{
+			Role:       role,
+			Content:    content,
+			Timestamp:  ts,
+			SourceTool: cursorSource,
+		})
+	}
+	return events
+}
+
+func cursorComposerMessages(composer map[string]interface{}) []interface{} {
+	for _, key := range []string{"messages", "conversationMessages"} {
+		if arr := cursorArray(composer[key]); len(arr) > 0 {
+			return arr
+		}
+	}
+	if arr := cursorArray(composer["conversation"]); len(arr) > 0 {
+		return arr
+	}
+	if conv, ok := composer["conversation"].(map[string]interface{}); ok {
+		for _, key := range []string{"messages", "conversationMessages"} {
+			if arr := cursorArray(conv[key]); len(arr) > 0 {
+				return arr
+			}
+		}
+	}
+	return nil
+}
+
+func cursorRole(role string) string {
+	switch strings.ToLower(role) {
+	case "user", "human":
+		return "user"
+	case "assistant", "ai", "bot":
+		return "assistant"
+	default:
+		return ""
+	}
+}
+
+func cursorText(v interface{}) string {
+	switch value := v.(type) {
+	case string:
+		return value
+	case map[string]interface{}:
+		return str(value, "text")
+	case []interface{}:
+		var parts []string
+		for _, item := range value {
+			if text := cursorText(item); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return ""
+	}
+}
+
 func cursorFirst(values ...interface{}) interface{} {
 	for _, v := range values {
 		if v != nil {
@@ -163,6 +251,13 @@ func cursorFirst(values ...interface{}) interface{} {
 		}
 	}
 	return nil
+}
+
+func cursorTimestamp(v interface{}) string {
+	if ts, ok := v.(string); ok {
+		return ts
+	}
+	return cursorUnixMS(v)
 }
 
 func cursorUnixMS(v interface{}) string {

--- a/internal/engine/parser_cursor_composer_test.go
+++ b/internal/engine/parser_cursor_composer_test.go
@@ -1,0 +1,40 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseCursorComposerMessages(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "cursor-composer-messages.json")
+	if got := DetectFormat(path).Format; got != "cursor" {
+		t.Fatalf("cursor composer message format: %s", got)
+	}
+	session, err := LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := session.Metrics
+	if m.SourceTool != "cursor" || m.UserMessages != 1 || m.AssistantTurns != 1 {
+		t.Fatalf("bad cursor composer metrics: %+v", m)
+	}
+	if m.SessionStart != "2026-05-03T10:00:00Z" || m.SessionEnd != "2026-05-03T10:01:00Z" {
+		t.Fatalf("bad cursor composer timestamps: %+v", m)
+	}
+}
+
+func TestParseCursorComposerMessagesMalformed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cursor-broken-composer.json")
+	raw := `{"composer.composerData":{"allComposers":[{"messages":[{"role":"assistant"}]}]}}`
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectFormat(path).Format; got != "cursor" {
+		t.Fatalf("cursor malformed composer format: %s", got)
+	}
+	if _, err := Parse(path); err == nil {
+		t.Fatal("expected malformed cursor composer export to fail")
+	}
+}

--- a/testdata/cursor-composer-messages.json
+++ b/testdata/cursor-composer-messages.json
@@ -1,0 +1,32 @@
+{
+  "composer.composerData": {
+    "allComposers": [
+      {
+        "composerId": "cmp-1",
+        "name": "Auth cleanup",
+        "lastUpdatedAt": 1710000060000,
+        "conversation": {
+          "messages": [
+            {
+              "role": "user",
+              "text": "Refactor the auth flow",
+              "timestamp": "2026-05-03T10:00:00Z"
+            },
+            {
+              "role": "assistant",
+              "content": [
+                {
+                  "text": "Updated the login component."
+                },
+                {
+                  "text": "Added focused tests."
+                }
+              ],
+              "timestamp": "2026-05-03T10:01:00Z"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Adds Cursor composer message extraction so agenttrace can parse user and assistant turns stored inside composer conversation/message arrays, instead of only showing composer summary metadata.

## Reliability rationale
This change improves reliability, maintenance value, CI confidence, or developer experience for the affected workflow while keeping the scope narrow and reviewable.
## Scope
- Parser detection via existing Cursor export keys
- Key field extraction for composer user/assistant messages and timestamps
- Normal and malformed input tests
- Synthetic redacted testdata fixture

## Test plan
- [x] go test ./...
- [x] go build -o /tmp/agenttrace ./cmd/agenttrace
- [x] agenttrace --doctor
- [x] /tmp/agenttrace --demo --overview -f json > /tmp/agenttrace-parser-after.json

## Safety
- [x] No prompt/session/token/secret uploaded
- [x] No protected files changed
- [x] One logical change only
