### PR TITLE
Improve session cache stale file handling

### DIFF
--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -216,12 +216,17 @@ func sortFilesByCache(paths []string, cache SessionCache) []string {
 	}
 	items := make([]item, 0, len(paths))
 	for _, p := range paths {
-		if entry, ok := cache.Entries[p]; ok {
-			items = append(items, item{path: p, t: time.Unix(0, entry.ModTime)})
-			continue
-		}
 		info, err := os.Stat(p)
 		if err != nil {
+			delete(cache.Entries, p)
+			continue
+		}
+		if entry, ok := cache.Entries[p]; ok {
+			if entry.ModTime == info.ModTime().UnixNano() && entry.Size == info.Size() {
+				items = append(items, item{path: p, t: time.Unix(0, entry.ModTime)})
+				continue
+			}
+			items = append(items, item{path: p, t: info.ModTime()})
 			continue
 		}
 		items = append(items, item{path: p, t: info.ModTime()})

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -698,6 +698,49 @@ func TestFindSessionFilesCachedUsesDirIndexAndFindsNewFiles(t *testing.T) {
 	}
 }
 
+func TestFindSessionFilesCachedSkipsDeletedCachedFiles(t *testing.T) {
+	dir := t.TempDir()
+	stale := filepath.Join(dir, "stale.jsonl")
+	if err := os.WriteFile(stale, []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fileInfo, err := os.Stat(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cache := SessionCache{
+		Entries: map[string]CacheEntry{
+			stale: {
+				ModTime: fileInfo.ModTime().UnixNano(),
+				Size:    fileInfo.Size(),
+				Session: Session{Name: "stale", Path: stale},
+			},
+		},
+		Dirs: map[string]DirCacheEntry{
+			dir: {
+				ModTime: dirInfo.ModTime().UnixNano(),
+				Files:   []string{stale},
+			},
+		},
+	}
+	if err := os.Remove(stale); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(dir, dirInfo.ModTime(), dirInfo.ModTime()); err != nil {
+		t.Fatal(err)
+	}
+
+	files := FindSessionFilesCached(dir, cache)
+	if len(files) != 0 {
+		t.Fatalf("deleted cached files should be skipped, got %v", files)
+	}
+}
+
 func TestLoadSessionCacheSkipsOnlyBadEntries(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary
- Filter stale cached session paths when the underlying file has been deleted.
- Prune deleted file entries from the in-memory session cache during cached discovery.
- Add a focused regression test for cached directory listings that still point at deleted files.

## Reliability rationale
This change improves reliability, maintenance value, CI confidence, or developer experience for the affected workflow while keeping the scope narrow and reviewable.
## Evidence
- `FindSessionFilesCached` can reuse cached directory listings when the directory mtime matches.
- Before this fix, `sortFilesByCache` trusted `cache.Entries[path]` without checking whether `path` still existed, so a deleted cached session could still be returned.
- The new regression test failed before the fix with a deleted `stale.jsonl` still present in discovery results, then passed after the fix.

## Scope
- Changed only `internal/engine/cache.go` and `internal/engine/engine_test.go`.
- No parser changes, no output format changes, no docs/marketing changes, no release changes.
- No new dependencies and no privacy-impacting behavior.

## Test plan
- `go test ./internal/engine -run TestFindSessionFilesCachedSkipsDeletedCachedFiles -count=1`
- `go test ./...`
- `go test ./... -cover`
- `go test ./internal/engine -coverprofile=/tmp/agenttrace-stale-cache-cover-clean.out` plus `go tool cover -func=/tmp/agenttrace-stale-cache-cover-clean.out`
- `go build -o /tmp/agenttrace ./cmd/agenttrace`
- `agenttrace --doctor`
- `/tmp/agenttrace --doctor`

## Safety checklist
- [x] Did not push to master/main.
- [x] Did not force push.
- [x] Did not merge the PR.
- [x] Did not tag or release.
- [x] Did not upload prompts, sessions, tokens, secrets, logs, or private data.
- [x] Kept this PR to one logical cache discovery reliability fix.
- [x] Did not add external dependencies.
- [x] Did not skip tests.

