### PR TITLE
Add Copilot attributes map parser support

### DIFF
--- a/internal/engine/parser_copilot.go
+++ b/internal/engine/parser_copilot.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -36,19 +38,8 @@ func parseCopilotCLI(raw string) ([]Event, error) {
 		name, _ := span["name"].(string)
 
 		// Extract model from attributes
-		if attrs, ok := span["attributes"].([]interface{}); ok {
-			for _, attr := range attrs {
-				if am, ok := attr.(map[string]interface{}); ok {
-					key, _ := am["key"].(string)
-					if key == "gen_ai.request.model" {
-						if v, ok := am["value"].(map[string]interface{}); ok {
-							if sv, _ := v["stringValue"].(string); sv != "" {
-								model = sv
-							}
-						}
-					}
-				}
-			}
+		if sv := extractStringAttribute(span, "gen_ai.request.model"); sv != "" {
+			model = sv
 		}
 
 		// Extract timestamp (nanoseconds → RFC3339)
@@ -59,22 +50,17 @@ func parseCopilotCLI(raw string) ([]Event, error) {
 
 		// Extract usage from attributes
 		usage := make(map[string]int)
-		if attrs, ok := span["attributes"].([]interface{}); ok {
-			for _, attr := range attrs {
-				if am, ok := attr.(map[string]interface{}); ok {
-					key, _ := am["key"].(string)
-					switch key {
-					case "gen_ai.usage.input_tokens":
-						usage["input_tokens"] = extractIntValue(am)
-					case "gen_ai.usage.output_tokens":
-						usage["output_tokens"] = extractIntValue(am)
-					case "gen_ai.usage.cache_creation_input_tokens":
-						usage["cache_creation_input_tokens"] = extractIntValue(am)
-					case "gen_ai.usage.cache_read_input_tokens":
-						usage["cache_read_input_tokens"] = extractIntValue(am)
-					}
-				}
-			}
+		if n := extractIntAttribute(span, "gen_ai.usage.input_tokens"); n > 0 {
+			usage["input_tokens"] = n
+		}
+		if n := extractIntAttribute(span, "gen_ai.usage.output_tokens"); n > 0 {
+			usage["output_tokens"] = n
+		}
+		if n := extractIntAttribute(span, "gen_ai.usage.cache_creation_input_tokens"); n > 0 {
+			usage["cache_creation_input_tokens"] = n
+		}
+		if n := extractIntAttribute(span, "gen_ai.usage.cache_read_input_tokens"); n > 0 {
+			usage["cache_read_input_tokens"] = n
 		}
 
 		// Map span name to event
@@ -149,6 +135,9 @@ func parseCopilotCLI(raw string) ([]Event, error) {
 		}
 	}
 
+	if len(events) == 0 {
+		return nil, fmt.Errorf("copilot_cli: no valid events found")
+	}
 	return events, nil
 }
 
@@ -162,51 +151,95 @@ func extractSpanContent(span map[string]interface{}) string {
 		}
 	}
 	// Try attributes for content
-	return extractStringAttribute(span, "content")
-}
-
-func extractStringAttribute(span map[string]interface{}, targetKey string) string {
-	attrs, ok := span["attributes"].([]interface{})
-	if !ok {
-		return ""
-	}
-	for _, attr := range attrs {
-		am, ok := attr.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		key, _ := am["key"].(string)
-		if key == targetKey {
-			if v, ok := am["value"].(map[string]interface{}); ok {
-				if sv, _ := v["stringValue"].(string); sv != "" {
-					return sv
-				}
-			}
+	for _, key := range []string{"content", "message", "body", "gen_ai.response.text"} {
+		if content := extractStringAttribute(span, key); content != "" {
+			return content
 		}
 	}
 	return ""
 }
 
+func extractStringAttribute(span map[string]interface{}, targetKey string) string {
+	return copilotStringValue(copilotAttributeValue(span, targetKey))
+}
+
 func extractBoolAttribute(span map[string]interface{}, targetKey string) bool {
-	attrs, ok := span["attributes"].([]interface{})
-	if !ok {
-		return false
-	}
-	for _, attr := range attrs {
-		am, ok := attr.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		key, _ := am["key"].(string)
-		if key == targetKey {
-			if v, ok := am["value"].(map[string]interface{}); ok {
-				if bv, _ := v["boolValue"].(bool); bv {
-					return true
-				}
+	return copilotBoolValue(copilotAttributeValue(span, targetKey))
+}
+
+func extractIntAttribute(span map[string]interface{}, targetKey string) int {
+	return copilotIntValue(copilotAttributeValue(span, targetKey))
+}
+
+func copilotAttributeValue(span map[string]interface{}, targetKey string) interface{} {
+	switch attrs := span["attributes"].(type) {
+	case []interface{}:
+		for _, attr := range attrs {
+			am, ok := attr.(map[string]interface{})
+			if !ok {
+				continue
 			}
+			key, _ := am["key"].(string)
+			if key == targetKey {
+				return am["value"]
+			}
+		}
+	case map[string]interface{}:
+		return attrs[targetKey]
+	}
+	return nil
+}
+
+func copilotStringValue(v interface{}) string {
+	switch value := v.(type) {
+	case string:
+		return value
+	case map[string]interface{}:
+		if sv, _ := value["stringValue"].(string); sv != "" {
+			return sv
+		}
+	}
+	return ""
+}
+
+func copilotBoolValue(v interface{}) bool {
+	switch value := v.(type) {
+	case bool:
+		return value
+	case map[string]interface{}:
+		if bv, _ := value["boolValue"].(bool); bv {
+			return true
 		}
 	}
 	return false
+}
+
+func copilotIntValue(v interface{}) int {
+	switch value := v.(type) {
+	case float64:
+		return int(value)
+	case int:
+		return value
+	case json.Number:
+		val, _ := value.Int64()
+		return int(val)
+	case string:
+		val, err := strconv.ParseInt(value, 10, 64)
+		if err == nil {
+			return int(val)
+		}
+	case map[string]interface{}:
+		if iv, ok := value["intValue"]; ok {
+			return copilotIntValue(iv)
+		}
+		if sv, ok := value["stringValue"]; ok {
+			return copilotIntValue(sv)
+		}
+		if dv, ok := value["doubleValue"]; ok {
+			return copilotIntValue(dv)
+		}
+	}
+	return 0
 }
 
 func extractIntValue(attr map[string]interface{}) int {
@@ -253,6 +286,9 @@ func toFloat64(v interface{}) (float64, bool) {
 		return n, true
 	case json.Number:
 		f, err := n.Float64()
+		return f, err == nil
+	case string:
+		f, err := strconv.ParseFloat(n, 64)
 		return f, err == nil
 	}
 	return 0, false

--- a/internal/engine/parser_copilot_test.go
+++ b/internal/engine/parser_copilot_test.go
@@ -1,0 +1,46 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseCopilotCLIAttributesMap(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "copilot-attrs-map.jsonl")
+	if got := DetectFormat(path).Format; got != "copilot_cli" {
+		t.Fatalf("copilot attributes map format: %s", got)
+	}
+	session, err := LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := session.Metrics
+	if m.SourceTool != "copilot_cli" || m.ModelUsed != "gpt-4.1" {
+		t.Fatalf("bad copilot source/model: %+v", m)
+	}
+	if m.TokensInput != 120 || m.TokensOutput < 40 {
+		t.Fatalf("bad copilot usage: %+v", m)
+	}
+	if m.ToolCallsTotal != 1 || m.ToolCallsOK != 1 || m.ToolUsage["read_file"] != 1 {
+		t.Fatalf("bad copilot tool metrics: %+v", m)
+	}
+	if m.SessionStart == "" || m.SessionEnd == "" {
+		t.Fatalf("expected copilot timestamps, got %+v", m)
+	}
+}
+
+func TestParseCopilotCLIMalformed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "copilot-broken.jsonl")
+	raw := "{\"traceId\":\"trace-1\",\"spanId\":\"span-empty\",\"name\":\"chat.completion\",\"attributes\":{\"gen_ai.request.model\":\"gpt-4.1\"}}\n{}\n"
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectFormat(path).Format; got != "copilot_cli" {
+		t.Fatalf("copilot malformed format: %s", got)
+	}
+	if _, err := Parse(path); err == nil {
+		t.Fatal("expected malformed copilot log to fail")
+	}
+}

--- a/testdata/copilot-attrs-map.jsonl
+++ b/testdata/copilot-attrs-map.jsonl
@@ -1,0 +1,3 @@
+{"traceId":"trace-1","spanId":"span-chat","name":"chat.completion","startTimeUnixNano":"1770000000000000000","attributes":{"gen_ai.request.model":"gpt-4.1","gen_ai.usage.input_tokens":120,"gen_ai.usage.output_tokens":"40","content":"Implemented the requested change."}}
+{"traceId":"trace-1","spanId":"span-tool-call","parentSpanId":"span-chat","name":"tool.call","startTimeUnixNano":"1770000001000000000","attributes":{"tool.name":"read_file","tool.call.id":"call-1"}}
+{"traceId":"trace-1","spanId":"span-tool-result","parentSpanId":"span-tool-call","name":"tool.result","startTimeUnixNano":"1770000002000000000","attributes":{"tool.call.id":"call-1","content":"ok","tool.result.is_error":false}}


### PR DESCRIPTION
## Summary
Adds Copilot-style OTel parser support for spans whose attributes are exported as a JSON object map instead of the OpenTelemetry array-of-key-value shape. It also accepts string nanosecond timestamps and returns a diagnostic error for malformed Copilot logs with no parseable events.

## Reliability rationale
This change improves reliability, maintenance value, CI confidence, or developer experience for the affected workflow while keeping the scope narrow and reviewable.
## Scope
- Parser detection through existing Copilot traceId/spanId detection
- Key field extraction for model, usage, content, tool call/result, errors, and timestamps from attributes maps
- Normal and malformed input tests
- Synthetic redacted testdata fixture

## Test plan
- [x] go test ./...
- [x] go build -o /tmp/agenttrace ./cmd/agenttrace
- [x] agenttrace --doctor
- [x] /tmp/agenttrace --demo --overview -f json > /tmp/agenttrace-parser-after.json

## Safety
- [x] No prompt/session/token/secret uploaded
- [x] No protected files changed
- [x] One logical change only
