### PR TITLE
Improve install path messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,18 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 
 ## 🚀 Quick Start
 
+Not sure which install path to use? Start with the one-liner for a quick local trial. Use Homebrew when you want managed upgrades, Go install when you already live in the Go toolchain, and manual build when you want to inspect or change the source first.
+
 ### One-liner install
+
+Recommended for first-time Linux/macOS users who want to try the TUI quickly:
 
 ```bash
 # Linux / macOS
 curl -sL https://raw.githubusercontent.com/luoyuctl/agenttrace/master/install.sh | sh
 ```
+
+Windows users can use the PowerShell installer:
 
 ```powershell
 # Windows (PowerShell)
@@ -98,11 +104,15 @@ iwr -useb https://raw.githubusercontent.com/luoyuctl/agenttrace/master/install.p
 
 ### Homebrew (macOS / Linux)
 
+Recommended when you prefer package-manager upgrades:
+
 ```bash
 brew install luoyuctl/tap/agenttrace
 ```
 
 ### Go install
+
+Recommended when your `$GOBIN` or `$GOPATH/bin` is already on `PATH`:
 
 ```bash
 go install github.com/luoyuctl/agenttrace/cmd/agenttrace@latest


### PR DESCRIPTION
## Summary
- Add quick guidance for choosing the right README install path.
- Recommend the one-liner for first trials, Homebrew for managed upgrades, Go install for Go users, and manual build for source inspection or modification.

## User-facing value
- First-time visitors get a clearer install choice and can reach `agenttrace --demo` or a local scan faster.

## Adoption rationale
- Reducing setup ambiguity improves onboarding clarity and makes it easier for developers to evaluate the tool in their own workflow.

## Scope
- README.md only.
- No Go source, parser, test, workflow, release, security/privacy, or external community changes.

## Test plan
- `agenttrace --doctor`
- `go test ./...`
- `git diff --check`
- `go build -o /tmp/agenttrace ./cmd/agenttrace`
- `markdownlint README.md docs/**/*.md || true` (markdownlint is not installed locally)

## Safety checklist
- [x] No push to master/main.
- [x] No force push.
- [x] No merge, tag, or release.
- [x] No prompt, session, token, secret, log, or private data uploaded.
- [x] Social/community content saved only as a local draft.

