### PR TITLE
Add Kimi tool args parser support

### DIFF
--- a/internal/engine/parser_kimi.go
+++ b/internal/engine/parser_kimi.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // parseKimiCLI parses Kimi CLI JSON session files.
@@ -89,10 +90,17 @@ func parseKimiCLI(doc map[string]interface{}) ([]Event, error) {
 				case "tool_use":
 					id, _ := b["id"].(string)
 					name, _ := b["name"].(string)
+					args := jsonish(b["input"])
+					if args == "" {
+						args = jsonish(b["arguments"])
+					}
 					// Kimi may use "function" sub-object for tool name
 					if name == "" {
 						if fn, ok := b["function"].(map[string]interface{}); ok {
 							name, _ = fn["name"].(string)
+							if args == "" {
+								args = jsonish(fn["arguments"])
+							}
 						}
 					}
 					events = append(events, Event{
@@ -100,6 +108,7 @@ func parseKimiCLI(doc map[string]interface{}) ([]Event, error) {
 						ToolCalls: []ToolCall{{
 							ID:   id,
 							Name: name,
+							Args: args,
 						}},
 						Timestamp:  ts,
 						SourceTool: "kimi_cli",
@@ -135,6 +144,7 @@ func parseKimiCLI(doc map[string]interface{}) ([]Event, error) {
 						tcItem := ToolCall{ID: str(tcm, "id")}
 						if fn, ok := tcm["function"].(map[string]interface{}); ok {
 							tcItem.Name = str(fn, "name")
+							tcItem.Args = jsonish(fn["arguments"])
 						}
 						tcList = append(tcList, tcItem)
 					}
@@ -187,5 +197,8 @@ func parseKimiCLI(doc map[string]interface{}) ([]Event, error) {
 		})
 	}
 
+	if len(events) == 0 {
+		return nil, fmt.Errorf("kimi_cli: no parseable events")
+	}
 	return events, nil
 }

--- a/internal/engine/parser_kimi_test.go
+++ b/internal/engine/parser_kimi_test.go
@@ -1,0 +1,52 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseKimiCLIToolArguments(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "kimi-tool-args.json")
+	if got := DetectFormat(path).Format; got != "kimi_cli" {
+		t.Fatalf("kimi tool args format: %s", got)
+	}
+	events, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var foundTool bool
+	for _, ev := range events {
+		for _, tc := range ev.ToolCalls {
+			if tc.Name == "read_file" && strings.Contains(tc.Args, "go.mod") {
+				foundTool = true
+			}
+		}
+	}
+	if !foundTool {
+		t.Fatalf("expected Kimi tool args in events: %+v", events)
+	}
+	m := Analyze(events, "kimi-k2.6")
+	if m.SourceTool != "kimi_cli" || m.ToolCallsTotal != 1 || m.ToolCallsOK != 1 || m.ToolUsage["read_file"] != 1 {
+		t.Fatalf("bad kimi metrics: %+v", m)
+	}
+	if m.TokensInput != 120 || m.TokensOutput < 40 {
+		t.Fatalf("bad kimi usage: %+v", m)
+	}
+}
+
+func TestParseKimiCLIMalformed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kimi-broken.json")
+	raw := `{"model":"kimi-k2.6","messages":[{"role":"assistant","content":[{"type":"unknown"}]}]}`
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectFormat(path).Format; got != "kimi_cli" {
+		t.Fatalf("kimi malformed format: %s", got)
+	}
+	if _, err := Parse(path); err == nil {
+		t.Fatal("expected malformed kimi session to fail")
+	}
+}

--- a/testdata/kimi-tool-args.json
+++ b/testdata/kimi-tool-args.json
@@ -1,0 +1,40 @@
+{
+  "model": "kimi-k2.6",
+  "metadata": {
+    "usage": {
+      "input_tokens": 120,
+      "output_tokens": 40
+    }
+  },
+  "messages": [
+    {
+      "role": "user",
+      "content": "Inspect the module file",
+      "timestamp": "2026-05-03T10:00:00Z"
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "thinking",
+          "thinking": "Need to read the module file first."
+        },
+        {
+          "type": "tool_use",
+          "id": "tool-1",
+          "name": "read_file",
+          "input": {
+            "path": "go.mod"
+          }
+        }
+      ],
+      "timestamp": "2026-05-03T10:00:01Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "tool-1",
+      "content": "module github.com/luoyuctl/agenttrace",
+      "timestamp": "2026-05-03T10:00:02Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Improves Kimi parser support by preserving tool call arguments from Anthropic-style `tool_use` blocks and OpenAI-style `function.arguments`. It also returns a diagnostic error for malformed Kimi sessions with no parseable events.

## Reliability rationale
This change improves reliability, maintenance value, CI confidence, or developer experience for the affected workflow while keeping the scope narrow and reviewable.
## Scope
- Parser detection via existing Kimi JSON detection
- Key field extraction for tool call arguments, model, usage, tool result, and timestamps
- Normal and malformed input tests
- Synthetic redacted testdata fixture

## Test plan
- [x] go test ./...
- [x] go build -o /tmp/agenttrace ./cmd/agenttrace
- [x] agenttrace --doctor
- [x] /tmp/agenttrace --demo --overview -f json > /tmp/agenttrace-parser-after.json

## Safety
- [x] No prompt/session/token/secret uploaded
- [x] No protected files changed
- [x] One logical change only
