### PR TITLE
[Parser] Add Cline task history parser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 |---|---|
 | Local-first privacy | Inspect sessions without uploading prompts, code, or tool logs |
 | Fast terminal triage | Open a TUI, sort bad sessions, and jump into detail/diagnostics |
-| Cross-agent comparison | Compare Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes, OpenCode, Oh My Pi, Kimi, and more |
+| Cross-agent comparison | Compare Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes, OpenCode, Oh My Pi, Kimi, and more |
 | Cost and token evidence | See cost, token usage, cache usage, retries, loops, latency, and health in one place |
 | CI guardrails | Export JSON/Markdown/HTML and fail builds on low health or high tool failure rates |
 
@@ -60,7 +60,7 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 | Silent tool loops | repeated tool calls, retry loops, long gaps, hanging sessions |
 | Slow agents | P50/P95/P99 latency, per-tool latency ranking, timeout-like gaps |
 | Quality regressions | health score, anomaly types, shallow reasoning, redacted thinking |
-| Hard-to-compare tools | session diff across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Oh My Pi, and more |
+| Hard-to-compare tools | session diff across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Oh My Pi, and more |
 | CI blind spots | JSON reports and health gates for average health, critical sessions, and tool failure rate |
 
 ## ✨ Features
@@ -72,7 +72,7 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 | ⚡ **Persistent Cache** | Incremental session cache avoids a full disk parse on every startup |
 | 🩺 **Doctor Mode** | `--doctor` checks detected agent dirs, cache health, and next steps |
 | ⌨️ **Command Mode** | `:health <80`, `:cost >0.1`, `:sort cost desc`, `:anomalies` |
-| 🔍 **Multi-Format Auto-Detect** | Claude Code / Codex CLI / Gemini CLI / Qwen Code / Aider / Cursor exports / Hermes / OpenCode / OpenClaw / Oh My Pi / Kimi / Copilot-style logs |
+| 🔍 **Multi-Format Auto-Detect** | Claude Code / Codex CLI / Gemini CLI / Qwen Code / Cline / Aider / Cursor exports / Hermes / OpenCode / OpenClaw / Oh My Pi / Kimi / Copilot-style logs |
 | 💸 **Cost & Time Waste** | How much 💰 you burned + ⏱️ time lost to loops, retries, failures |
 | 🚨 **6 Anomaly Types** | Hanging, tool failures, latency spikes, shallow thinking, redaction, zero-tool sessions |
 | 📊 **Multi-Session Comparison** | Compare across sessions and tools in one table |

--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -138,6 +138,9 @@ func FindSessionFilesCached(dir string, cache SessionCache) []string {
 	if cache.Dirs == nil {
 		cache.Dirs = make(map[string]DirCacheEntry)
 	}
+	if isClineTaskDir(dir) {
+		return []string{dir}
+	}
 
 	var roots []string
 	if dir == "" {
@@ -164,6 +167,9 @@ func collectSessionFilesCached(dir string, depth, maxDepth int, cache SessionCac
 	if depth > maxDepth {
 		return nil
 	}
+	if isClineTaskDir(dir) {
+		return []string{dir}
+	}
 	info, err := os.Stat(dir)
 	if err != nil || !info.IsDir() {
 		return nil
@@ -189,6 +195,10 @@ func collectSessionFilesCached(dir string, depth, maxDepth int, cache SessionCac
 	for _, e := range entries {
 		path := filepath.Join(dir, e.Name())
 		if e.IsDir() {
+			if isClineTaskDir(path) {
+				files = append(files, path)
+				continue
+			}
 			dirs = append(dirs, path)
 			continue
 		}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,5 +1,5 @@
 // Package engine provides the core analysis engine for agenttrace.
-// Pure Go. Supports 12 agent formats: Hermes Agent, Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, OpenClaw, Copilot CLI, Kimi CLI, Oh My Pi, Aider, Cursor.
+// Pure Go. Supports 13 agent formats: Hermes Agent, Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, OpenClaw, Copilot CLI, Kimi CLI, Oh My Pi, Aider, Cursor, Cline.
 package engine
 
 import (
@@ -55,6 +55,7 @@ var ToolDisplayNames = map[string]string{
 	"oh_my_pi":          "Oh My Pi",
 	"aider":             "Aider",
 	"cursor":            "Cursor",
+	"cline":             "Cline",
 	"generic":           "Generic JSON/JSONL",
 }
 
@@ -436,6 +437,11 @@ type FormatInfo struct {
 func DetectFormat(path string) FormatInfo {
 	fi := FormatInfo{Format: "unknown"}
 
+	if isClineTaskDir(path) {
+		fi.Format = "cline"
+		return fi
+	}
+
 	// Read entire file — Parse() downstream uses fi.Raw directly for event extraction
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -448,6 +454,11 @@ func DetectFormat(path string) FormatInfo {
 	if isAiderHistoryFile(path, content) {
 		fi.Raw = data
 		fi.Format = "aider_chat_history"
+		return fi
+	}
+	if isClineTaskFile(path) {
+		fi.Raw = data
+		fi.Format = "cline"
 		return fi
 	}
 
@@ -704,6 +715,8 @@ func Parse(path string) ([]Event, error) {
 		return parseAiderChatHistory(string(fi.Raw))
 	case "cursor":
 		return parseCursorExport(fi.Doc, fi.Arr)
+	case "cline":
+		return parseClinePath(path)
 	default:
 		return parseGeneric(string(fi.Raw))
 	}
@@ -1970,6 +1983,9 @@ func LoadAll(dir string) []Session {
 }
 
 func FindSessionFiles(dir string) []string {
+	if isClineTaskDir(dir) {
+		return []string{dir}
+	}
 	if dir == "" {
 		var all []string
 		for _, d := range DiscoverSessionDirs() {
@@ -1987,7 +2003,16 @@ func FindSessionFiles(dir string) []string {
 	}
 	var items []entryInfo
 	for _, e := range entries {
+		path := filepath.Join(dir, e.Name())
 		if e.IsDir() {
+			if isClineTaskDir(path) {
+				info, err := e.Info()
+				mt := time.Time{}
+				if err == nil {
+					mt = info.ModTime()
+				}
+				items = append(items, entryInfo{path: path, t: mt})
+			}
 			continue
 		}
 		name := e.Name()
@@ -1999,7 +2024,7 @@ func FindSessionFiles(dir string) []string {
 		if err == nil {
 			mt = info.ModTime()
 		}
-		items = append(items, entryInfo{path: filepath.Join(dir, name), t: mt})
+		items = append(items, entryInfo{path: path, t: mt})
 	}
 	sort.Slice(items, func(i, j int) bool {
 		return items[i].t.After(items[j].t)
@@ -2050,7 +2075,7 @@ func KnownSessionDirs() []KnownSessionDir {
 	if home == "" {
 		return nil
 	}
-	return []KnownSessionDir{
+	dirs := []KnownSessionDir{
 		{Name: "Hermes Agent", Path: filepath.Join(home, ".hermes", "sessions")},
 		{Name: "Codex CLI", Path: filepath.Join(home, ".codex", "sessions")},
 		{Name: "Codex CLI archived", Path: filepath.Join(home, ".codex", "archived_sessions")},
@@ -2059,6 +2084,19 @@ func KnownSessionDirs() []KnownSessionDir {
 		{Name: "Claude Code", Path: filepath.Join(home, ".claude", "projects")},
 		{Name: "Oh My Pi", Path: filepath.Join(home, ".omp", "agent", "sessions")},
 	}
+	dirs = append(dirs, clineKnownSessionDirs(home)...)
+	return dirs
+}
+
+func clineKnownSessionDirs(home string) []KnownSessionDir {
+	configDir, _ := os.UserConfigDir()
+	if configDir == "" {
+		configDir = filepath.Join(home, ".config")
+	}
+	return []KnownSessionDir{{
+		Name: "Cline",
+		Path: filepath.Join(configDir, "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "tasks"),
+	}}
 }
 
 // DiscoverSessionDirs returns all well-known agent session directories found on this machine.
@@ -2087,6 +2125,9 @@ func dirExists(p string) bool {
 
 // collectSessionFiles walks dir and returns all session files.
 func collectSessionFiles(dir string) []string {
+	if isClineTaskDir(dir) {
+		return []string{dir}
+	}
 	type entryInfo struct {
 		path string
 		t    time.Time
@@ -2104,8 +2145,18 @@ func collectSessionFiles(dir string) []string {
 			return
 		}
 		for _, e := range entries {
+			path := filepath.Join(d, e.Name())
 			if e.IsDir() {
-				walk(filepath.Join(d, e.Name()), depth+1)
+				if isClineTaskDir(path) {
+					info, err := e.Info()
+					mt := time.Time{}
+					if err == nil {
+						mt = info.ModTime()
+					}
+					items = append(items, entryInfo{path: path, t: mt})
+					continue
+				}
+				walk(path, depth+1)
 				continue
 			}
 			name := e.Name()
@@ -2117,7 +2168,7 @@ func collectSessionFiles(dir string) []string {
 			if err == nil {
 				mt = info.ModTime()
 			}
-			items = append(items, entryInfo{path: filepath.Join(d, name), t: mt})
+			items = append(items, entryInfo{path: path, t: mt})
 		}
 	}
 	walk(dir, 0)

--- a/internal/engine/parser_cline.go
+++ b/internal/engine/parser_cline.go
@@ -1,0 +1,478 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	clineSourceTool     = "cline"
+	clineAPIHistoryFile = "api_conversation_history.json"
+	clineUIMessagesFile = "ui_messages.json"
+	clineMetadataFile   = "task_metadata.json"
+	clineHistoryFile    = "taskHistory.json"
+)
+
+func isClineTaskDir(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	return fileExists(filepath.Join(path, clineAPIHistoryFile)) ||
+		fileExists(filepath.Join(path, clineUIMessagesFile))
+}
+
+func isClineTaskFile(path string) bool {
+	switch filepath.Base(path) {
+	case clineAPIHistoryFile, clineUIMessagesFile, clineMetadataFile:
+		return true
+	default:
+		return false
+	}
+}
+
+func parseClinePath(path string) ([]Event, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("cline: stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return parseClineTaskDir(path)
+	}
+	if isClineTaskFile(path) {
+		return parseClineTaskDir(filepath.Dir(path))
+	}
+	return parseClineSingleFile(path)
+}
+
+func parseClineTaskDir(dir string) ([]Event, error) {
+	metadata, err := readClineMetadata(dir)
+	if err != nil {
+		return nil, err
+	}
+	model := clineModel(metadata)
+
+	var events []Event
+	seen := make(map[string]bool)
+
+	apiPath := filepath.Join(dir, clineAPIHistoryFile)
+	if raw, ok, err := readClineJSON(apiPath); err != nil {
+		return nil, err
+	} else if ok {
+		for _, ev := range parseClineAPIHistory(raw, model) {
+			appendClineEvent(&events, seen, ev)
+		}
+	}
+
+	uiPath := filepath.Join(dir, clineUIMessagesFile)
+	if raw, ok, err := readClineJSON(uiPath); err != nil {
+		return nil, err
+	} else if ok {
+		for _, ev := range parseClineUIMessages(raw, model) {
+			appendClineEvent(&events, seen, ev)
+		}
+	}
+
+	if len(events) == 0 {
+		return nil, fmt.Errorf("cline: no parseable events in %s", dir)
+	}
+	applyClineMetadataTimestamps(events, metadata)
+	return events, nil
+}
+
+func parseClineSingleFile(path string) ([]Event, error) {
+	raw, ok, err := readClineJSON(path)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, fmt.Errorf("cline: missing %s", path)
+	}
+	var events []Event
+	seen := make(map[string]bool)
+	for _, ev := range parseClineAPIHistory(raw, "unknown") {
+		appendClineEvent(&events, seen, ev)
+	}
+	if len(events) == 0 {
+		for _, ev := range parseClineUIMessages(raw, "unknown") {
+			appendClineEvent(&events, seen, ev)
+		}
+	}
+	if len(events) == 0 {
+		return nil, fmt.Errorf("cline: no parseable events in %s", path)
+	}
+	return events, nil
+}
+
+func readClineMetadata(dir string) (map[string]interface{}, error) {
+	metadata := make(map[string]interface{})
+	if raw, ok, err := readClineJSON(filepath.Join(dir, clineMetadataFile)); err != nil {
+		return nil, err
+	} else if ok {
+		if m, ok := raw.(map[string]interface{}); ok {
+			for k, v := range m {
+				metadata[k] = v
+			}
+		}
+	}
+
+	taskID := firstString(metadata, "taskId", "task_id", "id")
+	for _, historyPath := range clineTaskHistoryCandidates(dir) {
+		raw, ok, err := readClineJSON(historyPath)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		for k, v := range clineTaskHistoryEntry(raw, taskID) {
+			if _, exists := metadata[k]; !exists {
+				metadata[k] = v
+			}
+		}
+	}
+
+	return metadata, nil
+}
+
+func clineTaskHistoryCandidates(dir string) []string {
+	return []string{
+		filepath.Join(dir, clineHistoryFile),
+		filepath.Join(filepath.Dir(dir), clineHistoryFile),
+		filepath.Join(filepath.Dir(filepath.Dir(dir)), clineHistoryFile),
+	}
+}
+
+func clineTaskHistoryEntry(raw interface{}, taskID string) map[string]interface{} {
+	switch v := raw.(type) {
+	case []interface{}:
+		for _, item := range v {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if taskID == "" || firstString(m, "taskId", "task_id", "id") == taskID {
+				return m
+			}
+		}
+	case map[string]interface{}:
+		if tasks, ok := v["tasks"].([]interface{}); ok {
+			return clineTaskHistoryEntry(tasks, taskID)
+		}
+		if taskID == "" || firstString(v, "taskId", "task_id", "id") == taskID {
+			return v
+		}
+	}
+	return nil
+}
+
+func readClineJSON(path string) (interface{}, bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("cline: read %s: %w", filepath.Base(path), err)
+	}
+	var raw interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, true, fmt.Errorf("cline: parse %s: %w", filepath.Base(path), err)
+	}
+	return raw, true, nil
+}
+
+func parseClineAPIHistory(raw interface{}, model string) []Event {
+	var messages []interface{}
+	switch v := raw.(type) {
+	case []interface{}:
+		messages = v
+	case map[string]interface{}:
+		for _, key := range []string{"messages", "conversation", "history"} {
+			if arr, ok := v[key].([]interface{}); ok {
+				messages = arr
+				break
+			}
+		}
+	}
+
+	var events []Event
+	for _, item := range messages {
+		msg, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		role := clineRole(firstString(msg, "role", "speaker", "author"))
+		ts := clineTimestamp(firstPresent(msg, "timestamp", "ts", "createdAt", "created_at"))
+		msgEvents := clineContentEvents(role, ts, model, msg["content"])
+		events = append(events, msgEvents...)
+		if len(msgEvents) == 0 {
+			text := firstString(msg, "text", "message")
+			if role != "" && text != "" {
+				events = append(events, Event{
+					Role:       role,
+					Content:    text,
+					Timestamp:  ts,
+					ModelUsed:  model,
+					SourceTool: clineSourceTool,
+				})
+			}
+		}
+	}
+	return events
+}
+
+func clineContentEvents(role, ts, model string, content interface{}) []Event {
+	var events []Event
+	switch v := content.(type) {
+	case string:
+		if role != "" && v != "" {
+			events = append(events, Event{
+				Role:       role,
+				Content:    v,
+				Timestamp:  ts,
+				ModelUsed:  model,
+				SourceTool: clineSourceTool,
+			})
+		}
+	case []interface{}:
+		for _, item := range v {
+			block, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			typ := firstString(block, "type")
+			switch typ {
+			case "text":
+				text := firstString(block, "text")
+				if role != "" && text != "" {
+					events = append(events, Event{
+						Role:       role,
+						Content:    text,
+						Timestamp:  ts,
+						ModelUsed:  model,
+						SourceTool: clineSourceTool,
+					})
+				}
+			case "thinking":
+				events = append(events, Event{
+					Role:       "assistant",
+					Reasoning:  firstString(block, "thinking", "text"),
+					Timestamp:  ts,
+					ModelUsed:  model,
+					SourceTool: clineSourceTool,
+				})
+			case "tool_use":
+				events = append(events, Event{
+					Role: "assistant",
+					ToolCalls: []ToolCall{{
+						ID:   firstString(block, "id", "tool_use_id"),
+						Name: firstString(block, "name", "tool_name"),
+						Args: jsonish(firstPresent(block, "input", "arguments")),
+					}},
+					Timestamp:  ts,
+					ModelUsed:  model,
+					SourceTool: clineSourceTool,
+				})
+			case "tool_result":
+				isErr, _ := block["is_error"].(bool)
+				events = append(events, Event{
+					Role:       "tool",
+					Content:    extractToolResultContent(block),
+					Timestamp:  ts,
+					ToolCallID: firstString(block, "tool_use_id", "tool_call_id", "id"),
+					IsError:    isErr,
+					ModelUsed:  model,
+					SourceTool: clineSourceTool,
+				})
+			}
+		}
+	}
+	return events
+}
+
+func parseClineUIMessages(raw interface{}, model string) []Event {
+	var messages []interface{}
+	switch v := raw.(type) {
+	case []interface{}:
+		messages = v
+	case map[string]interface{}:
+		if arr, ok := v["messages"].([]interface{}); ok {
+			messages = arr
+		}
+	}
+
+	var events []Event
+	for _, item := range messages {
+		msg, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		text := firstString(msg, "text", "content", "message")
+		if text == "" {
+			continue
+		}
+		ts := clineTimestamp(firstPresent(msg, "ts", "timestamp", "createdAt", "created_at"))
+		kind := firstString(msg, "type")
+		ask := firstString(msg, "ask")
+		say := firstString(msg, "say")
+		role := "assistant"
+		if kind == "ask" || ask != "" {
+			role = "user"
+		}
+		if say == "tool" || ask == "tool" {
+			role = "assistant"
+		}
+		events = append(events, Event{
+			Role:       role,
+			Content:    text,
+			Timestamp:  ts,
+			ModelUsed:  model,
+			SourceTool: clineSourceTool,
+		})
+	}
+	return events
+}
+
+func appendClineEvent(events *[]Event, seen map[string]bool, ev Event) {
+	if ev.SourceTool == "" {
+		ev.SourceTool = clineSourceTool
+	}
+	if ev.ModelUsed == "" {
+		ev.ModelUsed = "unknown"
+	}
+	if ev.Role == "" {
+		return
+	}
+	key := clineEventKey(ev)
+	if seen[key] {
+		return
+	}
+	seen[key] = true
+	*events = append(*events, ev)
+}
+
+func clineEventKey(ev Event) string {
+	var toolParts []string
+	for _, tc := range ev.ToolCalls {
+		toolParts = append(toolParts, tc.ID+":"+tc.Name+":"+tc.Args)
+	}
+	return strings.Join([]string{
+		ev.Role,
+		ev.Content,
+		ev.Timestamp,
+		ev.ToolCallID,
+		strings.Join(toolParts, ","),
+	}, "\x00")
+}
+
+func applyClineMetadataTimestamps(events []Event, metadata map[string]interface{}) {
+	if len(events) == 0 {
+		return
+	}
+	hasTimestamp := false
+	for _, ev := range events {
+		if ev.Timestamp != "" {
+			hasTimestamp = true
+			break
+		}
+	}
+	if hasTimestamp {
+		return
+	}
+	start := clineTimestamp(firstPresent(metadata, "createdAt", "created_at", "ts"))
+	end := clineTimestamp(firstPresent(metadata, "updatedAt", "updated_at", "lastUpdatedAt"))
+	if start != "" {
+		events[0].Timestamp = start
+	}
+	if end != "" {
+		events[len(events)-1].Timestamp = end
+	}
+}
+
+func clineModel(metadata map[string]interface{}) string {
+	if model := firstString(metadata, "model", "modelId", "model_id", "apiModelId"); model != "" {
+		return model
+	}
+	if cfg, ok := metadata["apiConfiguration"].(map[string]interface{}); ok {
+		if model := firstString(cfg, "model", "modelId", "model_id", "apiModelId"); model != "" {
+			return model
+		}
+	}
+	return "unknown"
+}
+
+func clineRole(role string) string {
+	switch strings.ToLower(role) {
+	case "human":
+		return "user"
+	case "ai", "bot":
+		return "assistant"
+	default:
+		return role
+	}
+}
+
+func clineTimestamp(v interface{}) string {
+	switch value := v.(type) {
+	case string:
+		if value == "" {
+			return ""
+		}
+		if _, err := time.Parse(time.RFC3339Nano, strings.ReplaceAll(value, "Z", "+00:00")); err == nil {
+			return value
+		}
+		if n, err := strconv.ParseInt(value, 10, 64); err == nil {
+			return clineUnixTimestamp(n)
+		}
+		return value
+	case float64:
+		return clineUnixTimestamp(int64(value))
+	case json.Number:
+		n, _ := value.Int64()
+		return clineUnixTimestamp(n)
+	default:
+		return ""
+	}
+}
+
+func clineUnixTimestamp(n int64) string {
+	switch {
+	case n > 1_000_000_000_000:
+		return time.UnixMilli(n).UTC().Format(time.RFC3339Nano)
+	case n > 1_000_000_000:
+		return time.Unix(n, 0).UTC().Format(time.RFC3339Nano)
+	default:
+		return ""
+	}
+}
+
+func firstString(m map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := m[key].(string); ok {
+			return value
+		}
+	}
+	return ""
+}
+
+func firstPresent(m map[string]interface{}, keys ...string) interface{} {
+	for _, key := range keys {
+		if value, ok := m[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/internal/engine/parser_cline_test.go
+++ b/internal/engine/parser_cline_test.go
@@ -1,0 +1,121 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseClineTaskHistory(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "cline-task")
+	if got := DetectFormat(path).Format; got != "cline" {
+		t.Fatalf("cline task format: %s", got)
+	}
+
+	events, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var foundTool, foundUI bool
+	for _, ev := range events {
+		if strings.Contains(ev.Content, "Task finished from Cline UI") {
+			foundUI = true
+		}
+		for _, tc := range ev.ToolCalls {
+			if tc.Name == "read_file" && strings.Contains(tc.Args, "go.mod") {
+				foundTool = true
+			}
+		}
+	}
+	if !foundTool {
+		t.Fatalf("expected Cline tool call in events: %+v", events)
+	}
+	if !foundUI {
+		t.Fatalf("expected Cline UI message in events: %+v", events)
+	}
+
+	session, err := LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := session.Metrics
+	if m.SourceTool != "cline" || m.ModelUsed != "claude-3-5-sonnet-latest" {
+		t.Fatalf("bad cline source/model: %+v", m)
+	}
+	if m.UserMessages != 1 || m.AssistantTurns < 3 {
+		t.Fatalf("bad cline role counts: %+v", m)
+	}
+	if m.ToolCallsTotal != 1 || m.ToolCallsOK != 1 || m.ToolUsage["read_file"] != 1 {
+		t.Fatalf("bad cline tool metrics: %+v", m)
+	}
+	if m.SessionStart == "" || m.SessionEnd == "" {
+		t.Fatalf("expected cline timestamps, got %+v", m)
+	}
+}
+
+func TestParseClineTaskMissingOptionalMetadata(t *testing.T) {
+	dir := t.TempDir()
+	raw := `[
+		{"role":"user","content":"hello"},
+		{"role":"assistant","content":[{"type":"text","text":"hi"}]}
+	]`
+	if err := os.WriteFile(filepath.Join(dir, clineAPIHistoryFile), []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := Parse(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events: %+v", events)
+	}
+}
+
+func TestParseClineTaskMalformedJSON(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "cline-broken-task")
+	if got := DetectFormat(path).Format; got != "cline" {
+		t.Fatalf("cline malformed format: %s", got)
+	}
+	_, err := Parse(path)
+	if err == nil {
+		t.Fatal("expected malformed cline task to fail")
+	}
+	if !strings.Contains(err.Error(), clineAPIHistoryFile) {
+		t.Fatalf("expected file-specific cline error, got %v", err)
+	}
+}
+
+func TestFindSessionFilesIncludesClineTaskDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	taskDir := filepath.Join(configDir, "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "tasks", "task-123")
+	if err := os.MkdirAll(taskDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	raw := `[{"role":"user","content":"hello"},{"role":"assistant","content":"hi"}]`
+	if err := os.WriteFile(filepath.Join(taskDir, clineAPIHistoryFile), []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := FindSessionFiles("")
+	if len(files) != 1 || files[0] != taskDir {
+		t.Fatalf("expected cline task dir, got %v", files)
+	}
+	files = FindSessionFiles(taskDir)
+	if len(files) != 1 || files[0] != taskDir {
+		t.Fatalf("expected direct cline task dir, got %v", files)
+	}
+
+	cache := SessionCache{Entries: map[string]CacheEntry{}, Dirs: map[string]DirCacheEntry{}}
+	files = FindSessionFilesCached("", cache)
+	if len(files) != 1 || files[0] != taskDir {
+		t.Fatalf("expected cached cline task dir, got %v", files)
+	}
+}

--- a/testdata/cline-broken-task/api_conversation_history.json
+++ b/testdata/cline-broken-task/api_conversation_history.json
@@ -1,0 +1,1 @@
+{"role":"user","content":"unterminated"

--- a/testdata/cline-task/api_conversation_history.json
+++ b/testdata/cline-task/api_conversation_history.json
@@ -1,0 +1,47 @@
+[
+  {
+    "role": "user",
+    "content": "Add Cline parser support.",
+    "timestamp": "2026-01-01T10:00:00Z"
+  },
+  {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "I will inspect the module file."
+      },
+      {
+        "type": "tool_use",
+        "id": "toolu_01",
+        "name": "read_file",
+        "input": {
+          "path": "go.mod"
+        }
+      }
+    ],
+    "timestamp": "2026-01-01T10:00:05Z"
+  },
+  {
+    "role": "user",
+    "content": [
+      {
+        "type": "tool_result",
+        "tool_use_id": "toolu_01",
+        "content": "module github.com/luoyuctl/agenttrace",
+        "is_error": false
+      }
+    ],
+    "timestamp": "2026-01-01T10:00:06Z"
+  },
+  {
+    "role": "assistant",
+    "content": [
+      {
+        "type": "text",
+        "text": "Parser support is wired."
+      }
+    ],
+    "timestamp": "2026-01-01T10:00:10Z"
+  }
+]

--- a/testdata/cline-task/task_metadata.json
+++ b/testdata/cline-task/task_metadata.json
@@ -1,0 +1,7 @@
+{
+  "taskId": "task-123",
+  "workspace": "/workspace/agenttrace",
+  "modelId": "claude-3-5-sonnet-latest",
+  "createdAt": 1767261600000,
+  "updatedAt": 1767261610000
+}

--- a/testdata/cline-task/ui_messages.json
+++ b/testdata/cline-task/ui_messages.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "say",
+    "say": "text",
+    "text": "Task opened in Cline UI.",
+    "ts": 1767261600000
+  },
+  {
+    "type": "say",
+    "say": "completion_result",
+    "text": "Task finished from Cline UI.",
+    "ts": 1767261610000
+  }
+]


### PR DESCRIPTION
Closes #31

## Summary
- Add Cline task-directory detection and parsing for api_conversation_history.json and ui_messages.json.
- Add bounded local discovery for the documented Cline VS Code globalStorage tasks path.
- Add fixtures and tests for normal Cline tasks, missing optional metadata, malformed JSON, and discovery.
- Update the supported-format README entries to include Cline.

## User value
Cline users can point agenttrace at a local task directory and get a meaningful session summary with conversation turns, tool calls, tool results, timestamps, and model metadata when present.

## Compatibility value
The parser accepts current task-directory shapes while ignoring unknown fields, treats task_metadata.json and taskHistory.json as optional metadata, and returns file-specific parser errors for malformed JSON.

## Scope
- Parser and discovery changes under internal/engine.
- Cline fixtures under testdata.
- README supported-format wording only.

## Test plan
- go test ./...
- go build -o /tmp/agenttrace ./cmd/agenttrace
- /tmp/agenttrace --doctor
- /tmp/agenttrace -f json testdata/cline-task
- /tmp/agenttrace testdata/cline-broken-task, expected clear parser error
- /tmp/agenttrace --demo --overview -f json > /tmp/agenttrace-parser-after.json

## Safety checklist
- [x] Read-only parser changes only.
- [x] No Cline files are modified or repaired.
- [x] No credentials, prompts, sessions, or logs from a real machine are uploaded.
- [x] No new dependencies.
- [x] No protected files, release config, or workflow files changed.