### PR TITLE
[Parser] Track current Gemini CLI chats and checkpoints

### DIFF
--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -195,6 +195,9 @@ func collectSessionFilesCached(dir string, depth, maxDepth int, cache SessionCac
 	for _, e := range entries {
 		path := filepath.Join(dir, e.Name())
 		if e.IsDir() {
+			if isSkippedSessionDir(path) {
+				continue
+			}
 			if isClineTaskDir(path) {
 				files = append(files, path)
 				continue
@@ -204,6 +207,9 @@ func collectSessionFilesCached(dir string, depth, maxDepth int, cache SessionCac
 		}
 		name := e.Name()
 		if !isSessionFileName(name) {
+			continue
+		}
+		if isGeminiTempPath(path) && !isGeminiTempSessionFile(path) {
 			continue
 		}
 		files = append(files, path)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -566,6 +566,9 @@ func detectSingleJSON(doc map[string]interface{}) string {
 	if provider, _ := doc["provider"].(string); provider == "openclaw" {
 		return "openclaw"
 	}
+	if isGeminiWrapper(doc) {
+		return "gemini_cli"
+	}
 
 	// Hermes .json: session_id + messages + model + platform, NO "usage" at top level
 	_, hasSessID := doc["session_id"]
@@ -662,6 +665,9 @@ func detectSingleJSON(doc map[string]interface{}) string {
 func detectJSONArray(arr []interface{}) string {
 	if isCursorGenerationArray(arr) || isCursorPromptArray(arr) {
 		return "cursor"
+	}
+	if isGeminiContentArray(arr) {
+		return "gemini_cli"
 	}
 	if isQwenCodeArray(arr) {
 		return "qwen_code"
@@ -1097,30 +1103,45 @@ func parseGeminiCLI(doc map[string]interface{}, raw string) ([]Event, error) {
 	model := "unknown"
 
 	parseParts := func(role, ts string, parts []interface{}) {
+		role = geminiRole(role)
 		for _, part := range parts {
 			p, ok := part.(map[string]interface{})
 			if !ok {
 				continue
 			}
 			if text, _ := p["text"].(string); text != "" {
-				events = append(events, Event{
-					Role: role, Content: text, Timestamp: ts,
-					ModelUsed: model, SourceTool: "gemini_cli",
-				})
+				if thought, _ := p["thought"].(bool); thought {
+					events = append(events, Event{
+						Role: "assistant", Reasoning: text, Timestamp: ts,
+						ModelUsed: model, SourceTool: "gemini_cli",
+					})
+				} else {
+					events = append(events, Event{
+						Role: role, Content: text, Timestamp: ts,
+						ModelUsed: model, SourceTool: "gemini_cli",
+					})
+				}
 			}
 			if fc, ok := p["functionCall"].(map[string]interface{}); ok {
 				name, _ := fc["name"].(string)
+				if name == "" && jsonish(fc["args"]) == "" {
+					continue
+				}
 				events = append(events, Event{
-					Role: role, Timestamp: ts,
+					Role: "assistant", Timestamp: ts,
 					ToolCalls: []ToolCall{{Name: name, Args: jsonish(fc["args"])}},
 					ModelUsed: model, SourceTool: "gemini_cli",
 				})
 			}
 			if fr, ok := p["functionResponse"].(map[string]interface{}); ok {
 				name, _ := fr["name"].(string)
+				content := jsonish(fr["response"])
+				if name == "" && content == "" {
+					continue
+				}
 				events = append(events, Event{
 					Role:       "tool",
-					Content:    jsonish(fr["response"]),
+					Content:    content,
 					Timestamp:  ts,
 					ToolCallID: name,
 					SourceTool: "gemini_cli",
@@ -1129,28 +1150,53 @@ func parseGeminiCLI(doc map[string]interface{}, raw string) ([]Event, error) {
 		}
 	}
 
-	parseObject := func(obj map[string]interface{}) {
+	parseContent := func(obj map[string]interface{}, fallbackTS string) {
+		role, _ := obj["role"].(string)
+		ts := fallbackTS
+		if tsItem, _ := obj["timestamp"].(string); tsItem != "" {
+			ts = tsItem
+		}
+		parts, _ := obj["parts"].([]interface{})
+		parseParts(role, ts, parts)
+	}
+
+	parseArray := func(arr []interface{}, fallbackTS string) {
+		for _, item := range arr {
+			cItem, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			parseContent(cItem, fallbackTS)
+		}
+	}
+
+	var parseObject func(map[string]interface{})
+	parseObject = func(obj map[string]interface{}) {
 		if mv, ok := obj["modelVersion"].(string); ok && mv != "" {
 			model = mv
 		}
-		if um, ok := obj["usageMetadata"]; ok {
+		if mv, ok := obj["model"].(string); ok && mv != "" {
+			model = mv
+		}
+		if mv, ok := obj["modelId"].(string); ok && mv != "" {
+			model = mv
+		}
+		for _, key := range []string{"usageMetadata", "usage", "tokenUsage"} {
+			um, ok := obj[key]
+			if !ok {
+				continue
+			}
 			ev := Event{Role: "meta", ModelUsed: model, SourceTool: "gemini_cli"}
 			ev.Usage = geminiUsage(um)
 			events = append(events, ev)
 		}
 		ts, _ := obj["timestamp"].(string)
 		if contents, ok := obj["contents"].([]interface{}); ok {
-			for _, item := range contents {
-				cItem, ok := item.(map[string]interface{})
-				if !ok {
-					continue
-				}
-				role, _ := cItem["role"].(string)
-				if tsItem, _ := cItem["timestamp"].(string); tsItem != "" {
-					ts = tsItem
-				}
-				parts, _ := cItem["parts"].([]interface{})
-				parseParts(role, ts, parts)
+			parseArray(contents, ts)
+		}
+		for _, key := range []string{"history", "messages", "conversation", "clientHistory", "chatHistory"} {
+			if arr, ok := obj[key].([]interface{}); ok {
+				parseArray(arr, ts)
 			}
 		}
 		if candidates, ok := obj["candidates"].([]interface{}); ok {
@@ -1166,10 +1212,25 @@ func parseGeminiCLI(doc map[string]interface{}, raw string) ([]Event, error) {
 				}
 			}
 		}
+		if isGeminiContentObject(obj) {
+			parseContent(obj, ts)
+		}
+		for _, key := range []string{"checkpoint", "session", "chat"} {
+			if nested, ok := obj[key].(map[string]interface{}); ok {
+				parseObject(nested)
+			}
+		}
 	}
 
 	if doc != nil {
 		parseObject(doc)
+		if len(events) > 0 {
+			return events, nil
+		}
+	}
+	var arr []interface{}
+	if err := json.Unmarshal([]byte(raw), &arr); err == nil {
+		parseArray(arr, "")
 		if len(events) > 0 {
 			return events, nil
 		}
@@ -1183,6 +1244,9 @@ func parseGeminiCLI(doc map[string]interface{}, raw string) ([]Event, error) {
 		if err := json.Unmarshal([]byte(line), &obj); err == nil {
 			parseObject(obj)
 		}
+	}
+	if len(events) == 0 {
+		return nil, fmt.Errorf("gemini_cli: no parseable events")
 	}
 	return events, nil
 }
@@ -2111,6 +2175,7 @@ func KnownSessionDirs() []KnownSessionDir {
 		{Name: "Codex CLI", Path: filepath.Join(home, ".codex", "sessions")},
 		{Name: "Codex CLI archived", Path: filepath.Join(home, ".codex", "archived_sessions")},
 		{Name: "Gemini CLI", Path: filepath.Join(home, ".gemini", "sessions")},
+		{Name: "Gemini CLI tmp", Path: filepath.Join(home, ".gemini", "tmp")},
 		{Name: "Qwen Code", Path: filepath.Join(home, ".qwen", "projects")},
 		{Name: "Claude Code", Path: filepath.Join(home, ".claude", "projects")},
 		{Name: "Oh My Pi", Path: filepath.Join(home, ".omp", "agent", "sessions")},
@@ -2178,6 +2243,9 @@ func collectSessionFiles(dir string) []string {
 		for _, e := range entries {
 			path := filepath.Join(d, e.Name())
 			if e.IsDir() {
+				if isSkippedSessionDir(path) {
+					continue
+				}
 				if isClineTaskDir(path) {
 					info, err := e.Info()
 					mt := time.Time{}
@@ -2192,6 +2260,9 @@ func collectSessionFiles(dir string) []string {
 			}
 			name := e.Name()
 			if !isSessionFileName(name) {
+				continue
+			}
+			if isGeminiTempPath(path) && !isGeminiTempSessionFile(path) {
 				continue
 			}
 			info, err := e.Info()
@@ -2243,6 +2314,9 @@ func maxSessionDirDepth(dir string) int {
 	if filepath.Base(dir) == "projects" && strings.Contains(filepath.ToSlash(dir), "/.claude/") {
 		return 1
 	}
+	if filepath.Base(dir) == "tmp" && strings.Contains(filepath.ToSlash(dir), "/.gemini/") {
+		return 4
+	}
 	return 4
 }
 
@@ -2280,9 +2354,22 @@ func geminiUsage(raw interface{}) map[string]int {
 		return nil
 	}
 	return map[string]int{
-		"input_tokens":  numberAsInt(m["promptTokenCount"]),
-		"output_tokens": numberAsInt(m["candidatesTokenCount"]),
+		"input_tokens": numberAsInt(firstNumeric(m,
+			"promptTokenCount", "inputTokenCount", "inputTokens", "input_tokens", "prompt_tokens")),
+		"output_tokens": numberAsInt(firstNumeric(m,
+			"candidatesTokenCount", "outputTokenCount", "outputTokens", "output_tokens", "completion_tokens")),
+		"cache_read_input_tokens": numberAsInt(firstNumeric(m,
+			"cachedContentTokenCount", "cacheReadInputTokens", "cache_read_input_tokens")),
 	}
+}
+
+func firstNumeric(m map[string]interface{}, keys ...string) interface{} {
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			return v
+		}
+	}
+	return nil
 }
 
 func numberAsInt(v interface{}) int {

--- a/internal/engine/parser_gemini.go
+++ b/internal/engine/parser_gemini.go
@@ -1,0 +1,81 @@
+package engine
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func isGeminiWrapper(doc map[string]interface{}) bool {
+	if doc == nil {
+		return false
+	}
+	if _, ok := doc["contents"]; ok {
+		return true
+	}
+	if _, ok := doc["candidates"]; ok {
+		return true
+	}
+	for _, key := range []string{"history", "messages", "conversation", "clientHistory", "chatHistory"} {
+		if arr, ok := doc[key].([]interface{}); ok && isGeminiContentArray(arr) {
+			return true
+		}
+	}
+	for _, key := range []string{"checkpoint", "session", "chat"} {
+		if nested, ok := doc[key].(map[string]interface{}); ok && isGeminiWrapper(nested) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGeminiContentArray(arr []interface{}) bool {
+	for _, item := range arr {
+		if m, ok := item.(map[string]interface{}); ok && isGeminiContentObject(m) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGeminiContentObject(obj map[string]interface{}) bool {
+	if _, ok := obj["parts"].([]interface{}); !ok {
+		return false
+	}
+	role, _ := obj["role"].(string)
+	return role == "user" || role == "model" || role == "assistant" || role == "tool"
+}
+
+func isGeminiTempSessionFile(path string) bool {
+	clean := filepath.Clean(path)
+	if !isGeminiTempPath(clean) {
+		return false
+	}
+	parent := filepath.Base(filepath.Dir(clean))
+	return parent == "chats" || parent == "checkpoints"
+}
+
+func isGeminiTempPath(path string) bool {
+	return strings.Contains(filepath.ToSlash(path), "/.gemini/tmp/")
+}
+
+func isSkippedSessionDir(path string) bool {
+	name := filepath.Base(path)
+	if name == ".git" || name == "node_modules" {
+		return true
+	}
+	if isGeminiTempPath(path) && strings.HasPrefix(name, ".") {
+		return true
+	}
+	return false
+}
+
+func geminiRole(role string) string {
+	switch role {
+	case "model", "assistant":
+		return "assistant"
+	case "tool":
+		return "tool"
+	default:
+		return role
+	}
+}

--- a/internal/engine/parser_gemini_test.go
+++ b/internal/engine/parser_gemini_test.go
@@ -1,0 +1,120 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseGeminiCurrentChat(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "gemini-current-chat.json")
+	if got := DetectFormat(path).Format; got != "gemini_cli" {
+		t.Fatalf("gemini chat format: %s", got)
+	}
+	session, err := LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := session.Metrics
+	if m.SourceTool != "gemini_cli" || m.ModelUsed != "gemini-2.5-pro" {
+		t.Fatalf("bad gemini source/model: %+v", m)
+	}
+	if m.UserMessages != 1 || m.AssistantTurns < 1 {
+		t.Fatalf("bad gemini role counts: %+v", m)
+	}
+	if m.ToolCallsTotal != 1 || m.ToolCallsOK != 1 || m.ToolUsage["read_file"] != 1 {
+		t.Fatalf("bad gemini tool metrics: %+v", m)
+	}
+	if m.TokensInput != 120 || m.TokensOutput != 45 || m.TokensCacheR != 8 {
+		t.Fatalf("bad gemini usage: %+v", m)
+	}
+}
+
+func TestParseGeminiCheckpoint(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "gemini-checkpoint.json")
+	if got := DetectFormat(path).Format; got != "gemini_cli" {
+		t.Fatalf("gemini checkpoint format: %s", got)
+	}
+	events, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var foundReasoning bool
+	for _, ev := range events {
+		if strings.Contains(ev.Reasoning, "restore the previous context") {
+			foundReasoning = true
+		}
+	}
+	if !foundReasoning {
+		t.Fatalf("expected gemini checkpoint reasoning: %+v", events)
+	}
+	m := Analyze(events, "gemini-2.5-flash")
+	if m.SourceTool != "gemini_cli" || m.TokensInput != 80 || m.TokensOutput != 20 {
+		t.Fatalf("bad gemini checkpoint metrics: %+v", m)
+	}
+}
+
+func TestParseGeminiMalformedWrapper(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gemini-broken.json")
+	raw := `{"modelVersion":"gemini-2.5-pro","history":[{"role":"model","parts":[{"functionCall":{}}]}]}`
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectFormat(path).Format; got != "gemini_cli" {
+		t.Fatalf("gemini malformed format: %s", got)
+	}
+	if _, err := Parse(path); err == nil {
+		t.Fatal("expected malformed gemini wrapper to fail")
+	}
+}
+
+func TestFindSessionFilesIncludesGeminiTmpChatsAndCheckpoints(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	tmpRoot := filepath.Join(home, ".gemini", "tmp", "repo")
+	chatDir := filepath.Join(tmpRoot, "chats")
+	checkpointDir := filepath.Join(tmpRoot, "checkpoints")
+	shadowGitDir := filepath.Join(tmpRoot, ".git")
+	for _, dir := range []string{chatDir, checkpointDir, shadowGitDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	chatPath := filepath.Join(chatDir, "chat.json")
+	checkpointPath := filepath.Join(checkpointDir, "checkpoint.json")
+	ignoredPath := filepath.Join(shadowGitDir, "ignored.json")
+	raw := `{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`
+	for _, path := range []string{chatPath, checkpointPath, ignoredPath} {
+		if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files := FindSessionFiles("")
+	if !containsPath(files, chatPath) || !containsPath(files, checkpointPath) {
+		t.Fatalf("expected gemini tmp chat/checkpoint files, got %v", files)
+	}
+	if containsPath(files, ignoredPath) {
+		t.Fatalf("expected shadow git file to be skipped, got %v", files)
+	}
+
+	cache := SessionCache{Entries: map[string]CacheEntry{}, Dirs: map[string]DirCacheEntry{}}
+	files = FindSessionFilesCached("", cache)
+	if !containsPath(files, chatPath) || !containsPath(files, checkpointPath) {
+		t.Fatalf("expected cached gemini tmp chat/checkpoint files, got %v", files)
+	}
+	if containsPath(files, ignoredPath) {
+		t.Fatalf("expected cached shadow git file to be skipped, got %v", files)
+	}
+}
+
+func containsPath(paths []string, want string) bool {
+	for _, path := range paths {
+		if path == want {
+			return true
+		}
+	}
+	return false
+}

--- a/testdata/gemini-checkpoint.json
+++ b/testdata/gemini-checkpoint.json
@@ -1,0 +1,33 @@
+{
+  "checkpoint": {
+    "model": "gemini-2.5-flash",
+    "conversation": [
+      {
+        "role": "user",
+        "timestamp": "2026-01-02T10:00:00Z",
+        "parts": [
+          {
+            "text": "Resume this checkpoint."
+          }
+        ]
+      },
+      {
+        "role": "model",
+        "timestamp": "2026-01-02T10:00:04Z",
+        "parts": [
+          {
+            "thought": true,
+            "text": "Need to restore the previous context."
+          },
+          {
+            "text": "Checkpoint resumed."
+          }
+        ]
+      }
+    ],
+    "tokenUsage": {
+      "inputTokens": 80,
+      "outputTokens": 20
+    }
+  }
+}

--- a/testdata/gemini-current-chat.json
+++ b/testdata/gemini-current-chat.json
@@ -1,0 +1,51 @@
+{
+  "modelVersion": "gemini-2.5-pro",
+  "history": [
+    {
+      "role": "user",
+      "timestamp": "2026-01-02T09:00:00Z",
+      "parts": [
+        {
+          "text": "Inspect the parser tests."
+        }
+      ]
+    },
+    {
+      "role": "model",
+      "timestamp": "2026-01-02T09:00:05Z",
+      "parts": [
+        {
+          "text": "I will read the test file."
+        },
+        {
+          "functionCall": {
+            "name": "read_file",
+            "args": {
+              "path": "internal/engine/engine_test.go"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "timestamp": "2026-01-02T09:00:06Z",
+      "parts": [
+        {
+          "functionResponse": {
+            "name": "read_file",
+            "response": {
+              "success": true,
+              "content": "package engine"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 120,
+    "candidatesTokenCount": 45,
+    "cachedContentTokenCount": 8
+  }
+}


### PR DESCRIPTION
Closes #32

## Summary
- Add Gemini chat/checkpoint wrapper detection for current local JSON shapes such as history, conversation, and checkpoint containers.
- Add bounded discovery for ~/.gemini/tmp chat and checkpoint files while skipping shadow Git-style directories.
- Extend Gemini parsing for top-level content arrays, function calls/results, thought text, and token usage aliases.
- Add synthetic fixtures and tests for current chat JSON, checkpoint JSON, malformed wrappers, and tmp discovery.

## User value
Gemini CLI users can inspect current local chat and checkpoint records without manually locating project-scoped temp files or reshaping JSON before import.

## Compatibility value
The adapter keeps existing contents/candidates parsing, accepts wrapper fields used by newer chat/checkpoint records, preserves unknown fields, and returns a clear parser error for unparseable Gemini wrappers.

## Scope
- Parser and discovery changes under internal/engine.
- Gemini fixtures under testdata.
- No README copy changes needed because Gemini CLI is already listed as supported.

## Test plan
- go test ./...
- go build -o /tmp/agenttrace ./cmd/agenttrace
- /tmp/agenttrace --doctor
- /tmp/agenttrace -f json testdata/gemini-current-chat.json
- /tmp/agenttrace -f json testdata/gemini-checkpoint.json
- malformed Gemini wrapper returns expected parser error
- /tmp/agenttrace --demo --overview -f json > /tmp/agenttrace-parser-after.json

## Safety checklist
- [x] Read-only local discovery only.
- [x] Does not restore checkpoints or inspect shadow Git contents.
- [x] No real prompts, sessions, tokens, secrets, or logs uploaded.
- [x] No new dependencies.
- [x] No protected files, release config, or workflow files changed.