### PR TITLE
[Parser] Align OpenCode local storage import

### DIFF
--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -217,6 +217,9 @@ func collectSessionFilesCached(dir string, depth, maxDepth int, cache SessionCac
 		if isGeminiTempPath(path) && !isGeminiTempSessionFile(path) {
 			continue
 		}
+		if isOpenCodeStoragePath(path) && !isOpenCodeStorageSessionFile(path) {
+			continue
+		}
 		files = append(files, path)
 	}
 	sort.Strings(files)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -481,6 +481,9 @@ func DetectFormat(path string) FormatInfo {
 			fi.Doc = doc
 			fi.Raw = data
 			fi.Format = detectSingleJSON(doc)
+			if fi.Format == "unknown" && isOpenCodeStorageSessionDoc(path, doc) {
+				fi.Format = "opencode"
+			}
 			return fi
 		}
 		var arr []interface{}
@@ -724,7 +727,7 @@ func Parse(path string) ([]Event, error) {
 	case "qwen_code":
 		return parseQwenCode(fi.Doc, fi.Arr, string(fi.Raw))
 	case "opencode":
-		return parseOpenCode(fi.Doc)
+		return parseOpenCode(path, fi.Doc)
 	case "openclaw":
 		return parseOpenClaw(fi.Doc)
 	case "copilot_cli":
@@ -1261,12 +1264,6 @@ func parseGeminiCLI(doc map[string]interface{}, raw string) ([]Event, error) {
 		return nil, fmt.Errorf("gemini_cli: no parseable events")
 	}
 	return events, nil
-}
-
-// ── OpenCode ──
-
-func parseOpenCode(doc map[string]interface{}) ([]Event, error) {
-	return parseAnthropicMessageWrapper(doc, "opencode")
 }
 
 // ── OpenClaw ──
@@ -2100,6 +2097,9 @@ func FindSessionFiles(dir string) []string {
 		}
 		return sortFilesByModTime(all)
 	}
+	if isOpenCodeStoragePath(dir) {
+		return collectSessionFiles(dir)
+	}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil
@@ -2192,6 +2192,7 @@ func KnownSessionDirs() []KnownSessionDir {
 		{Name: "Claude Code", Path: filepath.Join(home, ".claude", "projects")},
 		{Name: "Oh My Pi", Path: filepath.Join(home, ".omp", "agent", "sessions")},
 	}
+	dirs = append(dirs, openCodeKnownSessionDirs(home)...)
 	dirs = append(dirs, clineKnownSessionDirs(home)...)
 	return dirs
 }
@@ -2277,6 +2278,9 @@ func collectSessionFiles(dir string) []string {
 			if isGeminiTempPath(path) && !isGeminiTempSessionFile(path) {
 				continue
 			}
+			if isOpenCodeStoragePath(path) && !isOpenCodeStorageSessionFile(path) {
+				continue
+			}
 			info, err := e.Info()
 			mt := time.Time{}
 			if err == nil {
@@ -2328,6 +2332,12 @@ func maxSessionDirDepth(dir string) int {
 	}
 	if filepath.Base(dir) == "tmp" && strings.Contains(filepath.ToSlash(dir), "/.gemini/") {
 		return 4
+	}
+	if isOpenCodeStorageRoot(dir) {
+		return 2
+	}
+	if isOpenCodeStorageSessionRoot(dir) {
+		return 1
 	}
 	return 4
 }

--- a/internal/engine/parser_gemini.go
+++ b/internal/engine/parser_gemini.go
@@ -66,6 +66,9 @@ func isSkippedSessionDir(path string) bool {
 	if isGeminiTempPath(path) && strings.HasPrefix(name, ".") {
 		return true
 	}
+	if isOpenCodeStorageSkippedDir(path) {
+		return true
+	}
 	return false
 }
 

--- a/internal/engine/parser_opencode.go
+++ b/internal/engine/parser_opencode.go
@@ -1,0 +1,413 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type openCodeRecord struct {
+	path string
+	doc  map[string]interface{}
+}
+
+func parseOpenCode(path string, doc map[string]interface{}) ([]Event, error) {
+	if isOpenCodeStorageSessionDoc(path, doc) {
+		return parseOpenCodeStorageSession(path, doc)
+	}
+	return parseAnthropicMessageWrapper(doc, "opencode")
+}
+
+func openCodeKnownSessionDirs(home string) []KnownSessionDir {
+	var dirs []KnownSessionDir
+	seen := make(map[string]bool)
+	add := func(name, path string) {
+		if path == "" || seen[path] {
+			return
+		}
+		seen[path] = true
+		dirs = append(dirs, KnownSessionDir{Name: name, Path: path})
+	}
+
+	if dataHome := os.Getenv("XDG_DATA_HOME"); dataHome != "" {
+		add("OpenCode", filepath.Join(dataHome, "opencode", "storage"))
+	} else {
+		add("OpenCode", filepath.Join(home, ".local", "share", "opencode", "storage"))
+	}
+	add("OpenCode macOS", filepath.Join(home, "Library", "Application Support", "opencode", "storage"))
+	return dirs
+}
+
+func isOpenCodeStoragePath(path string) bool {
+	_, ok := openCodeStorageRel(path)
+	return ok
+}
+
+func isOpenCodeStorageRoot(path string) bool {
+	rel, ok := openCodeStorageRel(path)
+	return ok && rel == ""
+}
+
+func isOpenCodeStorageSessionRoot(path string) bool {
+	rel, ok := openCodeStorageRel(path)
+	return ok && rel == "session"
+}
+
+func isOpenCodeStorageSkippedDir(path string) bool {
+	rel, ok := openCodeStorageRel(path)
+	if !ok || rel == "" {
+		return false
+	}
+	parts := strings.Split(rel, "/")
+	if parts[0] != "session" {
+		return true
+	}
+	return len(parts) > 2
+}
+
+func isOpenCodeStorageSessionFile(path string) bool {
+	rel, ok := openCodeStorageRel(path)
+	if !ok {
+		return false
+	}
+	parts := strings.Split(rel, "/")
+	return len(parts) == 3 && parts[0] == "session" && strings.HasSuffix(parts[2], ".json")
+}
+
+func isOpenCodeStorageSessionDoc(path string, doc map[string]interface{}) bool {
+	if doc == nil || !isOpenCodeStorageSessionFile(path) {
+		return false
+	}
+	return str(doc, "id") != "" && str(doc, "projectID") != ""
+}
+
+func openCodeStorageRel(path string) (string, bool) {
+	clean := filepath.ToSlash(filepath.Clean(path))
+	marker := "/opencode/storage"
+	idx := strings.LastIndex(clean, marker)
+	if idx < 0 {
+		return "", false
+	}
+	start := idx + len(marker)
+	if len(clean) == start {
+		return "", true
+	}
+	if clean[start] != '/' {
+		return "", false
+	}
+	return strings.Trim(clean[start+1:], "/"), true
+}
+
+func parseOpenCodeStorageSession(path string, session map[string]interface{}) ([]Event, error) {
+	sessionID := str(session, "id")
+	if sessionID == "" {
+		return nil, fmt.Errorf("opencode: missing session id")
+	}
+	storageRoot, ok := openCodeStorageRootFromSessionFile(path)
+	if !ok {
+		return nil, fmt.Errorf("opencode: unsupported storage path %s", path)
+	}
+
+	messages, err := readOpenCodeRecords(filepath.Join(storageRoot, "message", sessionID))
+	if err != nil || len(messages) == 0 {
+		return nil, fmt.Errorf("opencode: no messages found for session %s", sessionID)
+	}
+	sortOpenCodeRecords(messages)
+
+	model := openCodeSessionModel(session)
+	usage := make(map[string]int)
+	var body []Event
+	for _, msg := range messages {
+		if msgModel := openCodeMessageModel(msg.doc); msgModel != "" && model == "unknown" {
+			model = msgModel
+		}
+		messageHadUsage := addOpenCodeTokens(usage, msg.doc["tokens"])
+		events, partUsage := parseOpenCodeMessage(storageRoot, msg.doc, model, messageHadUsage)
+		addUsage(usage, partUsage)
+		body = append(body, events...)
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("opencode: no parseable events for session %s", sessionID)
+	}
+
+	var events []Event
+	if model != "unknown" || usageHasValues(usage) {
+		ev := Event{Role: "meta", ModelUsed: model, SourceTool: "opencode"}
+		if usageHasValues(usage) {
+			ev.Usage = usage
+		}
+		events = append(events, ev)
+	}
+	return append(events, body...), nil
+}
+
+func openCodeStorageRootFromSessionFile(path string) (string, bool) {
+	if !isOpenCodeStorageSessionFile(path) {
+		return "", false
+	}
+	return filepath.Dir(filepath.Dir(filepath.Dir(path))), true
+}
+
+func readOpenCodeRecords(dir string) ([]openCodeRecord, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var records []openCodeRecord
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var doc map[string]interface{}
+		if err := json.Unmarshal(data, &doc); err != nil {
+			continue
+		}
+		records = append(records, openCodeRecord{path: path, doc: doc})
+	}
+	return records, nil
+}
+
+func sortOpenCodeRecords(records []openCodeRecord) {
+	sort.SliceStable(records, func(i, j int) bool {
+		ti := openCodeRecordTime(records[i].doc)
+		tj := openCodeRecordTime(records[j].doc)
+		if !ti.IsZero() && !tj.IsZero() && !ti.Equal(tj) {
+			return ti.Before(tj)
+		}
+		return records[i].path < records[j].path
+	})
+}
+
+func parseOpenCodeMessage(storageRoot string, msg map[string]interface{}, model string, messageHadUsage bool) ([]Event, map[string]int) {
+	role := str(msg, "role")
+	ts := openCodeTimeFromMap(msg["time"], "created", "start")
+	msgID := str(msg, "id")
+	parts, _ := readOpenCodeRecords(filepath.Join(storageRoot, "part", msgID))
+	sortOpenCodeRecords(parts)
+
+	var events []Event
+	partUsage := make(map[string]int)
+	for _, record := range parts {
+		part := record.doc
+		partType := str(part, "type")
+		partTS := openCodePartTimestamp(part, ts)
+		switch partType {
+		case "text":
+			text := str(part, "text")
+			if text != "" && (role == "user" || role == "assistant") {
+				events = append(events, Event{
+					Role: role, Content: text, Timestamp: partTS,
+					ModelUsed: model, SourceTool: "opencode",
+				})
+			}
+		case "reasoning":
+			text := str(part, "text")
+			if text != "" {
+				events = append(events, Event{
+					Role: "assistant", Reasoning: text, Timestamp: partTS,
+					ModelUsed: model, SourceTool: "opencode",
+				})
+			}
+		case "tool":
+			events = append(events, openCodeToolEvents(part, partTS, model)...)
+		case "step-finish":
+			if !messageHadUsage {
+				addOpenCodeTokens(partUsage, part["tokens"])
+			}
+		}
+	}
+	if len(parts) == 0 {
+		if text := str(msg, "content"); text != "" && (role == "user" || role == "assistant") {
+			events = append(events, Event{
+				Role: role, Content: text, Timestamp: ts,
+				ModelUsed: model, SourceTool: "opencode",
+			})
+		}
+	}
+	return events, partUsage
+}
+
+func openCodeToolEvents(part map[string]interface{}, ts, model string) []Event {
+	state, _ := part["state"].(map[string]interface{})
+	status := str(state, "status")
+	callID := str(part, "callID")
+	if callID == "" {
+		callID = str(part, "id")
+	}
+	name := str(part, "tool")
+	if name == "" {
+		name = str(part, "name")
+	}
+	input := jsonish(state["input"])
+	callTS := openCodeTimeFromMap(state["time"], "start")
+	if callTS == "" {
+		callTS = ts
+	}
+
+	events := []Event{{
+		Role: "assistant", Timestamp: callTS,
+		ToolCalls: []ToolCall{{ID: callID, Name: name, Args: input}},
+		ModelUsed: model, SourceTool: "opencode",
+	}}
+
+	output := jsonish(state["output"])
+	isErr := status == "error"
+	if output == "" {
+		output = jsonish(state["error"])
+		isErr = isErr || output != ""
+	}
+	if output != "" {
+		resultTS := openCodeTimeFromMap(state["time"], "end")
+		if resultTS == "" {
+			resultTS = callTS
+		}
+		events = append(events, Event{
+			Role: "tool", Content: output, Timestamp: resultTS,
+			ToolCallID: callID, IsError: isErr, SourceTool: "opencode",
+		})
+	}
+	return events
+}
+
+func openCodePartTimestamp(part map[string]interface{}, fallback string) string {
+	if ts := openCodeTimeFromMap(part["time"], "start", "created"); ts != "" {
+		return ts
+	}
+	if state, ok := part["state"].(map[string]interface{}); ok {
+		if ts := openCodeTimeFromMap(state["time"], "start", "created"); ts != "" {
+			return ts
+		}
+	}
+	return fallback
+}
+
+func openCodeRecordTime(doc map[string]interface{}) time.Time {
+	if t := openCodeTimeValue(doc["time"], "start", "created"); !t.IsZero() {
+		return t
+	}
+	if state, ok := doc["state"].(map[string]interface{}); ok {
+		return openCodeTimeValue(state["time"], "start", "created")
+	}
+	return time.Time{}
+}
+
+func openCodeTimeFromMap(raw interface{}, keys ...string) string {
+	t := openCodeTimeValue(raw, keys...)
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func openCodeTimeValue(raw interface{}, keys ...string) time.Time {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return openCodeParseTime(raw)
+	}
+	for _, key := range keys {
+		if t := openCodeParseTime(m[key]); !t.IsZero() {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func openCodeParseTime(raw interface{}) time.Time {
+	switch v := raw.(type) {
+	case float64:
+		return openCodeUnixTime(v)
+	case int64:
+		return openCodeUnixTime(float64(v))
+	case int:
+		return openCodeUnixTime(float64(v))
+	case json.Number:
+		f, _ := v.Float64()
+		return openCodeUnixTime(f)
+	case string:
+		if t := parseTS(v); !t.IsZero() {
+			return t
+		}
+		f, err := strconv.ParseFloat(v, 64)
+		if err == nil {
+			return openCodeUnixTime(f)
+		}
+	}
+	return time.Time{}
+}
+
+func openCodeUnixTime(v float64) time.Time {
+	if v <= 0 {
+		return time.Time{}
+	}
+	if v > 1e12 {
+		return time.UnixMilli(int64(v))
+	}
+	return time.Unix(int64(v), 0)
+}
+
+func openCodeSessionModel(session map[string]interface{}) string {
+	if model, ok := session["model"].(map[string]interface{}); ok {
+		if id := str(model, "id"); id != "" {
+			return id
+		}
+		if id := str(model, "modelID"); id != "" {
+			return id
+		}
+	}
+	return "unknown"
+}
+
+func openCodeMessageModel(msg map[string]interface{}) string {
+	if model := str(msg, "modelID"); model != "" {
+		return model
+	}
+	if model := str(msg, "model"); model != "" {
+		return model
+	}
+	return ""
+}
+
+func addOpenCodeTokens(usage map[string]int, raw interface{}) bool {
+	tokens, ok := raw.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	addUsageValue(usage, "input_tokens", tokens["input"])
+	addUsageValue(usage, "output_tokens", tokens["output"])
+	if cache, ok := tokens["cache"].(map[string]interface{}); ok {
+		addUsageValue(usage, "cache_read_input_tokens", cache["read"])
+		addUsageValue(usage, "cache_creation_input_tokens", cache["write"])
+	}
+	return true
+}
+
+func addUsage(dst, src map[string]int) {
+	for k, v := range src {
+		dst[k] += v
+	}
+}
+
+func addUsageValue(usage map[string]int, key string, raw interface{}) {
+	if n := numberAsInt(raw); n > 0 {
+		usage[key] += n
+	}
+}
+
+func usageHasValues(usage map[string]int) bool {
+	for _, v := range usage {
+		if v > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/parser_opencode_test.go
+++ b/internal/engine/parser_opencode_test.go
@@ -1,0 +1,143 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseOpenCodeWrapperStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "opencode-wrapper.json")
+	raw := `{"provider":"opencode","model":"claude-sonnet-4","messages":[{"role":"user","content":"hi","timestamp":"2026-01-01T00:00:00Z"},{"role":"assistant","content":"hello","timestamp":"2026-01-01T00:00:01Z"}]}`
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectFormat(path).Format; got != "opencode" {
+		t.Fatalf("opencode wrapper format: %s", got)
+	}
+	session, err := LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.Metrics.SourceTool != "opencode" || session.Metrics.UserMessages != 1 || session.Metrics.AssistantTurns != 1 {
+		t.Fatalf("bad opencode wrapper metrics: %+v", session.Metrics)
+	}
+}
+
+func TestParseOpenCodeStorageSession(t *testing.T) {
+	path := filepath.Join("..", "..", "testdata", "opencode", "storage", "session", "project_alpha", "ses_abc.json")
+	if got := DetectFormat(path).Format; got != "opencode" {
+		t.Fatalf("opencode storage format: %s", got)
+	}
+
+	events, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) < 4 {
+		t.Fatalf("expected stitched opencode events, got %+v", events)
+	}
+	var foundUser, foundAssistantText, foundToolCall, foundToolResult bool
+	for _, ev := range events {
+		if ev.Role == "user" && strings.Contains(ev.Content, "parser status") {
+			foundUser = true
+		}
+		if ev.Role == "assistant" && strings.Contains(ev.Content, "inspect the parser") {
+			foundAssistantText = true
+		}
+		if ev.Role == "assistant" && len(ev.ToolCalls) == 1 && ev.ToolCalls[0].Name == "read" {
+			foundToolCall = true
+		}
+		if ev.Role == "tool" && ev.ToolCallID == "call_read" && ev.Content == "engine.go parsed" {
+			foundToolResult = true
+		}
+	}
+	if !foundUser || !foundAssistantText || !foundToolCall || !foundToolResult {
+		t.Fatalf("missing stitched opencode events: %+v", events)
+	}
+
+	session, err := LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := session.Metrics
+	if m.SourceTool != "opencode" || m.ModelUsed != "claude-sonnet-4" {
+		t.Fatalf("bad opencode source/model: %+v", m)
+	}
+	if m.UserMessages != 1 || m.AssistantTurns < 1 {
+		t.Fatalf("bad opencode role counts: %+v", m)
+	}
+	if m.ToolCallsTotal != 1 || m.ToolCallsOK != 1 || m.ToolUsage["read"] != 1 {
+		t.Fatalf("bad opencode tool metrics: %+v", m)
+	}
+	if m.TokensInput != 42 || m.TokensOutput != 17 || m.TokensCacheR != 3 || m.TokensCacheW != 2 {
+		t.Fatalf("bad opencode usage: %+v", m)
+	}
+}
+
+func TestParseOpenCodeStorageSessionMissingMessages(t *testing.T) {
+	dir := t.TempDir()
+	sessionDir := filepath.Join(dir, "opencode", "storage", "session", "project_alpha")
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessionDir, "ses_missing.json")
+	raw := `{"id":"ses_missing","projectID":"project_alpha","time":{"created":1764750000000}}`
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectFormat(path).Format; got != "opencode" {
+		t.Fatalf("opencode malformed format: %s", got)
+	}
+	if _, err := Parse(path); err == nil {
+		t.Fatal("expected missing opencode messages to fail")
+	}
+}
+
+func TestFindSessionFilesIncludesOpenCodeStorageSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "")
+	storage := filepath.Join(home, ".local", "share", "opencode", "storage")
+	sessionDir := filepath.Join(storage, "session", "project_alpha")
+	messageDir := filepath.Join(storage, "message", "ses_abc")
+	partDir := filepath.Join(storage, "part", "msg_user")
+	for _, dir := range []string{sessionDir, messageDir, partDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sessionPath := filepath.Join(sessionDir, "ses_abc.json")
+	messagePath := filepath.Join(messageDir, "msg_user.json")
+	partPath := filepath.Join(partDir, "part_text.json")
+	raw := `{"id":"ses_abc","projectID":"project_alpha","time":{"created":1764750000000}}`
+	for _, path := range []string{sessionPath, messagePath, partPath} {
+		if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files := FindSessionFiles("")
+	if !containsPath(files, sessionPath) {
+		t.Fatalf("expected opencode session file, got %v", files)
+	}
+	if containsPath(files, messagePath) || containsPath(files, partPath) {
+		t.Fatalf("expected only opencode session files, got %v", files)
+	}
+
+	files = FindSessionFiles(storage)
+	if !containsPath(files, sessionPath) || containsPath(files, messagePath) || containsPath(files, partPath) {
+		t.Fatalf("expected bounded custom opencode discovery, got %v", files)
+	}
+
+	cache := SessionCache{Entries: map[string]CacheEntry{}, Dirs: map[string]DirCacheEntry{}}
+	files = FindSessionFilesCached("", cache)
+	if !containsPath(files, sessionPath) {
+		t.Fatalf("expected cached opencode session file, got %v", files)
+	}
+	if containsPath(files, messagePath) || containsPath(files, partPath) {
+		t.Fatalf("expected cached discovery to skip opencode message/part files, got %v", files)
+	}
+}

--- a/testdata/opencode/storage/message/ses_abc/msg_assistant.json
+++ b/testdata/opencode/storage/message/ses_abc/msg_assistant.json
@@ -1,0 +1,25 @@
+{
+  "id": "msg_assistant",
+  "sessionID": "ses_abc",
+  "role": "assistant",
+  "parentID": "msg_user",
+  "modelID": "claude-sonnet-4",
+  "providerID": "anthropic",
+  "agent": "build",
+  "path": {
+    "cwd": "/repo",
+    "root": "/repo"
+  },
+  "time": {
+    "created": 1764750002000,
+    "completed": 1764750004000
+  },
+  "tokens": {
+    "input": 42,
+    "output": 17,
+    "cache": {
+      "read": 3,
+      "write": 2
+    }
+  }
+}

--- a/testdata/opencode/storage/message/ses_abc/msg_user.json
+++ b/testdata/opencode/storage/message/ses_abc/msg_user.json
@@ -1,0 +1,8 @@
+{
+  "id": "msg_user",
+  "sessionID": "ses_abc",
+  "role": "user",
+  "time": {
+    "created": 1764750001000
+  }
+}

--- a/testdata/opencode/storage/part/msg_assistant/part_finish.json
+++ b/testdata/opencode/storage/part/msg_assistant/part_finish.json
@@ -1,0 +1,15 @@
+{
+  "id": "part_finish",
+  "sessionID": "ses_abc",
+  "messageID": "msg_assistant",
+  "type": "step-finish",
+  "cost": 0.001,
+  "tokens": {
+    "input": 42,
+    "output": 17,
+    "cache": {
+      "read": 3,
+      "write": 2
+    }
+  }
+}

--- a/testdata/opencode/storage/part/msg_assistant/part_text.json
+++ b/testdata/opencode/storage/part/msg_assistant/part_text.json
@@ -1,0 +1,11 @@
+{
+  "id": "part_assistant_text",
+  "sessionID": "ses_abc",
+  "messageID": "msg_assistant",
+  "type": "text",
+  "text": "I will inspect the parser files.",
+  "time": {
+    "start": 1764750002000,
+    "end": 1764750002400
+  }
+}

--- a/testdata/opencode/storage/part/msg_assistant/part_tool.json
+++ b/testdata/opencode/storage/part/msg_assistant/part_tool.json
@@ -1,0 +1,20 @@
+{
+  "id": "part_tool",
+  "sessionID": "ses_abc",
+  "messageID": "msg_assistant",
+  "type": "tool",
+  "callID": "call_read",
+  "tool": "read",
+  "state": {
+    "status": "completed",
+    "input": {
+      "path": "internal/engine/engine.go"
+    },
+    "output": "engine.go parsed",
+    "title": "Read file",
+    "time": {
+      "start": 1764750002500,
+      "end": 1764750003000
+    }
+  }
+}

--- a/testdata/opencode/storage/part/msg_user/part_text.json
+++ b/testdata/opencode/storage/part/msg_user/part_text.json
@@ -1,0 +1,11 @@
+{
+  "id": "part_user_text",
+  "sessionID": "ses_abc",
+  "messageID": "msg_user",
+  "type": "text",
+  "text": "show me the parser status",
+  "time": {
+    "start": 1764750001000,
+    "end": 1764750001000
+  }
+}

--- a/testdata/opencode/storage/session/project_alpha/ses_abc.json
+++ b/testdata/opencode/storage/session/project_alpha/ses_abc.json
@@ -1,0 +1,16 @@
+{
+  "id": "ses_abc",
+  "slug": "parser-demo",
+  "projectID": "project_alpha",
+  "directory": "/repo",
+  "title": "Parser demo",
+  "version": "0.4.0",
+  "model": {
+    "id": "claude-sonnet-4",
+    "providerID": "anthropic"
+  },
+  "time": {
+    "created": 1764750000000,
+    "updated": 1764750004000
+  }
+}


### PR DESCRIPTION
Closes #33

## Summary
- add read-only OpenCode storage session detection for `.../opencode/storage/session/<project>/<session>.json`
- stitch session, message, and part JSON records into normalized text, tool, and usage events
- keep discovery bounded to session info files and skip message/part records as standalone sessions
- add fixtures and regression coverage for storage import plus the existing wrapper path

## User value
OpenCode users can inspect current local sessions without manually concatenating records.

## Compatibility value
Existing single-file OpenCode wrapper support stays intact while the parser handles the current split storage layout.

## Scope
- parser discovery and cache filtering only
- OpenCode parser and fixtures only

## Test plan
- `go test ./internal/engine -run OpenCode`
- `go test ./...`
- `go build ./...`

## Safety checklist
- read-only local storage traversal
- no auth or provider credential parsing
- no storage mutation or OpenCode command execution
