### PR TITLE
[Parser] Support OpenCode data dir discovery

### DIFF
--- a/internal/engine/parser_opencode.go
+++ b/internal/engine/parser_opencode.go
@@ -34,6 +34,9 @@ func openCodeKnownSessionDirs(home string) []KnownSessionDir {
 		dirs = append(dirs, KnownSessionDir{Name: name, Path: path})
 	}
 
+	if dataDir := os.Getenv("OPENCODE_DATA_DIR"); dataDir != "" {
+		add("OpenCode", dataDir)
+	}
 	if dataHome := os.Getenv("XDG_DATA_HOME"); dataHome != "" {
 		add("OpenCode", filepath.Join(dataHome, "opencode", "storage"))
 	} else {
@@ -87,6 +90,12 @@ func isOpenCodeStorageSessionDoc(path string, doc map[string]interface{}) bool {
 }
 
 func openCodeStorageRel(path string) (string, bool) {
+	for _, root := range openCodeEnvStorageRoots() {
+		if rel, ok := openCodeRelFromRoot(root, path); ok {
+			return rel, true
+		}
+	}
+
 	clean := filepath.ToSlash(filepath.Clean(path))
 	marker := "/opencode/storage"
 	idx := strings.LastIndex(clean, marker)
@@ -101,6 +110,32 @@ func openCodeStorageRel(path string) (string, bool) {
 		return "", false
 	}
 	return strings.Trim(clean[start+1:], "/"), true
+}
+
+func openCodeEnvStorageRoots() []string {
+	if root := os.Getenv("OPENCODE_DATA_DIR"); root != "" {
+		return []string{root}
+	}
+	return nil
+}
+
+func openCodeRelFromRoot(root, path string) (string, bool) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", false
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(absRoot, absPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return "", false
+	}
+	if rel == "." {
+		return "", true
+	}
+	return filepath.ToSlash(rel), true
 }
 
 func parseOpenCodeStorageSession(path string, session map[string]interface{}) ([]Event, error) {

--- a/internal/engine/parser_opencode_test.go
+++ b/internal/engine/parser_opencode_test.go
@@ -100,6 +100,7 @@ func TestFindSessionFilesIncludesOpenCodeStorageSessions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("OPENCODE_DATA_DIR", "")
 	storage := filepath.Join(home, ".local", "share", "opencode", "storage")
 	sessionDir := filepath.Join(storage, "session", "project_alpha")
 	messageDir := filepath.Join(storage, "message", "ses_abc")
@@ -139,5 +140,37 @@ func TestFindSessionFilesIncludesOpenCodeStorageSessions(t *testing.T) {
 	}
 	if containsPath(files, messagePath) || containsPath(files, partPath) {
 		t.Fatalf("expected cached discovery to skip opencode message/part files, got %v", files)
+	}
+}
+
+func TestFindSessionFilesIncludesOpenCodeDataDir(t *testing.T) {
+	storage := filepath.Join(t.TempDir(), "custom-opencode-storage")
+	t.Setenv("OPENCODE_DATA_DIR", storage)
+	sessionDir := filepath.Join(storage, "session", "project_alpha")
+	messageDir := filepath.Join(storage, "message", "ses_abc")
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(messageDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sessionPath := filepath.Join(sessionDir, "ses_abc.json")
+	messagePath := filepath.Join(messageDir, "msg_user.json")
+	raw := `{"id":"ses_abc","projectID":"project_alpha","time":{"created":1764750000000}}`
+	for _, path := range []string{sessionPath, messagePath} {
+		if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if got := DetectFormat(sessionPath).Format; got != "opencode" {
+		t.Fatalf("opencode data dir format: %s", got)
+	}
+	files := FindSessionFiles("")
+	if !containsPath(files, sessionPath) {
+		t.Fatalf("expected OPENCODE_DATA_DIR session file, got %v", files)
+	}
+	if containsPath(files, messagePath) {
+		t.Fatalf("expected OPENCODE_DATA_DIR discovery to skip message files, got %v", files)
 	}
 }


### PR DESCRIPTION
Follow-up to #53 and #33.

## Summary
- honor `OPENCODE_DATA_DIR` as an OpenCode storage root candidate
- detect `session/<project>/<session>.json` under custom OpenCode data roots
- keep discovery bounded to session info files and skip message/part records as standalone sessions

## User value
Users with a custom OpenCode data directory can still have sessions discovered by doctor and normal session discovery.

## Compatibility value
Default `~/.local/share/opencode/storage` discovery remains unchanged; this only adds the documented environment override.

## Test plan
- `go test ./internal/engine -run OpenCode`
- `go test ./...`
- `go build ./...`

## Safety checklist
- read-only path discovery
- no storage mutation or OpenCode command execution
- no credential parsing
