### PR TITLE
[codex] Fix TUI cost alert baseline

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1531,3 +1531,41 @@ func TestPredictCostAnomaly_Critical(t *testing.T) {
 		t.Errorf("level: %s, triggered: %v", alert.Level, alert.Triggered)
 	}
 }
+
+func TestPredictCostAnomalyEnglishMessageOrdersBaselineAndRatio(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.EN)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	sessions := []Session{
+		{Metrics: Metrics{AssistantTurns: 10, CostEstimated: 0.05}},
+	}
+	current := Session{Metrics: Metrics{AssistantTurns: 10, CostEstimated: 0.25}}
+	alert := PredictCostAnomaly(sessions, current)
+
+	if !strings.Contains(alert.Message, "avg $0.01/turn, 5x") {
+		t.Fatalf("cost alert swapped baseline and ratio: %q", alert.Message)
+	}
+	if strings.Contains(alert.Message, "0x avg $5.00") {
+		t.Fatalf("cost alert kept the old misleading format: %q", alert.Message)
+	}
+}
+
+func TestPredictCostAnomalyLoopWasteMessageShowsAmountsAndPercent(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.EN)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	sessions := []Session{
+		{Metrics: Metrics{AssistantTurns: 10, CostEstimated: 1.00}},
+	}
+	current := Session{
+		Metrics:  Metrics{AssistantTurns: 10, CostEstimated: 1.00},
+		LoopCost: LoopCost{TotalLoopCost: 0.80},
+	}
+	alert := PredictCostAnomaly(sessions, current)
+
+	if !alert.Triggered || !strings.Contains(alert.Message, "$0.8000 of $1.0000 total (80%)") {
+		t.Fatalf("loop waste alert should show loop cost, total cost, and percent: %+v", alert)
+	}
+}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -714,8 +714,8 @@ var translations = map[string]map[Lang]string{
 
 	// ── Cost alert ──
 	"cost_alert_title":    {EN: "🚨 Waste Alert", ZH: "🚨 浪费预警"},
-	"cost_alert_critical": {EN: "This session burned $%.2f/turn (%.0fx avg $%.2f/turn)", ZH: "本会话单轮烧掉 $%.2f（是平均 $%.2f 的 %.0f 倍）"},
-	"cost_alert_warning":  {EN: "Loop waste is %.0f%% of total — consider adding circuit breaker", ZH: "循环浪费占总浪费 %.0f%% — 建议添加熔断机制"},
+	"cost_alert_critical": {EN: "This session burned $%.2f/turn (avg $%.2f/turn, %.0fx)", ZH: "本会话单轮烧掉 $%.2f（平均 $%.2f，%.0f 倍）"},
+	"cost_alert_warning":  {EN: "Loop waste is $%.4f of $%.4f total (%.0f%%) — consider adding circuit breaker", ZH: "循环浪费 $%.4f / 总成本 $%.4f（%.0f%%）— 建议添加熔断机制"},
 
 	// ── Health trend ──
 	"trend_title":      {EN: "Health Trend", ZH: "健康趋势"},
@@ -937,7 +937,7 @@ var translations = map[string]map[Lang]string{
 	"insight_confidence":            {EN: "Confidence: ", ZH: "置信度: "},
 	"diag_for":                      {EN: "Diagnostics for: %s", ZH: "诊断对象: %s"},
 	"diag_simple_loop":              {EN: "⚠ Simple loop detected (cost $%.4f) — see Detail view", ZH: "⚠ 检测到简单循环 (成本 $%.4f) — 查看详情视图"},
-	"diag_score":                    {EN: "Score %d/100", ZH: "评分 %d/100"},
+	"diag_score":                    {EN: "Diagnostic score %d/100", ZH: "诊断评分 %d/100"},
 	"diag_all_clear":                {EN: "All Clear", ZH: "全部正常"},
 	"diag_issues_found":             {EN: "Issues Found", ZH: "发现问题"},
 	"diag_no_latency":               {EN: "No latency data available", ZH: "暂无延迟数据"},

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -676,9 +676,32 @@ func (m *Model) openDiff() {
 
 func (m *Model) prepareDetailState(s engine.Session) {
 	m.fixSuggestions = engine.GenerateFixes(s.Metrics, s.Anomalies)
-	m.costAlert = engine.PredictCostAnomaly(m.sessions, s)
+	m.costAlert = engine.PredictCostAnomaly(costBaselineSessions(m.sessions, s), s)
 	m.loopResult = s.LoopResultData
 	m.toolWarnings = s.ToolWarnings
+}
+
+func costBaselineSessions(sessions []engine.Session, current engine.Session) []engine.Session {
+	history := make([]engine.Session, 0, len(sessions))
+	for _, s := range sessions {
+		if sameSessionIdentity(s, current) {
+			continue
+		}
+		history = append(history, s)
+	}
+	return history
+}
+
+func sameSessionIdentity(a, b engine.Session) bool {
+	if a.Path != "" && b.Path != "" {
+		return a.Path == b.Path
+	}
+	if a.Name == "" && a.Metrics.SessionStart == "" && a.Metrics.SourceTool == "" {
+		return false
+	}
+	return a.Name == b.Name &&
+		a.Metrics.SessionStart == b.Metrics.SessionStart &&
+		a.Metrics.SourceTool == b.Metrics.SourceTool
 }
 
 func (m *Model) refreshDetailViewport() {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -788,6 +788,26 @@ func TestDetailRefreshUpdatesSessionDiagnostics(t *testing.T) {
 	}
 }
 
+func TestPrepareDetailStateExcludesCurrentSessionFromCostBaseline(t *testing.T) {
+	m := sampleModelForTest()
+	m.sessions = []engine.Session{
+		{
+			Name: "current", Path: "/tmp/current.jsonl",
+			Metrics: engine.Metrics{AssistantTurns: 1, CostEstimated: 10.0, SourceTool: "codex_cli", SessionStart: "2026-05-03T00:00:00Z"},
+		},
+		{
+			Name: "history", Path: "/tmp/history.jsonl",
+			Metrics: engine.Metrics{AssistantTurns: 1, CostEstimated: 1.0, SourceTool: "codex_cli", SessionStart: "2026-05-02T00:00:00Z"},
+		},
+	}
+
+	m.prepareDetailState(m.sessions[0])
+
+	if m.costAlert.Baseline != 1.0 {
+		t.Fatalf("cost baseline should exclude current session, got %.2f", m.costAlert.Baseline)
+	}
+}
+
 func TestChineseListUsesTranslatedLabels(t *testing.T) {
 	prev := i18n.Current
 	i18n.SetLang(i18n.ZH)


### PR DESCRIPTION
## Summary
- Fix cost alert copy so average cost and multiplier render in the correct order.
- Exclude the current session from the TUI cost anomaly baseline.
- Rename diagnostics score copy to avoid confusing diagnostic score with health score.

## Issues
- Split out of #62 after #65 identified mixed quality/product scope.

## Validation
- go test ./internal/engine -run 'TestPredictCostAnomaly' -count=1 -v
- go test ./internal/tui -run 'TestPrepareDetailStateExcludesCurrentSessionFromCostBaseline|TestDetailRendersDiagnosticSummary' -count=1 -v
- go test ./... -count=1
- go vet ./...
- go build -o /tmp/agenttrace-cli-tui ./cmd/agenttrace
- Ran demo TUI and verified the critical detail shows avg /bin/zsh.02/turn, 12x.