### PR TITLE
Improve demo fallback and roadmap focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,19 +337,18 @@ Session                   Turns  Tools   Succ     Cost  Health
 
 ## 🗺️ Roadmap
 
-- [x] `curl -sL ... | sh` install script
-- [x] Multi-platform prebuilt binaries (linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64)
-- [x] Homebrew distribution
-- [x] npm wrapper prepared
-- [x] GitHub Actions CI and release pipeline
-- [x] CI health gate thresholds
+**Done**
+
+- [x] Installer paths: curl script, prebuilt binaries, Homebrew, and prepared npm wrapper
+- [x] Release safety: GitHub Actions, release pipeline, and CI health gates
+- [x] Session intelligence: historical trends, cost audit, health gates, and shareable reports
+- [x] Parser coverage: Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes, OpenCode, OpenClaw, Oh My Pi, Kimi, and Copilot-style logs
+
+**Next**
+
 - [ ] Publish npm package
-- [x] Historical trend tracking
-- [ ] Web dashboard (React + Charts)
+- [ ] Web dashboard for report exploration
 - [ ] VS Code extension
-- [x] OpenCode format support
-- [x] Aider chat history support
-- [x] Cursor exported JSON support
 
 See [CI Integration](docs/ci-integration.md) for a ready-to-copy GitHub Actions health gate.
 

--- a/cmd/agenttrace/gate_test.go
+++ b/cmd/agenttrace/gate_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -53,5 +54,30 @@ func TestOverviewGateChineseMessage(t *testing.T) {
 	failures := evaluateOverviewGate(engine.ComputeOverview(sessions), sessions, overviewGate{FailUnderHealth: 80})
 	if len(failures) != 1 || !strings.Contains(failures[0], "平均健康分") {
 		t.Fatalf("expected Chinese gate message, got %v", failures)
+	}
+}
+
+func TestTUILaunchErrorMessageAddsDemoTTYFallback(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.EN)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	msg := tuiLaunchErrorMessage(errors.New("could not open a new TTY: open /dev/tty: device not configured"), true)
+
+	for _, want := range []string{
+		"Error: could not open a new TTY",
+		"agenttrace --demo --overview -f json",
+		"agenttrace --demo --overview -f html -o agenttrace-overview.html",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("TTY fallback message missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestTUILaunchErrorMessageSkipsFallbackOutsideDemo(t *testing.T) {
+	msg := tuiLaunchErrorMessage(errors.New("open /dev/tty: device not configured"), false)
+	if strings.Contains(msg, "--demo --overview") {
+		t.Fatalf("non-demo TUI error should not include demo fallback:\n%s", msg)
 	}
 }

--- a/cmd/agenttrace/main.go
+++ b/cmd/agenttrace/main.go
@@ -140,7 +140,7 @@ func main() {
 		m := tui.New(sessionsDir)
 		p := tea.NewProgram(m, tea.WithAltScreen())
 		if _, err := p.Run(); err != nil {
-			fmt.Fprintf(os.Stderr, i18n.T("cli_error"), err)
+			fmt.Fprint(os.Stderr, tuiLaunchErrorMessage(err, *demo))
 			os.Exit(1)
 		}
 		return
@@ -309,4 +309,22 @@ func main() {
 // to discover sessions from ~/.hermes, ~/.claude, ~/.codex, ~/.gemini simultaneously.
 func resolveDefaultDir() string {
 	return ""
+}
+
+func tuiLaunchErrorMessage(err error, demo bool) string {
+	msg := fmt.Sprintf(i18n.T("cli_error"), err)
+	if demo && isTTYOpenError(err) {
+		msg += i18n.T("cli_demo_tty_hint")
+	}
+	return msg
+}
+
+func isTTYOpenError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "/dev/tty") ||
+		strings.Contains(msg, "not a terminal") ||
+		strings.Contains(msg, "could not open a new tty")
 }

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -1181,6 +1181,7 @@ var translations = map[string]map[Lang]string{
 	"cli_saved":                  {EN: "Saved: %s\n", ZH: "已保存: %s\n"},
 	"cli_no_session_files":       {EN: "No session files found.\n", ZH: "未找到会话文件。\n"},
 	"cli_error_loading":          {EN: "Error loading %s: %v\n", ZH: "加载 %s 时出错: %v\n"},
+	"cli_demo_tty_hint":          {EN: "This shell cannot open an interactive TUI. Try one of these non-interactive demo commands instead:\n  agenttrace --demo --overview -f json\n  agenttrace --demo --overview -f html -o agenttrace-overview.html\n", ZH: "当前 shell 无法打开交互式 TUI。可以改用这些非交互式演示命令：\n  agenttrace --demo --overview -f json\n  agenttrace --demo --overview -f html -o agenttrace-overview.html\n"},
 	"cli_retry_events":           {EN: "Retry Events:       %d", ZH: "重试事件:          %d"},
 	"doctor_title":               {EN: "AGENTTRACE Doctor", ZH: "AGENTTRACE 诊断"},
 	"doctor_mode":                {EN: "Mode", ZH: "模式"},


### PR DESCRIPTION
## Summary
- add a non-TTY demo fallback message with commands that work without an interactive terminal
- keep the README roadmap under ten visible entries by grouping completed foundations and next product bets
- cover the fallback copy with CLI tests

Closes #35
Closes #36

## Validation
- go test ./cmd/agenttrace -count=1
- go test ./... -count=1
- go vet ./...
- go build -o /tmp/agenttrace-onboarding ./cmd/agenttrace
- /tmp/agenttrace-onboarding --demo
- /tmp/agenttrace-onboarding --demo --overview -f json
- /tmp/agenttrace-onboarding --demo --overview -f html -o /tmp/agenttrace-overview.html