### PR TITLE
Keep overview metric labels compact

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2690,14 +2690,26 @@ func (m Model) renderDashboardMetrics(width int) string {
 	if len(m.sessions) == 0 {
 		health = 0
 	}
+	tokenTitle := i18n.T("metric_total_tokens")
+	costTitle := i18n.T("metric_total_cost_usd")
+	errorTitle := i18n.T("metric_error_rate")
+	p95Title := i18n.T("metric_p95_latency")
+	healthTitle := i18n.T("metric_health_score")
+	if cardW < 20 {
+		tokenTitle = i18n.T("metric_tokens")
+		costTitle = i18n.T("metric_cost")
+		errorTitle = i18n.T("metric_errors")
+		p95Title = i18n.T("metric_p95")
+		healthTitle = i18n.T("metric_health")
+	}
 
 	cards := []string{
-		metricCard(i18n.T("metric_total_tokens"), compactInt(totalTokens), i18n.T("metric_live"), cardW, "82"),
-		metricCard(i18n.T("metric_total_cost_usd"), money2(m.costSummary.TotalCost), i18n.T("metric_estimated"), cardW, "82"),
+		metricCard(tokenTitle, compactInt(totalTokens), i18n.T("metric_live"), cardW, "82"),
+		metricCard(costTitle, money2(m.costSummary.TotalCost), i18n.T("metric_estimated"), cardW, "82"),
 		metricCard(i18n.T("metric_sessions"), fmt.Sprintf("%d", len(m.sessions)), i18n.T("metric_loaded"), cardW, "82"),
-		metricCard(i18n.T("metric_error_rate"), fmt.Sprintf("%.2f%%", errorRate), fmt.Sprintf(i18n.T("metric_failed"), toolFail), cardW, "82"),
-		metricCard(i18n.T("metric_p95_latency"), fmt.Sprintf("%.2fs", p95), i18n.T("metric_tool_gaps"), cardW, "39"),
-		metricCard(i18n.T("metric_health_score"), fmt.Sprintf("%d%%", health), healthLabel(health), cardW, "82"),
+		metricCard(errorTitle, fmt.Sprintf("%.2f%%", errorRate), fmt.Sprintf(i18n.T("metric_failed"), toolFail), cardW, "82"),
+		metricCard(p95Title, fmt.Sprintf("%.2fs", p95), i18n.T("metric_tool_gaps"), cardW, "39"),
+		metricCard(healthTitle, fmt.Sprintf("%d%%", health), healthLabel(health), cardW, "82"),
 	}
 
 	if width >= 110 {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1054,6 +1054,24 @@ func TestOverviewShowsTriagePanel(t *testing.T) {
 	}
 }
 
+func TestOverviewUsesShortMetricTitlesAtStandardWidth(t *testing.T) {
+	m := resizeForTest(t, sampleModelForTest(), 120, 36)
+	m.view = viewOverview
+
+	rendered := m.View()
+
+	for _, unwanted := range []string{"TOTAL TOKENS", "TOTAL COST", "(USD)", "ERROR RATE", "P95 LATENCY"} {
+		if strings.Contains(rendered, unwanted) {
+			t.Fatalf("standard overview should avoid wrapped metric title %q:\n%s", unwanted, rendered)
+		}
+	}
+	for _, want := range []string{"TOKENS", "COST", "ERRORS", "P95", "HEALTH"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("standard overview missing short metric title %q:\n%s", want, rendered)
+		}
+	}
+}
+
 func TestChineseOverviewShowsTranslatedActionHint(t *testing.T) {
 	prev := i18n.Current
 	i18n.SetLang(i18n.ZH)


### PR DESCRIPTION
## Summary
- use short metric titles when overview cards are narrow enough to wrap long labels
- keep the 120x36 first screen from splitting `TOTAL COST (USD)` across card lines
- add a regression test for standard terminal overview labels

## Validation
- go test ./internal/tui -run 'TestOverviewUsesShortMetricTitlesAtStandardWidth|TestOverviewShowsTriagePanel|TestViewsRenderWithinTerminalWidth' -count=1 -v
- go test ./... -count=1
- go vet ./...
- go build -o /tmp/agenttrace-metric-labels ./cmd/agenttrace
- stty cols 120 rows 36; /tmp/agenttrace-metric-labels --demo in a PTY, then verified `?`, `! + Enter`, and `w` flows