### PR TITLE
Bump version to 0.3.45

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/luoyuctl/agenttrace/stargazers"><img src="https://img.shields.io/github/stars/luoyuctl/agenttrace?style=social" alt="GitHub stars"></a>
   <img src="https://img.shields.io/badge/go-1.24+-00ADD8.svg" alt="Go">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
-  <img src="https://img.shields.io/badge/Homebrew-v0.3.44-2bbc8a.svg" alt="Homebrew">
+  <img src="https://img.shields.io/badge/Homebrew-v0.3.45-2bbc8a.svg" alt="Homebrew">
 </p>
 
 <h3 align="center">💸 Stop burning cash and hours on invisible AI agent waste</h3>
@@ -253,7 +253,7 @@ See [docs/cursor-import.md](docs/cursor-import.md) for details.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  AGENTTRACE v0.3.44 — AI Agent Session Performance Report
+  AGENTTRACE v0.3.45 — AI Agent Session Performance Report
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 💰 TOKEN COST

--- a/homebrew/Formula/agenttrace.rb
+++ b/homebrew/Formula/agenttrace.rb
@@ -2,7 +2,7 @@ class Agenttrace < Formula
   desc "TUI observability for AI coding agent sessions, cost, latency, and anomalies"
   homepage "https://github.com/luoyuctl/agenttrace"
   url "https://github.com/luoyuctl/agenttrace.git", branch: "master"
-  version "0.3.44"
+  version "0.3.45"
   license "MIT"
 
   depends_on "go" => :build
@@ -12,6 +12,6 @@ class Agenttrace < Formula
   end
 
   test do
-    assert_match "agenttrace v0.3.44", shell_output("#{bin}/agenttrace --version")
+    assert_match "agenttrace v0.3.45", shell_output("#{bin}/agenttrace --version")
   end
 end

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,7 +15,7 @@ import (
 	"github.com/luoyuctl/agenttrace/internal/i18n"
 )
 
-const Version = "0.3.44"
+const Version = "0.3.45"
 
 // Severity constants for anomaly severity (internal, not i18n).
 const (

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agenttrace",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "description": "High-signal TUI observability for AI coding agent sessions, cost, tools, latency, and anomalies",
   "main": "install.js",
   "bin": {

--- a/site/index.html
+++ b/site/index.html
@@ -28,7 +28,7 @@
         "name": "agenttrace",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
-        "softwareVersion": "0.3.44",
+        "softwareVersion": "0.3.45",
         "description": "TUI observability for AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes, OpenCode, Kimi, and Copilot-style logs.",
         "url": "https://luoyuctl.github.io/agenttrace/",
         "codeRepository": "https://github.com/luoyuctl/agenttrace",


### PR DESCRIPTION
## Summary
- bump CLI/version metadata from 0.3.44 to 0.3.45
- align README badge/sample output, npm package version, site metadata, and checked-in Homebrew formula test

## Validation
- go test ./... -count=1
- go vet ./...
- go build -o /tmp/agenttrace-0345 ./cmd/agenttrace && /tmp/agenttrace-0345 --version
- node --check npm/install.js && node --check npm/run.js
- ruby -c homebrew/Formula/agenttrace.rb
- bash -n install.sh && bash -n scripts/record-demo.sh
- npm pack --dry-run