### PR TITLE
Tighten tokscale parity for Claude and OpenCode

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1395,6 +1395,7 @@ func parseClaudeCodeJSONL(raw string) ([]Event, error) {
 	var events []Event
 	sessionID := ""
 	modelName := "unknown"
+	seenUsageSnapshots := make(map[string]bool)
 
 	for _, line := range strings.Split(raw, "\n") {
 		line = strings.TrimSpace(line)
@@ -1460,11 +1461,23 @@ func parseClaudeCodeJSONL(raw string) ([]Event, error) {
 				}
 				// Extract real token counts from API usage
 				if usage, ok := msg["usage"].(map[string]interface{}); ok {
-					ev := Event{Role: "meta", Timestamp: ts,
-						ModelUsed: modelName, SourceTool: "claude_code"}
-					ub, _ := json.Marshal(usage)
-					json.Unmarshal(ub, &ev.Usage)
-					events = append(events, ev)
+					msgID, _ := msg["id"].(string)
+					usageKey := ""
+					if msgID != "" {
+						if ub, err := json.Marshal(usage); err == nil {
+							usageKey = msgID + ":" + string(ub)
+						}
+					}
+					if usageKey == "" || !seenUsageSnapshots[usageKey] {
+						if usageKey != "" {
+							seenUsageSnapshots[usageKey] = true
+						}
+						ev := Event{Role: "meta", Timestamp: ts,
+							ModelUsed: modelName, SourceTool: "claude_code"}
+						ub, _ := json.Marshal(usage)
+						json.Unmarshal(ub, &ev.Usage)
+						events = append(events, ev)
+					}
 				}
 				if content, ok := msg["content"].([]interface{}); ok {
 					for _, blk := range content {
@@ -2295,6 +2308,9 @@ func isSessionFileName(name string) bool {
 	if name == aiderHistoryFile {
 		return true
 	}
+	if strings.HasSuffix(name, ".meta.json") {
+		return false
+	}
 	if strings.HasPrefix(name, "request_dump_") || name == "sessions.json" {
 		return false
 	}
@@ -2457,7 +2473,7 @@ func ScanAllDirs() []Session {
 
 func maxSessionDirDepth(dir string) int {
 	if filepath.Base(dir) == "projects" && strings.Contains(filepath.ToSlash(dir), "/.claude/") {
-		return 1
+		return 3
 	}
 	if filepath.Base(dir) == "tmp" && strings.Contains(filepath.ToSlash(dir), "/.gemini/") {
 		return 4

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -232,6 +232,44 @@ func TestParseClaudeCodeJSONLWithPreamble(t *testing.T) {
 	}
 }
 
+func TestCollectSessionFilesIncludesClaudeSubagents(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".claude", "projects")
+	subagentDir := filepath.Join(root, "project-alpha", "session-abc", "subagents")
+	if err := os.MkdirAll(subagentDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	subagentPath := filepath.Join(subagentDir, "agent-a1.jsonl")
+	if err := os.WriteFile(subagentPath, []byte(`{"type":"assistant","message":{"role":"assistant","model":"claude-haiku-4-5","usage":{"input_tokens":1}}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	metaPath := filepath.Join(subagentDir, "agent-a1.meta.json")
+	if err := os.WriteFile(metaPath, []byte(`{"agentId":"a1"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	files := collectSessionFiles(root)
+	if !containsPath(files, subagentPath) {
+		t.Fatalf("expected claude subagent transcript to be discovered")
+	}
+	if containsPath(files, metaPath) {
+		t.Fatalf("expected claude subagent metadata to be skipped")
+	}
+}
+
+func TestParseClaudeCodeJSONLDeduplicatesAssistantUsage(t *testing.T) {
+	raw := strings.Join([]string{
+		`{"type":"assistant","timestamp":"2026-05-03T10:00:00Z","message":{"id":"msg_1","role":"assistant","model":"claude-sonnet-4-6","usage":{"input_tokens":100,"output_tokens":10},"content":[{"type":"text","text":"hello"}]}}`,
+		`{"type":"assistant","timestamp":"2026-05-03T10:00:01Z","message":{"id":"msg_1","role":"assistant","model":"claude-sonnet-4-6","usage":{"input_tokens":100,"output_tokens":10},"content":[{"type":"tool_use","id":"tool_1","name":"Read","input":{}}]}}`,
+	}, "\n")
+	events, err := parseClaudeCodeJSONL(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := Analyze(events, "claude-sonnet-4-6")
+	if m.TokensInput != 100 || m.TokensOutput != 10 {
+		t.Fatalf("expected duplicate assistant usage to count once: %+v", m)
+	}
+}
+
 func TestParseClaudeCodeJSONLWithPreambleMalformed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "broken-claude.jsonl")

--- a/internal/engine/parser_opencode_test.go
+++ b/internal/engine/parser_opencode_test.go
@@ -96,6 +96,38 @@ func TestParseOpenCodeStorageSessionMissingMessages(t *testing.T) {
 	}
 }
 
+func TestOpenCodeSQLiteMessageTokensUseMessageUsage(t *testing.T) {
+	agg := &sqliteSessionAgg{}
+	doc := map[string]interface{}{
+		"tokens": map[string]interface{}{
+			"input":     float64(100),
+			"output":    float64(20),
+			"reasoning": float64(5),
+			"cache": map[string]interface{}{
+				"read":  float64(7),
+				"write": float64(3),
+			},
+		},
+		"modelID": "glm-5",
+	}
+	if !addOpenCodeSQLiteMessageTokens(agg, doc) {
+		t.Fatal("expected message tokens to be detected")
+	}
+	if agg.inputTokens != 100 || agg.outputTokens != 25 || agg.cacheReadTokens != 7 || agg.cacheWriteToken != 3 {
+		t.Fatalf("bad sqlite message tokens: %+v", agg)
+	}
+	if !agg.usageCostSet || agg.usageCost <= 0 {
+		t.Fatalf("expected sqlite message cost to be tracked: %+v", agg)
+	}
+
+	addOpenCodeStepFinishTokens(agg, map[string]interface{}{
+		"tokens": map[string]interface{}{"input": float64(50), "output": float64(10)},
+	})
+	if agg.inputTokens != 150 || agg.outputTokens != 35 {
+		t.Fatalf("bad step-finish fallback tokens: %+v", agg)
+	}
+}
+
 func TestFindSessionFilesIncludesOpenCodeStorageSessions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/engine/sqlite_sessions.go
+++ b/internal/engine/sqlite_sessions.go
@@ -35,6 +35,9 @@ type sqliteSessionAgg struct {
 	outputTokens    int
 	cacheReadTokens int
 	cacheWriteToken int
+	messageTokens   int
+	usageCost       float64
+	usageCostSet    bool
 	sourceTool      string
 	path            string
 }
@@ -227,6 +230,9 @@ func addOpenCodeSQLiteMessages(db *sql.DB, aggs map[string]*sqliteSessionAgg) {
 		if model := openCodeSQLiteMessageModel(doc); model != "" {
 			agg.model = model
 		}
+		if addOpenCodeSQLiteMessageTokens(agg, doc) {
+			agg.messageTokens++
+		}
 	}
 }
 
@@ -252,7 +258,9 @@ func addOpenCodeSQLiteParts(db *sql.DB, aggs map[string]*sqliteSessionAgg) {
 		}
 		switch str(doc, "type") {
 		case "step-finish":
-			addOpenCodeStepFinishTokens(agg, doc)
+			if agg.messageTokens == 0 {
+				addOpenCodeStepFinishTokens(agg, doc)
+			}
 		case "tool":
 			agg.toolCallsTotal++
 			if openCodeToolFailed(doc) {
@@ -264,18 +272,46 @@ func addOpenCodeSQLiteParts(db *sql.DB, aggs map[string]*sqliteSessionAgg) {
 	}
 }
 
+func addOpenCodeSQLiteMessageTokens(agg *sqliteSessionAgg, doc map[string]interface{}) bool {
+	tokens, ok := doc["tokens"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	input, output, cacheRead, cacheWrite := addOpenCodeTokensFromMap(agg, tokens)
+	model := openCodeSQLiteMessageModel(doc)
+	if model == "" {
+		model = agg.model
+	}
+	if model != "" {
+		agg.usageCost += tokenCostRaw(input, output, cacheWrite, cacheRead, model)
+		agg.usageCostSet = true
+	}
+	return true
+}
+
 func addOpenCodeStepFinishTokens(agg *sqliteSessionAgg, doc map[string]interface{}) {
 	tokens, ok := doc["tokens"].(map[string]interface{})
 	if !ok {
 		return
 	}
+	input, output, cacheRead, cacheWrite := addOpenCodeTokensFromMap(agg, tokens)
+	if agg.model != "" {
+		agg.usageCost += tokenCostRaw(input, output, cacheWrite, cacheRead, agg.model)
+		agg.usageCostSet = true
+	}
+}
+
+func addOpenCodeTokensFromMap(agg *sqliteSessionAgg, tokens map[string]interface{}) (int, int, int, int) {
 	cache, _ := tokens["cache"].(map[string]interface{})
+	input := numberAsInt(tokens["input"])
+	output := numberAsInt(tokens["output"]) + numberAsInt(tokens["reasoning"])
 	cacheRead := numberAsInt(cache["read"])
-	input := max(0, numberAsInt(tokens["input"])-cacheRead)
+	cacheWrite := numberAsInt(cache["write"])
 	agg.inputTokens += input
-	agg.outputTokens += numberAsInt(tokens["output"]) + numberAsInt(tokens["reasoning"])
+	agg.outputTokens += output
 	agg.cacheReadTokens += cacheRead
-	agg.cacheWriteToken += numberAsInt(cache["write"])
+	agg.cacheWriteToken += cacheWrite
+	return input, output, cacheRead, cacheWrite
 }
 
 func openCodeToolFailed(doc map[string]interface{}) bool {
@@ -329,6 +365,10 @@ func sessionFromSQLiteAgg(agg sqliteSessionAgg) Session {
 	if model == "" {
 		model = "default"
 	}
+	costEstimated := estimateTokenCost(agg.inputTokens, agg.outputTokens, agg.cacheWriteToken, agg.cacheReadTokens, model)
+	if agg.usageCostSet {
+		costEstimated = round4(agg.usageCost)
+	}
 	m := Metrics{
 		EventsTotal:    agg.events,
 		UserMessages:   agg.userMessages,
@@ -346,7 +386,7 @@ func sessionFromSQLiteAgg(agg sqliteSessionAgg) Session {
 		SourceTool:     agg.sourceTool,
 		SessionStart:   unixSecondsRFC3339(agg.startUnix),
 		SessionEnd:     unixSecondsRFC3339(agg.endUnix),
-		CostEstimated:  estimateTokenCost(agg.inputTokens, agg.outputTokens, agg.cacheWriteToken, agg.cacheReadTokens, model),
+		CostEstimated:  costEstimated,
 	}
 	if agg.endUnix > agg.startUnix {
 		m.DurationSec = agg.endUnix - agg.startUnix
@@ -366,13 +406,15 @@ func sessionFromSQLiteAgg(agg sqliteSessionAgg) Session {
 }
 
 func estimateTokenCost(input, output, cacheWrite, cacheRead int, model string) float64 {
+	return round4(tokenCostRaw(input, output, cacheWrite, cacheRead, model))
+}
+
+func tokenCostRaw(input, output, cacheWrite, cacheRead int, model string) float64 {
 	pricing := LookupPrice(model)
-	return round4(
-		float64(input)/1e6*pricing.Input +
-			float64(output)/1e6*pricing.Output +
-			float64(cacheWrite)/1e6*pricing.CW +
-			float64(cacheRead)/1e6*pricing.CR,
-	)
+	return float64(input)/1e6*pricing.Input +
+		float64(output)/1e6*pricing.Output +
+		float64(cacheWrite)/1e6*pricing.CW +
+		float64(cacheRead)/1e6*pricing.CR
 }
 
 func unixSecondsRFC3339(v float64) string {


### PR DESCRIPTION
## Summary
- discover Claude subagent transcripts while skipping subagent metadata files
- de-duplicate repeated Claude assistant usage snapshots in JSONL transcripts
- use OpenCode SQLite message-level token usage and per-message model cost, with step-finish fallback

## Verification
- go test ./...
- CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /tmp/agenttrace-parity-final ./cmd/agenttrace
- Real local non-demo comparison: /tmp/agenttrace-overview-parity5.json vs /tmp/tokscale-models-parity5.json
  - agenttrace total cost: 4240.4533
  - tokscale total cost: 4244.9240
  - delta: -4.4707 (-0.1053%)
