### PR TITLE
[Quality] Stabilize overview report ordering

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -234,7 +234,18 @@ func ComputeOverview(sessions []Session) Overview {
 	}
 	// Sort anomalies by severity (high → medium → low)
 	sort.SliceStable(ov.AnomaliesTop, func(i, j int) bool {
-		return anomalySeverityRank(ov.AnomaliesTop[i].Severity) < anomalySeverityRank(ov.AnomaliesTop[j].Severity)
+		a := ov.AnomaliesTop[i]
+		b := ov.AnomaliesTop[j]
+		if ai, bi := anomalySeverityRank(a.Severity), anomalySeverityRank(b.Severity); ai != bi {
+			return ai < bi
+		}
+		if a.Session != b.Session {
+			return a.Session < b.Session
+		}
+		if a.Type != b.Type {
+			return a.Type < b.Type
+		}
+		return a.Age < b.Age
 	})
 	return ov
 }

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1265,6 +1265,66 @@ func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
 	}
 }
 
+func TestReportOverviewFormatsUseCanonicalRecentSessionOrder(t *testing.T) {
+	sessions := []Session{
+		{
+			Name:   "mid",
+			Health: 70,
+			Metrics: Metrics{
+				SessionStart:  "2026-05-02T10:10:00Z",
+				SourceTool:    "codex_cli",
+				ModelUsed:     "gpt-5.1",
+				TokensInput:   20,
+				TokensOutput:  10,
+				CostEstimated: 0.02,
+			},
+		},
+		{
+			Name:   "old",
+			Health: 90,
+			Metrics: Metrics{
+				SessionStart:  "2026-05-02T10:00:00Z",
+				SourceTool:    "aider",
+				ModelUsed:     "gpt-4.1",
+				TokensInput:   10,
+				TokensOutput:  5,
+				CostEstimated: 0.01,
+			},
+		},
+		{
+			Name:   "new",
+			Health: 40,
+			Metrics: Metrics{
+				SessionStart:  "2026-05-02T10:35:00Z",
+				SourceTool:    "gemini_cli",
+				ModelUsed:     "gemini-2.5-pro",
+				TokensInput:   30,
+				TokensOutput:  15,
+				CostEstimated: 0.03,
+			},
+		},
+	}
+	ov := ComputeOverview(sessions)
+
+	var payload struct {
+		RecentSessions []struct {
+			Name string `json:"name"`
+		} `json:"recent_sessions"`
+	}
+	if err := json.Unmarshal([]byte(ReportOverviewJSON(ov, sessions)), &payload); err != nil {
+		t.Fatalf("invalid overview json: %v", err)
+	}
+	if got := []string{payload.RecentSessions[0].Name, payload.RecentSessions[1].Name, payload.RecentSessions[2].Name}; strings.Join(got, ",") != "new,mid,old" {
+		t.Fatalf("json recent sessions should be newest first, got %v", got)
+	}
+
+	md := ReportOverviewMarkdown(ov, sessions)
+	assertOrderedSubstrings(t, md, []string{"| new |", "| mid |", "| old |"})
+
+	html := ReportOverviewHTML(ov, sessions)
+	assertOrderedSubstrings(t, html, []string{">new<", ">mid<", ">old<"})
+}
+
 func TestComputeOverviewSortsAnomaliesBySeverity(t *testing.T) {
 	sessions := []Session{
 		{
@@ -1294,6 +1354,33 @@ func TestComputeOverviewSortsAnomaliesBySeverity(t *testing.T) {
 		if got[i].Session != name {
 			t.Fatalf("anomaly %d should be %q, got %+v", i, name, got)
 		}
+	}
+}
+
+func TestComputeOverviewSortsAnomaliesDeterministicallyWithinSeverity(t *testing.T) {
+	sessions := []Session{
+		{
+			Name:      "z-session",
+			Anomalies: []Anomaly{{Type: "tool_failures", Severity: SeverityHigh}, {Type: "hanging", Severity: SeverityHigh}},
+		},
+		{
+			Name:      "a-session",
+			Anomalies: []Anomaly{{Type: "latency", Severity: SeverityHigh}},
+		},
+		{
+			Name:      "m-session",
+			Anomalies: []Anomaly{{Type: "no_tools", Severity: SeverityLow}},
+		},
+	}
+
+	got := ComputeOverview(sessions).AnomaliesTop
+	want := []string{"a-session:latency", "z-session:hanging", "z-session:tool_failures", "m-session:no_tools"}
+	var names []string
+	for _, item := range got {
+		names = append(names, item.Session+":"+item.Type)
+	}
+	if strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Fatalf("anomalies should have deterministic severity/session/type order, got %v", names)
 	}
 }
 
@@ -1340,6 +1427,21 @@ func TestReportOverviewMarkdownIncludesCISummary(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("markdown report missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func assertOrderedSubstrings(t *testing.T, haystack string, needles []string) {
+	t.Helper()
+	last := -1
+	for _, needle := range needles {
+		idx := strings.Index(haystack, needle)
+		if idx < 0 {
+			t.Fatalf("missing %q in:\n%s", needle, haystack)
+		}
+		if idx <= last {
+			t.Fatalf("%q should appear after previous marker in:\n%s", needle, haystack)
+		}
+		last = idx
 	}
 }
 

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -341,6 +341,7 @@ func ReportCompareJSON(sessions []Session, model string) string {
 
 // ReportOverviewJSON generates machine-readable global overview data.
 func ReportOverviewJSON(ov Overview, sessions []Session) string {
+	orderedSessions := canonicalOverviewSessions(sessions)
 	type groupItem struct {
 		Name     string  `json:"name"`
 		Sessions int     `json:"sessions"`
@@ -367,15 +368,15 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 	totalTools := 0
 	failedTools := 0
 	totalHealth := 0
-	for _, s := range sessions {
+	for _, s := range orderedSessions {
 		totalTokens += s.Metrics.TokensInput + s.Metrics.TokensOutput + s.Metrics.TokensCacheW + s.Metrics.TokensCacheR
 		totalTools += s.Metrics.ToolCallsOK + s.Metrics.ToolCallsFail
 		failedTools += s.Metrics.ToolCallsFail
 		totalHealth += s.Health
 	}
 	avgHealth := 0.0
-	if len(sessions) > 0 {
-		avgHealth = round4(float64(totalHealth) / float64(len(sessions)))
+	if len(orderedSessions) > 0 {
+		avgHealth = round4(float64(totalHealth) / float64(len(orderedSessions)))
 	}
 	toolFailRate := 0.0
 	if totalTools > 0 {
@@ -392,6 +393,9 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 	}
 	sort.Slice(agents, func(i, j int) bool {
 		if agents[i].Sessions == agents[j].Sessions {
+			if agents[i].Cost == agents[j].Cost {
+				return agents[i].Name < agents[j].Name
+			}
 			return agents[i].Cost > agents[j].Cost
 		}
 		return agents[i].Sessions > agents[j].Sessions
@@ -403,17 +407,20 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 	}
 	sort.Slice(models, func(i, j int) bool {
 		if models[i].Cost == models[j].Cost {
+			if models[i].Sessions == models[j].Sessions {
+				return models[i].Name < models[j].Name
+			}
 			return models[i].Sessions > models[j].Sessions
 		}
 		return models[i].Cost > models[j].Cost
 	})
 
-	recentCap := len(sessions)
+	recentCap := len(orderedSessions)
 	if recentCap > 10 {
 		recentCap = 10
 	}
 	recent := make([]recentSession, 0, recentCap)
-	for i, s := range sessions {
+	for i, s := range orderedSessions {
 		if i >= 10 {
 			break
 		}
@@ -433,7 +440,7 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 	if anomalies == nil {
 		anomalies = []AnomalyTop{}
 	}
-	trend := AnalyzeHealthTrend(sessions)
+	trend := AnalyzeHealthTrend(orderedSessions)
 	points := make([]trendPoint, 0, len(trend.Points))
 	for _, p := range trend.Points {
 		points = append(points, trendPoint{Name: p.Name, Health: p.Health, Cost: round4(p.Cost)})
@@ -471,8 +478,9 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 
 // ReportOverviewMarkdown generates a human-readable Markdown overview for PR comments and CI artifacts.
 func ReportOverviewMarkdown(ov Overview, sessions []Session) string {
-	summary := overviewReportSummary(sessions)
-	trend := AnalyzeHealthTrend(sessions)
+	orderedSessions := canonicalOverviewSessions(sessions)
+	summary := overviewReportSummary(orderedSessions)
+	trend := AnalyzeHealthTrend(orderedSessions)
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "# %s\n\n", i18n.T("report_md_title"))
@@ -497,6 +505,9 @@ func ReportOverviewMarkdown(ov Overview, sessions []Session) string {
 	}
 	sort.Slice(agents, func(i, j int) bool {
 		if agents[i].v.Sessions == agents[j].v.Sessions {
+			if agents[i].v.Cost == agents[j].v.Cost {
+				return agents[i].k < agents[j].k
+			}
 			return agents[i].v.Cost > agents[j].v.Cost
 		}
 		return agents[i].v.Sessions > agents[j].v.Sessions
@@ -512,12 +523,12 @@ func ReportOverviewMarkdown(ov Overview, sessions []Session) string {
 	fmt.Fprintf(&b, "\n## %s\n\n", i18n.T("report_recent_sessions"))
 	fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s |\n|---|---|---|---:|---:|---:|\n",
 		i18n.T("report_session"), i18n.T("report_source"), i18n.T("report_model"), i18n.T("report_health"), i18n.T("report_cost"), i18n.T("report_anomalies"))
-	limit := len(sessions)
+	limit := len(orderedSessions)
 	if limit > 10 {
 		limit = 10
 	}
 	for i := 0; i < limit; i++ {
-		s := sessions[i]
+		s := orderedSessions[i]
 		source := s.Metrics.SourceTool
 		if d, ok := ToolDisplayNames[source]; ok {
 			source = d
@@ -550,8 +561,9 @@ func ReportOverviewMarkdown(ov Overview, sessions []Session) string {
 
 // ReportOverviewHTML generates a self-contained HTML report for CI artifacts and sharing.
 func ReportOverviewHTML(ov Overview, sessions []Session) string {
-	summary := overviewReportSummary(sessions)
-	trend := AnalyzeHealthTrend(sessions)
+	orderedSessions := canonicalOverviewSessions(sessions)
+	summary := overviewReportSummary(orderedSessions)
+	trend := AnalyzeHealthTrend(orderedSessions)
 	agents := sortedAgents(ov.ByAgent)
 	models := sortedModels(ov.ByModel)
 
@@ -585,15 +597,15 @@ func ReportOverviewHTML(ov Overview, sessions []Session) string {
 	w(fmt.Sprintf(`<div class="metric"><span>%s</span><strong>$%.2f</strong><p>%s</p></div>`, html.EscapeString(i18n.T("total_cost")), ov.TotalCost, html.EscapeString(i18n.T("report_estimated_cost"))))
 	w(fmt.Sprintf(`<div class="metric %s"><span>%s</span><strong>%d/%d</strong><p>%s</p></div>`, html.EscapeString(failureClass(summary.ToolFailRate)), html.EscapeString(i18n.T("report_tool_failures")), summary.FailedTools, summary.TotalTools, html.EscapeString(fmt.Sprintf(i18n.T("report_failure_rate"), summary.ToolFailRate))))
 	w(`</div>`)
-	if len(sessions) > 1 {
+	if len(orderedSessions) > 1 {
 		w(fmt.Sprintf(`<section><h2>%s</h2><p>%s</p></section>`, html.EscapeString(i18n.T("trend_title")), html.EscapeString(trend.Message)))
 	}
 
 	w(fmt.Sprintf(`<section><h2>%s</h2><table><thead><tr><th>%s</th><th>%s</th><th>%s</th><th class="num">%s</th><th class="num">%s</th><th class="num">%s</th><th class="num">%s</th></tr></thead><tbody>`,
 		html.EscapeString(i18n.T("report_recent_sessions")), html.EscapeString(i18n.T("report_session")), html.EscapeString(i18n.T("report_source")), html.EscapeString(i18n.T("report_model")), html.EscapeString(i18n.T("report_total_tokens")), html.EscapeString(i18n.T("report_cost")), html.EscapeString(i18n.T("report_health")), html.EscapeString(i18n.T("report_anomalies"))))
-	limit := minReportInt(len(sessions), 20)
+	limit := minReportInt(len(orderedSessions), 20)
 	for i := 0; i < limit; i++ {
-		s := sessions[i]
+		s := orderedSessions[i]
 		source := s.Metrics.SourceTool
 		if d, ok := ToolDisplayNames[source]; ok {
 			source = d
@@ -705,6 +717,27 @@ func overviewReportSummary(sessions []Session) overviewSummary {
 	return summary
 }
 
+func canonicalOverviewSessions(sessions []Session) []Session {
+	ordered := append([]Session(nil), sessions...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		ti := parseTS(ordered[i].Metrics.SessionStart)
+		tj := parseTS(ordered[j].Metrics.SessionStart)
+		if !ti.IsZero() || !tj.IsZero() {
+			if ti.IsZero() != tj.IsZero() {
+				return !ti.IsZero()
+			}
+			if !ti.Equal(tj) {
+				return ti.After(tj)
+			}
+		}
+		if ordered[i].Name != ordered[j].Name {
+			return ordered[i].Name < ordered[j].Name
+		}
+		return ordered[i].Path < ordered[j].Path
+	})
+	return ordered
+}
+
 type agentKV struct {
 	k string
 	v AgentOverview
@@ -717,6 +750,9 @@ func sortedAgents(items map[string]AgentOverview) []agentKV {
 	}
 	sort.Slice(agents, func(i, j int) bool {
 		if agents[i].v.Sessions == agents[j].v.Sessions {
+			if agents[i].v.Cost == agents[j].v.Cost {
+				return agents[i].k < agents[j].k
+			}
 			return agents[i].v.Cost > agents[j].v.Cost
 		}
 		return agents[i].v.Sessions > agents[j].v.Sessions
@@ -736,6 +772,9 @@ func sortedModels(items map[string]ModelOverview) []modelKV {
 	}
 	sort.Slice(models, func(i, j int) bool {
 		if models[i].v.Cost == models[j].v.Cost {
+			if models[i].v.Sessions == models[j].v.Sessions {
+				return models[i].k < models[j].k
+			}
 			return models[i].v.Sessions > models[j].v.Sessions
 		}
 		return models[i].v.Cost > models[j].v.Cost


### PR DESCRIPTION
Closes #87

## Summary
- Canonicalize overview recent-session rendering by session start, name, and path before JSON, Markdown, and HTML output.
- Add deterministic tie breakers for overview anomaly ordering within the same severity.
- Keep this branch text-only and avoid carrying the stale demo GIF conflict from the previous PR.

## Reliability rationale
Stable report ordering makes demo output, CI artifacts, README examples, and review snapshots easier to compare because visible differences now map to product changes instead of incidental iteration order.

## Scope
- `internal/engine` overview ordering helpers and anomaly tie breakers.
- Focused report ordering tests for JSON, Markdown, HTML, and anomaly ordering.

## Non-goals
- No metric calculation changes.
- No parser behavior changes.
- No CLI flag changes.
- No report layout redesign.
- No demo GIF refresh.

## Test plan
- `go test ./...`
- `go build -o /tmp/agenttrace ./cmd/agenttrace`
- `/tmp/agenttrace --doctor`
- `/tmp/agenttrace --demo --overview -f json`
- `/tmp/agenttrace --demo --overview -f markdown`
- `/tmp/agenttrace --demo --overview -f html -o /tmp/agenttrace-demo-v2.html`
- Repeated JSON, Markdown, and HTML demo overview runs compared with `cmp`.