### PR TITLE
[Quality] Align overview aggregate metrics

### DIFF
--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -176,6 +176,16 @@ func CachedSession(path string, cache SessionCache) (Session, bool) {
 // listings. It still checks directory mtimes so newly written sessions are
 // picked up incrementally, but unchanged directories do not need ReadDir.
 func FindSessionFilesCached(dir string, cache SessionCache) []string {
+	return findSessionFilesCached(dir, cache, false)
+}
+
+// FindReportableSessionFilesCached 返回与 overview 默认数据源一致的文件列表：
+// SQLite 托管的数据源存在时，跳过对应的旧文件目录。
+func FindReportableSessionFilesCached(dir string, cache SessionCache) []string {
+	return findSessionFilesCached(dir, cache, true)
+}
+
+func findSessionFilesCached(dir string, cache SessionCache, skipSQLiteBacked bool) []string {
 	if cache.Entries == nil {
 		cache.Entries = make(map[string]CacheEntry)
 	}
@@ -199,6 +209,9 @@ func FindSessionFilesCached(dir string, cache SessionCache) []string {
 	seen := make(map[string]bool)
 	var files []string
 	for _, root := range roots {
+		if dir == "" && skipSQLiteBacked && skipSQLiteBackedFileDir(root) {
+			continue
+		}
 		maxDepth := maxSessionDirDepth(root)
 		for _, f := range collectSessionFilesCached(root, 0, maxDepth, cache) {
 			if !seen[f] {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2475,7 +2475,7 @@ func ScanAllDirs() []Session {
 			sessions = append(sessions, *s)
 		}
 	}
-	sessions = append(sessions, loadSQLiteBackedSessions()...)
+	sessions = append(sessions, LoadSQLiteBackedSessions()...)
 	sort.Slice(sessions, func(i, j int) bool {
 		return sessions[i].Metrics.SessionStart > sessions[j].Metrics.SessionStart
 	})

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -907,6 +907,31 @@ func TestFindSessionFilesCachedSkipsDeletedCachedFiles(t *testing.T) {
 	}
 }
 
+func TestFindReportableSessionFilesCachedSkipsSQLiteBackedDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sessionsDir := filepath.Join(home, ".hermes", "sessions")
+	if err := os.MkdirAll(sessionsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	sessionPath := filepath.Join(sessionsDir, "legacy.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".hermes", "state.db"), []byte("sqlite"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rawFiles := FindSessionFilesCached("", SessionCache{Entries: map[string]CacheEntry{}, Dirs: map[string]DirCacheEntry{}})
+	if len(rawFiles) != 1 || rawFiles[0] != sessionPath {
+		t.Fatalf("raw cached discovery should still expose files: %v", rawFiles)
+	}
+	reportable := FindReportableSessionFilesCached("", SessionCache{Entries: map[string]CacheEntry{}, Dirs: map[string]DirCacheEntry{}})
+	if len(reportable) != 0 {
+		t.Fatalf("reportable discovery should skip sqlite-backed file dirs: %v", reportable)
+	}
+}
+
 func TestLoadSessionCacheDefersEntryDecode(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -1197,6 +1222,8 @@ func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
 				ModelUsed:     "claude-sonnet-4",
 				TokensInput:   100,
 				TokensOutput:  50,
+				TokensCacheW:  25,
+				TokensCacheR:  50,
 				ToolCallsOK:   9,
 				ToolCallsFail: 1,
 				CostEstimated: 0.25,
@@ -1253,7 +1280,7 @@ func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
 	if payload.Version != Version || payload.Summary.TotalSessions != 2 || payload.Summary.Critical != 1 {
 		t.Fatalf("bad summary: %+v", payload.Summary)
 	}
-	if payload.Summary.TotalCost != 1 || payload.Summary.TotalTokens != 450 || payload.Summary.ToolFailRate != 25 {
+	if payload.Summary.TotalCost != 1 || payload.Summary.TotalTokens != 525 || payload.Summary.ToolFailRate != 25 {
 		t.Fatalf("missing operational totals: %+v", payload.Summary)
 	}
 	if payload.Summary.HealthTrend.Direction == "" || payload.Summary.HealthTrend.Message == "" || len(payload.Summary.HealthTrend.Points) != 2 {
@@ -1394,6 +1421,8 @@ func TestReportOverviewMarkdownIncludesCISummary(t *testing.T) {
 				ModelUsed:     "gpt-4.1",
 				TokensInput:   1000,
 				TokensOutput:  500,
+				TokensCacheW:  25,
+				TokensCacheR:  50,
 				ToolCallsOK:   4,
 				ToolCallsFail: 1,
 				CostEstimated: 0.12,
@@ -1417,6 +1446,7 @@ func TestReportOverviewMarkdownIncludesCISummary(t *testing.T) {
 	for _, want := range []string{
 		"# agenttrace overview",
 		"| Sessions | 2 |",
+		"| Total tokens | 2075 |",
 		"| Health Trend |",
 		"| Tool failures | 6 / 10 (60.0%) |",
 		"| Aider | 1 |",
@@ -1509,6 +1539,8 @@ func TestReportOverviewHTMLIsShareableAndEscaped(t *testing.T) {
 				ModelUsed:     "gpt-4.1",
 				TokensInput:   1000,
 				TokensOutput:  500,
+				TokensCacheW:  25,
+				TokensCacheR:  50,
 				ToolCallsOK:   4,
 				ToolCallsFail: 1,
 				CostEstimated: 0.12,
@@ -1533,6 +1565,8 @@ func TestReportOverviewHTMLIsShareableAndEscaped(t *testing.T) {
 		"<!doctype html>",
 		"<title>agenttrace overview</title>",
 		"AI agent session overview",
+		"Total tokens",
+		"<strong>2075</strong>",
 		"Tool failures",
 		"Aider",
 		"Cursor",

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -593,6 +593,7 @@ func ReportOverviewHTML(ov Overview, sessions []Session) string {
 	w(`</header>`)
 	w(`<div class="grid" aria-label="summary metrics">`)
 	w(fmt.Sprintf(`<div class="metric"><span>%s</span><strong>%d</strong><p>%d %s / %d %s / %d %s</p></div>`, html.EscapeString(i18n.T("report_sessions")), ov.TotalSessions, ov.Healthy, html.EscapeString(i18n.T("overview_healthy")), ov.Warning, html.EscapeString(i18n.T("overview_warning")), ov.Critical, html.EscapeString(i18n.T("overview_critical"))))
+	w(fmt.Sprintf(`<div class="metric"><span>%s</span><strong>%d</strong><p>%s</p></div>`, html.EscapeString(i18n.T("report_total_tokens")), summary.TotalTokens, html.EscapeString(i18n.T("metric_live"))))
 	w(fmt.Sprintf(`<div class="metric"><span>%s</span><strong>%s</strong><p>%s</p></div>`, html.EscapeString(i18n.T("report_avg_health")), html.EscapeString(fmt.Sprintf("%.1f", summary.AvgHealth)), html.EscapeString(i18n.T("report_fleet_quality"))))
 	w(fmt.Sprintf(`<div class="metric"><span>%s</span><strong>$%.2f</strong><p>%s</p></div>`, html.EscapeString(i18n.T("total_cost")), ov.TotalCost, html.EscapeString(i18n.T("report_estimated_cost"))))
 	w(fmt.Sprintf(`<div class="metric %s"><span>%s</span><strong>%d/%d</strong><p>%s</p></div>`, html.EscapeString(failureClass(summary.ToolFailRate)), html.EscapeString(i18n.T("report_tool_failures")), summary.FailedTools, summary.TotalTools, html.EscapeString(fmt.Sprintf(i18n.T("report_failure_rate"), summary.ToolFailRate))))

--- a/internal/engine/sqlite_sessions.go
+++ b/internal/engine/sqlite_sessions.go
@@ -53,6 +53,11 @@ func loadSQLiteBackedSessions() []Session {
 	return sessions
 }
 
+// LoadSQLiteBackedSessions 返回以本地 SQLite 为权威来源的会话。
+func LoadSQLiteBackedSessions() []Session {
+	return loadSQLiteBackedSessions()
+}
+
 func skipSQLiteBackedFileDir(dir string) bool {
 	home, _ := os.UserHomeDir()
 	if home == "" {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -84,7 +84,8 @@ type loadedSession struct {
 }
 
 type sessionDiscoveryMsg struct {
-	files []string
+	files    []string
+	sessions []loadedSession
 }
 
 // loadProgressMsg 承载一批渐进加载结果。
@@ -293,7 +294,13 @@ func (m *Model) finishLoading() {
 
 func discoverSessionFilesCmd(dir string, cache engine.SessionCache) tea.Cmd {
 	return func() tea.Msg {
-		return sessionDiscoveryMsg{files: engine.FindSessionFilesCached(dir, cache)}
+		msg := sessionDiscoveryMsg{files: engine.FindReportableSessionFilesCached(dir, cache)}
+		if dir == "" {
+			for _, s := range engine.LoadSQLiteBackedSessions() {
+				msg.sessions = append(msg.sessions, loadedSession{session: s})
+			}
+		}
+		return msg
 	}
 }
 
@@ -355,8 +362,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sessionDiscoveryMsg:
 		m.loadQueue = msg.files
-		m.loadTotal = len(msg.files)
-		if m.loadTotal == 0 {
+		m.loadTotal = len(msg.files) + len(msg.sessions)
+		if len(msg.sessions) > 0 {
+			m.appendLoadedSessions(msg.sessions)
+		}
+		if len(msg.files) == 0 {
 			m.finishLoading()
 			return m, nil
 		}
@@ -814,7 +824,7 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 		failStr = dimStyle.Render(failStr)
 	}
 
-	tokensStr := compactInt(met.TokensInput + met.TokensOutput)
+	tokensStr := compactInt(metricsTotalTokens(met))
 	issue := sessionIssueLabel(s)
 	switch len(m.table.Columns()) {
 	case 7:
@@ -1196,7 +1206,7 @@ func (m Model) renderSelectedSessionSummary(width int) string {
 			truncate(s.Name, nameW),
 			i18n.T("health"), clampHealth(s.Health),
 			money4(met.CostEstimated),
-			compactInt(met.TokensInput+met.TokensOutput),
+			compactInt(metricsTotalTokens(met)),
 		)
 		line2 := fmt.Sprintf("%s %d  %s %d/%d %s  %s %s",
 			i18n.T("turns_header"), nonNegativeInt(met.AssistantTurns),
@@ -1213,7 +1223,7 @@ func (m Model) renderSelectedSessionSummary(width int) string {
 		truncate(s.Name, nameW),
 		i18n.T("health"), clampHealth(s.Health),
 		i18n.T("cost"), safeAmount(met.CostEstimated),
-		i18n.T("tokens"), compactInt(met.TokensInput+met.TokensOutput),
+		i18n.T("tokens"), compactInt(metricsTotalTokens(met)),
 	)
 	line2 := fmt.Sprintf("%s %d  %s %d/%d %s  %s %s",
 		i18n.T("turns_header"), nonNegativeInt(met.AssistantTurns),
@@ -2421,7 +2431,7 @@ func (m Model) renderCompactOverview(width int) string {
 }
 
 func (m Model) renderCompactMetricStrip(width int) string {
-	totalTokens := m.costSummary.TotalTokensIn + m.costSummary.TotalTokensOut
+	totalTokens := costSummaryTotalTokens(m.costSummary)
 	toolTotal, toolFail := aggregateToolCounts(m.sessions)
 	errorRate := 0.0
 	if toolTotal > 0 {
@@ -2490,7 +2500,7 @@ func (m Model) renderCompactRecent(width int) string {
 			healthColor(health).Render("●"),
 			nameW,
 			truncate(s.Name, nameW),
-			compactInt(s.Metrics.TokensInput+s.Metrics.TokensOutput),
+			compactInt(sessionTotalTokens(s)),
 			health,
 		)
 		lines = append(lines, truncate(line, width))
@@ -2539,7 +2549,7 @@ func anomalyRateStyle(rate float64) lipgloss.Style {
 }
 
 func (m Model) renderDashboardHero(width int) string {
-	totalTokens := m.costSummary.TotalTokensIn + m.costSummary.TotalTokensOut
+	totalTokens := costSummaryTotalTokens(m.costSummary)
 	toolTotal, toolFail := aggregateToolCounts(m.sessions)
 	errRate := 0.0
 	if toolTotal > 0 {
@@ -2677,7 +2687,7 @@ func (m Model) overviewActionMessage() string {
 func (m Model) renderDashboardMetrics(width int) string {
 	if width < 70 {
 		cardW := width
-		totalTokens := m.costSummary.TotalTokensIn + m.costSummary.TotalTokensOut
+		totalTokens := costSummaryTotalTokens(m.costSummary)
 		toolTotal, toolFail := aggregateToolCounts(m.sessions)
 		errorRate := 0.0
 		if toolTotal > 0 {
@@ -2702,7 +2712,7 @@ func (m Model) renderDashboardMetrics(width int) string {
 	if cardW < 16 {
 		cardW = (width - 4) / 3
 	}
-	totalTokens := m.costSummary.TotalTokensIn + m.costSummary.TotalTokensOut
+	totalTokens := costSummaryTotalTokens(m.costSummary)
 	toolTotal, toolFail := aggregateToolCounts(m.sessions)
 	errorRate := 0.0
 	if toolTotal > 0 {
@@ -2756,7 +2766,7 @@ func (m Model) renderTokenUsagePanel(width int) string {
 	values := recentTokenSeries(m.sessions, 36)
 	innerW := dashboardInnerWidth(width)
 	chart := miniBarChart(values, innerW, 8, []string{"34", "82"})
-	total := compactInt(m.costSummary.TotalTokensIn + m.costSummary.TotalTokensOut)
+	total := compactInt(costSummaryTotalTokens(m.costSummary))
 	legend := greenStyle.Render(i18n.T("legend_input")) + "  " + brandStyle.Render(i18n.T("legend_output")) + "  " + dimStyle.Render(i18n.T("legend_cache"))
 	content := chart + "\n" + legend
 	return dashboardPanel(i18n.T("panel_token_usage"), brandStyle.Render(fmt.Sprintf(i18n.T("metric_total"), total)), content, width)
@@ -2926,7 +2936,7 @@ func (m Model) renderTopAgentsPanel(width int) string {
 	var items []item
 	bySource := map[string]int{}
 	for _, s := range m.sessions {
-		bySource[s.Metrics.SourceTool] += nonNegativeInt(s.Metrics.TokensInput + s.Metrics.TokensOutput)
+		bySource[s.Metrics.SourceTool] += nonNegativeInt(sessionTotalTokens(s))
 	}
 	for k, v := range bySource {
 		name := k
@@ -2976,7 +2986,7 @@ func (m Model) renderRecentSessionsPanel(width int) string {
 			status = orangeStyle.Render("●")
 		}
 		name := truncate(s.Name, nameW)
-		tokens := compactInt(s.Metrics.TokensInput + s.Metrics.TokensOutput)
+		tokens := compactInt(sessionTotalTokens(s))
 		lines = append(lines, fmt.Sprintf("%s %-*s %6s %3d%%",
 			status,
 			nameW,
@@ -3013,6 +3023,18 @@ func aggregateToolCounts(sessions []engine.Session) (total, failed int) {
 	return total, failed
 }
 
+func costSummaryTotalTokens(cs engine.CostSummary) int {
+	return cs.TotalTokensIn + cs.TotalTokensOut + cs.TotalCacheRead + cs.TotalCacheWrite
+}
+
+func sessionTotalTokens(s engine.Session) int {
+	return metricsTotalTokens(s.Metrics)
+}
+
+func metricsTotalTokens(m engine.Metrics) int {
+	return m.TokensInput + m.TokensOutput + m.TokensCacheW + m.TokensCacheR
+}
+
 func aggregateP95Latency(sessions []engine.Session) float64 {
 	var vals []float64
 	for _, s := range sessions {
@@ -3036,7 +3058,7 @@ func recentTokenSeries(sessions []engine.Session, n int) []float64 {
 	limit := minInt(n, len(sessions))
 	for i := 0; i < limit; i++ {
 		s := sessions[limit-1-i]
-		vals[n-limit+i] = chartValue(float64(s.Metrics.TokensInput + s.Metrics.TokensOutput + s.Metrics.TokensCacheR))
+		vals[n-limit+i] = chartValue(float64(sessionTotalTokens(s)))
 	}
 	return vals
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"database/sql"
 	"fmt"
 	"math"
 	"os"
@@ -14,6 +15,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/luoyuctl/agenttrace/internal/engine"
 	"github.com/luoyuctl/agenttrace/internal/i18n"
+	_ "modernc.org/sqlite"
 )
 
 func sampleModelForTest() Model {
@@ -546,7 +548,7 @@ func TestCompactListKeepsTokensAndHealthReadable(t *testing.T) {
 	if row[2] != "1" || row[3] != "0" {
 		t.Fatalf("expected compact triage signals, got row=%v", row)
 	}
-	if row[5] != "154.0K" {
+	if row[5] != "214.0K" {
 		t.Fatalf("expected full compact token value, got %q", row[5])
 	}
 	if row[6] != "92%" {
@@ -1107,6 +1109,20 @@ func TestOverviewUsesShortMetricTitlesAtStandardWidth(t *testing.T) {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("standard overview missing short metric title %q:\n%s", want, rendered)
 		}
+	}
+}
+
+func TestOverviewAggregateTokensIncludeCacheTokens(t *testing.T) {
+	m := resizeForTest(t, sampleModelForTest(), 120, 36)
+	m.view = viewOverview
+
+	rendered := m.View()
+
+	if !strings.Contains(rendered, "767.0K") {
+		t.Fatalf("overview aggregate token total should include cache tokens like exports:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "597.0K") {
+		t.Fatalf("overview should not use input+output-only token total:\n%s", rendered)
 	}
 }
 
@@ -2135,6 +2151,82 @@ func TestStartReloadDiscoversThenLoadsCachedSessions(t *testing.T) {
 	if m.loadedFromCache != 1 || len(m.loadQueue) != 1 {
 		t.Fatalf("bad cache load state: fromCache=%d queue=%d", m.loadedFromCache, len(m.loadQueue))
 	}
+}
+
+func TestDefaultDiscoveryUsesReportableSQLiteBackedSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	sessionsDir := filepath.Join(home, ".hermes", "sessions")
+	if err := os.MkdirAll(sessionsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sessionsDir, "legacy.jsonl"), []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(home, ".hermes", "state.db")
+	if err := writeHermesStateDBForTest(dbPath); err != nil {
+		t.Fatal(err)
+	}
+
+	m := resizeForTest(t, New(""), 100, 30)
+	m.sessionCache = engine.SessionCache{Entries: map[string]engine.CacheEntry{}, Dirs: map[string]engine.DirCacheEntry{}}
+	msg, ok := m.startReload()().(sessionDiscoveryMsg)
+	if !ok {
+		t.Fatalf("expected discovery message")
+	}
+	if len(msg.files) != 0 {
+		t.Fatalf("default TUI discovery should skip sqlite-backed legacy files: %v", msg.files)
+	}
+	if len(msg.sessions) != 1 || msg.sessions[0].session.Metrics.SourceTool != "hermes_db" {
+		t.Fatalf("expected one sqlite-backed Hermes session, got %+v", msg.sessions)
+	}
+
+	next, cmd := m.Update(msg)
+	if cmd != nil {
+		t.Fatalf("sqlite-only discovery should finish without file load command")
+	}
+	m = next.(Model)
+	if len(m.sessions) != 1 || m.overview.TotalSessions != 1 {
+		t.Fatalf("TUI aggregate should use same sqlite-backed source as overview: sessions=%d ov=%+v", len(m.sessions), m.overview)
+	}
+	if got := engine.ComputeOverview(engine.ScanAllDirs()).TotalSessions; got != m.overview.TotalSessions {
+		t.Fatalf("TUI and overview discovery disagreed: tui=%d overview=%d", m.overview.TotalSessions, got)
+	}
+}
+
+func writeHermesStateDBForTest(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	if _, err := db.Exec(`create table sessions (
+		id text primary key,
+		model text,
+		started_at real,
+		ended_at real,
+		message_count integer,
+		tool_call_count integer,
+		input_tokens integer,
+		output_tokens integer,
+		cache_read_tokens integer,
+		cache_write_tokens integer
+	)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`create table messages (session_id text, role text)`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`insert into sessions values ('db-session', 'gpt-5.1', 1760000000, 1760000060, 2, 1, 1000, 200, 50, 25)`); err != nil {
+		return err
+	}
+	_, err = db.Exec(`insert into messages values ('db-session', 'user'), ('db-session', 'assistant')`)
+	return err
 }
 
 func TestStartLoadMessageKeepsReloadedModelState(t *testing.T) {


### PR DESCRIPTION
## Summary
- Align default TUI discovery with overview exports by skipping SQLite-backed legacy file directories and loading SQLite-backed sessions directly.
- Use cache read/write tokens in TUI aggregate token totals so they match JSON/Markdown/HTML overview semantics.
- Add total-token summary to HTML overview and regression coverage for SQLite-backed discovery and cache-token aggregates.

Closes #107

## Test plan
- go test ./...
- go build -o /tmp/agenttrace-quality-107 ./cmd/agenttrace
- /tmp/agenttrace-quality-107 --doctor || true
- /tmp/agenttrace-quality-107 --demo --overview -f json
- /tmp/agenttrace-quality-107 --overview -f json | jq ' .summary | {total_sessions,total_tokens,total_cost,avg_health,critical,tool_fail_rate}'