### PR TITLE
[Growth] Keep release, install, and public metadata in sync

### DIFF
--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -215,6 +215,16 @@ go build -o /tmp/agenttrace ./cmd/agenttrace
 /tmp/agenttrace --demo --overview -f json
 ```
 
+## Release Consistency Checklist
+
+Before sharing a release publicly, compare these surfaces against `gh release list --repo luoyuctl/agenttrace --limit 1`:
+
+- README release and Homebrew badges point at the latest version.
+- `homebrew/Formula/agenttrace.rb`, `homebrew/README.md`, `npm/package.json`, and `npm/README.md` match the current install story.
+- `site/index.html` JSON-LD `softwareVersion`, `site/demo-report.html`, `site/llms.txt`, `site/robots.txt`, and `site/sitemap.xml` remain present and version-consistent where they mention a release.
+- GitHub Discussions, release notes, and launch copy do not point readers at stale release links.
+- Public CTAs use neutral product actions such as `Get agenttrace`, `Install`, or `Latest release`.
+
 Install smoke:
 
 ```bash

--- a/npm/README.md
+++ b/npm/README.md
@@ -33,7 +33,7 @@ From this directory:
 node --check install.js
 node --check run.js
 AGENTTRACE_BIN=/path/to/agenttrace node run.js --version
-AGENTTRACE_RELEASE_TAG=v0.3.41 node install.js
+AGENTTRACE_RELEASE_TAG=v0.3.48 node install.js
 npm pack --dry-run
 ```
 

--- a/site/demo-report.html
+++ b/site/demo-report.html
@@ -18,7 +18,7 @@ section{border:1px solid var(--line);background:rgba(16,20,25,.78);padding:20px;
 <main>
 <header>
 <div><div class="brand">agenttrace</div><h1>AI agent session overview</h1><p>Static report generated from local coding-agent traces.</p></div>
-<div class="meta">v0.3.9<br>3 sessions<br><code>agenttrace --overview -f html</code></div>
+<div class="meta">v0.3.48<br>3 sessions<br><code>agenttrace --overview -f html</code></div>
 </header>
 <div class="grid" aria-label="summary metrics">
 <div class="metric"><span>Sessions</span><strong>3</strong><p>1 healthy / 1 warning / 1 critical</p></div>
@@ -51,4 +51,3 @@ section{border:1px solid var(--line);background:rgba(16,20,25,.78);padding:20px;
 </main>
 </body>
 </html>
-

--- a/site/index.html
+++ b/site/index.html
@@ -53,7 +53,7 @@
         <a href="#install">Install</a>
         <a href="#ci">CI</a>
         <a href="https://github.com/luoyuctl/agenttrace/discussions/2">Feedback</a>
-        <a class="nav-cta" href="https://github.com/luoyuctl/agenttrace">Star on GitHub</a>
+        <a class="nav-cta" href="#install">Get agenttrace</a>
       </nav>
     </header>
 


### PR DESCRIPTION
Closes #112

## Summary

- Replace the public site nav CTA with `Get agenttrace`.
- Sync the static sample report metadata to `v0.3.48`.
- Update the npm maintainer smoke-check release tag to `v0.3.48`.
- Add a release consistency checklist covering README badges, Homebrew, npm, site metadata, launch copy, and discussions.

## User-facing value

Users evaluating install freshness now see a more coherent release and install story across the website, sample report, npm wrapper docs, and launch checklist.

## Adoption rationale

Release metadata drift makes a project feel stale even when the binaries and docs are current. This keeps the public onboarding path aligned with the latest shipped release and gives maintainers a checklist to catch drift before sharing a release.

## Scope

- Changed only docs/site/npm public metadata surfaces.
- No Go source, parser, quality logic, workflow, license, privacy, or security files changed.
- No release, tag, or external community posting performed.

## Test plan

- `git diff --check`
- `markdownlint README.md docs/**/*.md || true` (local command missing: `markdownlint`)
- `go test ./... || true`
- `go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace || true`
- `/tmp/agenttrace-growth-check --doctor || true`
- Checked site SEO metadata remains present: title, description, canonical, OG/Twitter tags, JSON-LD, robots, sitemap, and llms.txt.
- Checked public copy for disallowed wording from the growth rules.

## Safety checklist

- [x] Linked Issue exists.
- [x] Branch was created from `origin/master` and pushed before edits.
- [x] No same-Issue open PR or remote `growth/112-*` branch existed before claiming.
- [x] Latest release remains `v0.3.48`.
- [x] README/Homebrew/npm/site version references touched by this issue are aligned to `v0.3.48`.
- [x] Public CTA uses a neutral product action.
- [x] No tag, release, merge, or external post was created.
