### PR TITLE
[Quality] Clamp loop waste to session cost

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -156,6 +156,47 @@ type LoopCost struct {
 	LoopGroups      int     `json:"loop_groups"`
 }
 
+func ClampLoopWaste(loopCost, totalCost float64) float64 {
+	if math.IsNaN(loopCost) || math.IsInf(loopCost, 0) || loopCost < 0 {
+		loopCost = 0
+	}
+	if math.IsNaN(totalCost) || math.IsInf(totalCost, 0) || totalCost <= 0 {
+		return 0
+	}
+	if loopCost > totalCost {
+		return totalCost
+	}
+	return loopCost
+}
+
+func LoopWastePercent(loopCost, totalCost float64) float64 {
+	if math.IsNaN(totalCost) || math.IsInf(totalCost, 0) || totalCost <= 0 {
+		return 0
+	}
+	return ClampLoopWaste(loopCost, totalCost) / totalCost * 100
+}
+
+func ClampLoopCostToTotal(lc LoopCost, totalCost float64) LoopCost {
+	lc.RetryCost = ClampLoopWaste(lc.RetryCost, totalCost)
+	lc.ToolLoopCost = ClampLoopWaste(lc.ToolLoopCost, totalCost)
+	lc.FormatRetryCost = ClampLoopWaste(lc.FormatRetryCost, totalCost)
+	lc.TotalLoopCost = ClampLoopWaste(lc.TotalLoopCost, totalCost)
+	componentTotal := lc.RetryCost + lc.ToolLoopCost + lc.FormatRetryCost
+	if lc.TotalLoopCost == 0 || componentTotal == 0 || componentTotal <= lc.TotalLoopCost {
+		return lc
+	}
+	scale := lc.TotalLoopCost / componentTotal
+	lc.RetryCost *= scale
+	lc.ToolLoopCost *= scale
+	lc.FormatRetryCost *= scale
+	return lc
+}
+
+func ClampLoopResultToTotal(lr LoopResult, totalCost float64) LoopResult {
+	lr.LoopCost = ClampLoopWaste(lr.LoopCost, totalCost)
+	return lr
+}
+
 // ── Global Overview ──
 
 // AgentOverview holds per-agent aggregate stats.
@@ -2104,7 +2145,8 @@ func LoadSession(path string) (*Session, error) {
 	m := Analyze(events, model)
 	a := DetectAnomalies(m)
 	h := HealthScore(m, a)
-	loopResult := AnalyzeLoops(events)
+	loopResult := ClampLoopResultToTotal(AnalyzeLoops(events), m.CostEstimated)
+	loopCost := ClampLoopCostToTotal(ComputeLoopCost(events), m.CostEstimated)
 
 	// v0.2: community-driven diagnostics
 	loops := DetectFingerprintLoops(events)
@@ -2121,7 +2163,7 @@ func LoadSession(path string) (*Session, error) {
 		Metrics:            m,
 		Anomalies:          a,
 		Health:             h,
-		LoopCost:           ComputeLoopCost(events),
+		LoopCost:           loopCost,
 		LoopFingerprints:   loops,
 		ToolLatencies:      latencies,
 		ContextUtil:        ctxUtil,
@@ -2166,6 +2208,8 @@ func LocalizeSession(s Session) Session {
 			tw.Detail = detail
 		}
 	}
+	s.LoopCost = ClampLoopCostToTotal(s.LoopCost, s.Metrics.CostEstimated)
+	s.LoopResultData = ClampLoopResultToTotal(s.LoopResultData, s.Metrics.CostEstimated)
 	return s
 }
 
@@ -2971,7 +3015,7 @@ func PredictCostAnomaly(sessions []Session, current Session) CostAlert {
 	for _, s := range sessions {
 		if s.Metrics.AssistantTurns > 0 {
 			totalCostTurn += s.Metrics.CostEstimated / float64(s.Metrics.AssistantTurns)
-			totalLoopTurn += s.LoopCost.TotalLoopCost / float64(s.Metrics.AssistantTurns)
+			totalLoopTurn += ClampLoopWaste(s.LoopCost.TotalLoopCost, s.Metrics.CostEstimated) / float64(s.Metrics.AssistantTurns)
 			count++
 		}
 	}
@@ -2989,7 +3033,7 @@ func PredictCostAnomaly(sessions []Session, current Session) CostAlert {
 
 	var curLoopTurn float64
 	if current.Metrics.AssistantTurns > 0 {
-		curLoopTurn = current.LoopCost.TotalLoopCost / float64(current.Metrics.AssistantTurns)
+		curLoopTurn = ClampLoopWaste(current.LoopCost.TotalLoopCost, current.Metrics.CostEstimated) / float64(current.Metrics.AssistantTurns)
 	}
 
 	alert := CostAlert{
@@ -3010,14 +3054,14 @@ func PredictCostAnomaly(sessions []Session, current Session) CostAlert {
 		alert.Triggered = true
 		alert.Level = "warning"
 		alert.Message = fmt.Sprintf(i18n.T("cost_alert_critical"), curCostTurn, avgCostTurn, alert.Ratio)
-	} else if current.Metrics.CostEstimated > 0 && current.LoopCost.TotalLoopCost/current.Metrics.CostEstimated > 0.50 {
+	} else if loopPercent := LoopWastePercent(current.LoopCost.TotalLoopCost, current.Metrics.CostEstimated); loopPercent > 50 {
 		alert.Triggered = true
 		alert.Level = "critical"
-		alert.Message = fmt.Sprintf(i18n.T("cost_alert_warning"), current.LoopCost.TotalLoopCost, current.Metrics.CostEstimated, current.LoopCost.TotalLoopCost/current.Metrics.CostEstimated*100)
-	} else if current.Metrics.CostEstimated > 0 && current.LoopCost.TotalLoopCost/current.Metrics.CostEstimated > 0.30 {
+		alert.Message = fmt.Sprintf(i18n.T("cost_alert_warning"), ClampLoopWaste(current.LoopCost.TotalLoopCost, current.Metrics.CostEstimated), current.Metrics.CostEstimated, loopPercent)
+	} else if loopPercent := LoopWastePercent(current.LoopCost.TotalLoopCost, current.Metrics.CostEstimated); loopPercent > 30 {
 		alert.Triggered = true
 		alert.Level = "warning"
-		alert.Message = fmt.Sprintf(i18n.T("cost_alert_warning"), current.LoopCost.TotalLoopCost, current.Metrics.CostEstimated, current.LoopCost.TotalLoopCost/current.Metrics.CostEstimated*100)
+		alert.Message = fmt.Sprintf(i18n.T("cost_alert_warning"), ClampLoopWaste(current.LoopCost.TotalLoopCost, current.Metrics.CostEstimated), current.Metrics.CostEstimated, loopPercent)
 	} else {
 		alert.Triggered = false
 		alert.Level = "info"
@@ -3629,10 +3673,8 @@ func ComputeWasteReport(m Metrics, events []Event, loopResult LoopResult) WasteR
 	wr.Cache = AnalyzeCacheEfficiency(m)
 	wr.Bloat = AnalyzeToolBloat(m)
 	wr.Stuck = DetectStuckPatterns(events)
-	wr.LoopCost = loopResult.LoopCost
-	if m.CostEstimated > 0 {
-		wr.LoopPercent = wr.LoopCost / m.CostEstimated * 100
-	}
+	wr.LoopCost = ClampLoopWaste(loopResult.LoopCost, m.CostEstimated)
+	wr.LoopPercent = LoopWastePercent(loopResult.LoopCost, m.CostEstimated)
 	wr.TotalWasted = wr.Cache.WastedCost + wr.LoopCost
 	if wr.Bloat.BloatScore > 50 {
 		wr.TotalWasted += m.CostEstimated * 0.15
@@ -3732,10 +3774,8 @@ func ComputeWasteReportFromSession(s *Session) WasteReport {
 		// Fallback to simple stuck detection from metrics
 		wr.Stuck = detectStuckFromMetrics(s.Metrics)
 	}
-	wr.LoopCost = s.LoopCost.TotalLoopCost
-	if s.Metrics.CostEstimated > 0 {
-		wr.LoopPercent = wr.LoopCost / s.Metrics.CostEstimated * 100
-	}
+	wr.LoopCost = ClampLoopWaste(s.LoopCost.TotalLoopCost, s.Metrics.CostEstimated)
+	wr.LoopPercent = LoopWastePercent(s.LoopCost.TotalLoopCost, s.Metrics.CostEstimated)
 	wr.TotalWasted = wr.Cache.WastedCost + wr.LoopCost
 	if wr.Bloat.BloatScore > 50 {
 		wr.TotalWasted += s.Metrics.CostEstimated * 0.05

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1854,3 +1854,41 @@ func TestPredictCostAnomalyLoopWasteMessageShowsAmountsAndPercent(t *testing.T) 
 		t.Fatalf("loop waste alert should show loop cost, total cost, and percent: %+v", alert)
 	}
 }
+
+func TestPredictCostAnomalyClampsLoopWasteToTotal(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.EN)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	sessions := []Session{
+		{Metrics: Metrics{AssistantTurns: 1, CostEstimated: 0.0008}},
+	}
+	current := Session{
+		Metrics:  Metrics{AssistantTurns: 1, CostEstimated: 0.0008},
+		LoopCost: LoopCost{TotalLoopCost: 0.0750},
+	}
+	alert := PredictCostAnomaly(sessions, current)
+
+	if !alert.Triggered || !strings.Contains(alert.Message, "$0.0008 of $0.0008 total (100%)") {
+		t.Fatalf("loop waste alert should clamp loop cost to total: %+v", alert)
+	}
+	if strings.Contains(alert.Message, "$0.0750") || strings.Contains(alert.Message, "9375%") {
+		t.Fatalf("loop waste alert kept impossible cost relationship: %q", alert.Message)
+	}
+}
+
+func TestWasteReportClampsLoopWasteToTotal(t *testing.T) {
+	s := Session{
+		Metrics:  Metrics{CostEstimated: 0.0008},
+		LoopCost: LoopCost{ToolLoopCost: 0.0450, RetryCost: 0.0300, TotalLoopCost: 0.0750},
+	}
+
+	report := ComputeWasteReportFromSession(&s)
+
+	if report.LoopCost != 0.0008 || report.LoopPercent != 100 {
+		t.Fatalf("waste report should clamp loop waste to total, got cost=%f percent=%f", report.LoopCost, report.LoopPercent)
+	}
+	if report.TotalWasted > s.Metrics.CostEstimated {
+		t.Fatalf("total wasted should not exceed total cost for loop-only waste: got %.4f total %.4f", report.TotalWasted, s.Metrics.CostEstimated)
+	}
+}

--- a/internal/tui/insights.go
+++ b/internal/tui/insights.go
@@ -46,8 +46,9 @@ func buildSessionInsight(s engine.Session, fixes []engine.FixSuggestion, alert e
 		}
 	}
 	if s.LoopCost.TotalLoopCost > 0 {
+		loopCost := engine.ClampLoopWaste(s.LoopCost.TotalLoopCost, met.CostEstimated)
 		ins.Issue = i18n.T("insight_loop_cost")
-		ins.Impact = fmt.Sprintf(i18n.T("insight_loop_impact"), safeAmount(s.LoopCost.TotalLoopCost), safeAmount(met.CostEstimated))
+		ins.Impact = fmt.Sprintf(i18n.T("insight_loop_impact"), loopCost, safeAmount(met.CostEstimated))
 		ins.Evidence = fmt.Sprintf(i18n.T("insight_loop_evidence"), s.LoopCost.RetryEvents, s.LoopCost.LoopGroups)
 		ins.Confidence = i18n.T("insight_high")
 		ins.Color = lipgloss.Color("196")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1550,6 +1550,10 @@ func (m Model) renderLoopAnalysis() string {
 	}
 	lr := m.loopResult
 	if lr.HasLoop {
+		loopCost := safeAmount(lr.LoopCost)
+		if idx := m.findSessionIndex(); idx >= 0 && idx < len(m.sessions) {
+			loopCost = engine.ClampLoopWaste(loopCost, m.sessions[idx].Metrics.CostEstimated)
+		}
 		loopCard := lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color("196")).
@@ -1561,7 +1565,7 @@ func (m Model) renderLoopAnalysis() string {
 			lr.Turns,
 			i18n.T("loop_turns"),
 			i18n.T("loop_cost"),
-			lr.LoopCost)
+			loopCost)
 		return loopCard.Render(content)
 	}
 	loopCard := lipgloss.NewStyle().
@@ -1716,7 +1720,7 @@ func (m Model) renderWaste() string {
 func (m Model) renderFingerprintLoops(s engine.Session) string {
 	if len(s.LoopFingerprints) == 0 {
 		if s.LoopCost.TotalLoopCost > 0 {
-			return yellowStyle.Render(fmt.Sprintf(i18n.T("diag_simple_loop"), s.LoopCost.TotalLoopCost))
+			return yellowStyle.Render(fmt.Sprintf(i18n.T("diag_simple_loop"), engine.ClampLoopWaste(s.LoopCost.TotalLoopCost, s.Metrics.CostEstimated)))
 		}
 		return greenStyle.Render(i18n.T("diag_no_loop_fp"))
 	}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1839,6 +1839,68 @@ func TestDetailRendersDiagnosticSummary(t *testing.T) {
 	}
 }
 
+func TestDetailInsightClampsLoopWasteToTotal(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.EN)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	s := engine.Session{
+		Metrics:  engine.Metrics{CostEstimated: 0.0008},
+		LoopCost: engine.LoopCost{RetryEvents: 4, LoopGroups: 1, TotalLoopCost: 0.0750},
+	}
+
+	ins := buildSessionInsight(s, nil, engine.CostAlert{})
+
+	if !strings.Contains(ins.Impact, "$0.0008 loop cost inside $0.0008 total") {
+		t.Fatalf("detail insight should clamp loop waste to total, got %q", ins.Impact)
+	}
+	if strings.Contains(ins.Impact, "$0.0750") {
+		t.Fatalf("detail insight kept impossible loop cost: %q", ins.Impact)
+	}
+}
+
+func TestDiagnosticsClampSimpleLoopCostToTotal(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.EN)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	s := engine.Session{
+		Metrics:  engine.Metrics{CostEstimated: 0.0008},
+		LoopCost: engine.LoopCost{TotalLoopCost: 0.0750},
+	}
+	m := resizeForTest(t, sampleModelForTest(), 100, 36)
+
+	rendered := m.renderFingerprintLoops(s)
+
+	if !strings.Contains(rendered, "cost $0.0008") {
+		t.Fatalf("diagnostics should clamp simple loop cost to total, got %q", rendered)
+	}
+	if strings.Contains(rendered, "$0.0750") {
+		t.Fatalf("diagnostics kept impossible loop cost: %q", rendered)
+	}
+}
+
+func TestLoopAnalysisClampsLoopResultCostToTotal(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.EN)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	m := resizeForTest(t, sampleModelForTest(), 100, 36)
+	m.sessions = []engine.Session{{Metrics: engine.Metrics{CostEstimated: 0.0008}}}
+	m.filteredIndices = nil
+	m.detailReady = true
+	m.loopResult = engine.LoopResult{HasLoop: true, LoopType: "tool_loop", Turns: 5, LoopCost: 0.0750}
+
+	rendered := m.renderLoopAnalysis()
+
+	if !strings.Contains(rendered, "$0.0008") {
+		t.Fatalf("loop analysis should clamp loop result cost to total, got %q", rendered)
+	}
+	if strings.Contains(rendered, "$0.0750") {
+		t.Fatalf("loop analysis kept impossible loop cost: %q", rendered)
+	}
+}
+
 func TestOpeningDetailWithNoVisibleRowsClearsStaleViewport(t *testing.T) {
 	m := resizeForTest(t, sampleModelForTest(), 100, 36)
 	m.view = viewList


### PR DESCRIPTION
Closes #108

## Summary

- Clamp loop waste cost and percent to the session total whenever it is phrased as part of total cost.
- Apply the same cost semantics across loaded sessions, localized cached sessions, cost alerts, waste reports, TUI detail insights, and diagnostics loop displays.
- Add regression tests for low-total-cost loop sessions so impossible `loop waste > total` relationships do not reappear.

## User-facing value

The TUI no longer shows cost narratives like `$0.0750 of $0.0008 total`. Detail and Diagnostics now agree that loop waste is bounded by the displayed session total when presented as part of that total.

## Test plan

- `go test ./internal/engine ./internal/tui`
- `go test ./...`
- `go build -o /tmp/agenttrace-quality-108 ./cmd/agenttrace`
- `git diff --check`
- `/tmp/agenttrace-quality-108 --doctor || true`
- `/tmp/agenttrace-quality-108 --demo --overview -f json`
- `/tmp/agenttrace-quality-108 --overview -f json | jq '.summary | {total_sessions,total_tokens,total_cost,avg_health,critical,tool_fail_rate}'`

## Notes

- No pricing data changed.
- No loop detection was removed.
- No database create/drop/delete logic added.
