### PR TITLE
[Quality] Align TUI cache status with doctor

### DIFF
--- a/cmd/agenttrace/doctor.go
+++ b/cmd/agenttrace/doctor.go
@@ -45,12 +45,7 @@ func renderDoctorReport(dir string, demo bool, format string) (string, error) {
 func buildDoctorReport(dir string, demo bool) doctorReport {
 	cache := engine.LoadSessionCache()
 	files := engine.FindSessionFilesCached(dir, cache)
-	valid := 0
-	for _, file := range files {
-		if _, ok := engine.CachedSession(file, cache); ok {
-			valid++
-		}
-	}
+	valid := engine.ValidCachedSessionCount(files, cache)
 
 	mode := i18n.T("doctor_mode_auto")
 	if dir != "" {

--- a/internal/engine/cache.go
+++ b/internal/engine/cache.go
@@ -80,6 +80,16 @@ func (sc SessionCache) EntryCount() int {
 	return len(seen)
 }
 
+func ValidCachedSessionCount(paths []string, cache SessionCache) int {
+	valid := 0
+	for _, path := range paths {
+		if isCachedSessionFresh(path, cache) {
+			valid++
+		}
+	}
+	return valid
+}
+
 // LoadSessionCache 从磁盘读取会话缓存，完整 Session 会按需解码。
 func LoadSessionCache() SessionCache {
 	data, err := os.ReadFile(sessionCachePath())
@@ -154,17 +164,11 @@ func ClearSessionCache() error {
 
 // CachedSession returns a parsed session only when file metadata still matches.
 func CachedSession(path string, cache SessionCache) (Session, bool) {
+	if !isCachedSessionFresh(path, cache) {
+		return Session{}, false
+	}
 	entry, ok := cachedEntry(path, cache)
 	if !ok {
-		return Session{}, false
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		deleteCachedSession(cache, path)
-		return Session{}, false
-	}
-	if entry.ModTime != info.ModTime().UnixNano() || entry.Size != info.Size() {
-		deleteCachedSession(cache, path)
 		return Session{}, false
 	}
 	s := entry.Session
@@ -354,6 +358,23 @@ func cachedEntryHeader(path string, cache SessionCache) (CacheEntry, bool) {
 		return CacheEntry{}, false
 	}
 	return entry, true
+}
+
+func isCachedSessionFresh(path string, cache SessionCache) bool {
+	entry, ok := cachedEntryHeader(path, cache)
+	if !ok {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		deleteCachedSession(cache, path)
+		return false
+	}
+	if entry.ModTime != info.ModTime().UnixNano() || entry.Size != info.Size() {
+		deleteCachedSession(cache, path)
+		return false
+	}
+	return true
 }
 
 func decodeCacheEntryHeader(raw json.RawMessage) (CacheEntry, bool) {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -907,6 +907,37 @@ func TestFindSessionFilesCachedSkipsDeletedCachedFiles(t *testing.T) {
 	}
 }
 
+func TestValidCachedSessionCountUsesCurrentFileMetadata(t *testing.T) {
+	dir := t.TempDir()
+	fresh := filepath.Join(dir, "fresh.jsonl")
+	stale := filepath.Join(dir, "stale.jsonl")
+	if err := os.WriteFile(fresh, []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stale, []byte("{}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	freshInfo, err := os.Stat(fresh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleInfo, err := os.Stat(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := SessionCache{Entries: map[string]CacheEntry{
+		fresh: {ModTime: freshInfo.ModTime().UnixNano(), Size: freshInfo.Size(), Session: Session{Name: "fresh"}},
+		stale: {ModTime: staleInfo.ModTime().Add(-time.Hour).UnixNano(), Size: staleInfo.Size(), Session: Session{Name: "stale"}},
+	}}
+
+	if got := ValidCachedSessionCount([]string{fresh, stale}, cache); got != 1 {
+		t.Fatalf("expected one valid cached session, got %d", got)
+	}
+	if _, ok := cache.Entries[stale]; ok {
+		t.Fatalf("stale cache entry should be evicted")
+	}
+}
+
 func TestFindReportableSessionFilesCachedSkipsSQLiteBackedDirs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -831,7 +831,7 @@ var translations = map[string]map[Lang]string{
 	"loading_scanning_hint": {EN: "Scanning known agent directories. Press q to quit.", ZH: "正在扫描已知 Agent 目录。按 q 退出。"},
 	"loading_parsing_hint":  {EN: "Parsing and analyzing session files. Press q to quit.", ZH: "正在解析和分析会话文件。按 q 退出。"},
 	"loading_from_cache":    {EN: "%d from cache", ZH: "%d 个来自缓存"},
-	"cache_status":          {EN: "cache %d/%d", ZH: "缓存 %d/%d"},
+	"cache_status":          {EN: "cache hits %d/%d valid (%d entries)", ZH: "缓存命中 %d/%d 有效（%d 条）"},
 	"scroll_label":          {EN: "Scroll", ZH: "滚动"},
 	"list_filter":           {EN: "filter", ZH: "筛选"},
 	"list_selected":         {EN: "SELECTED SESSION", ZH: "当前会话"},

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -84,8 +84,10 @@ type loadedSession struct {
 }
 
 type sessionDiscoveryMsg struct {
-	files    []string
-	sessions []loadedSession
+	files        []string
+	sessions     []loadedSession
+	cacheEntries int
+	cacheValid   int
 }
 
 // loadProgressMsg 承载一批渐进加载结果。
@@ -111,6 +113,8 @@ type Model struct {
 	loadProgress    int
 	loadTotal       int
 	loadedFromCache int
+	cacheEntries    int
+	cacheValid      int
 	loadQueue       []string
 	sessionCache    engine.SessionCache
 	unsavedNewCount int
@@ -235,6 +239,8 @@ func (m *Model) startReload() tea.Cmd {
 	m.loadProgress = 0
 	m.loadTotal = 0
 	m.loadedFromCache = 0
+	m.cacheEntries = 0
+	m.cacheValid = 0
 	m.unsavedNewCount = 0
 	m.loading = true
 
@@ -294,7 +300,13 @@ func (m *Model) finishLoading() {
 
 func discoverSessionFilesCmd(dir string, cache engine.SessionCache) tea.Cmd {
 	return func() tea.Msg {
-		msg := sessionDiscoveryMsg{files: engine.FindReportableSessionFilesCached(dir, cache)}
+		files := engine.FindReportableSessionFilesCached(dir, cache)
+		cacheValid := engine.ValidCachedSessionCount(files, cache)
+		msg := sessionDiscoveryMsg{
+			files:        files,
+			cacheEntries: cache.EntryCount(),
+			cacheValid:   cacheValid,
+		}
 		if dir == "" {
 			for _, s := range engine.LoadSQLiteBackedSessions() {
 				msg.sessions = append(msg.sessions, loadedSession{session: s})
@@ -363,6 +375,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sessionDiscoveryMsg:
 		m.loadQueue = msg.files
 		m.loadTotal = len(msg.files) + len(msg.sessions)
+		m.cacheEntries = msg.cacheEntries
+		m.cacheValid = msg.cacheValid
 		if len(msg.sessions) > 0 {
 			m.appendLoadedSessions(msg.sessions)
 		}
@@ -1433,17 +1447,31 @@ func (m Model) renderHelp() string {
 }
 
 func (m Model) cacheStatusLabel() string {
-	if m.loadTotal <= 0 {
+	if m.loadTotal <= 0 && m.cacheEntries <= 0 {
 		return ""
 	}
-	cached := m.loadedFromCache
-	if cached < 0 {
-		cached = 0
+	hits := m.loadedFromCache
+	if hits < 0 {
+		hits = 0
 	}
-	if cached > m.loadTotal {
-		cached = m.loadTotal
+	if m.loadTotal > 0 && hits > m.loadTotal {
+		hits = m.loadTotal
 	}
-	return fmt.Sprintf(i18n.T("cache_status"), cached, m.loadTotal)
+	valid := m.cacheValid
+	if valid < hits {
+		valid = hits
+	}
+	if valid < 0 {
+		valid = 0
+	}
+	entries := m.cacheEntries
+	if entries < valid {
+		entries = valid
+	}
+	if entries < 0 {
+		entries = 0
+	}
+	return fmt.Sprintf(i18n.T("cache_status"), hits, valid, entries)
 }
 
 func (m Model) viewName() string {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -2210,8 +2210,8 @@ func TestStartReloadDiscoversThenLoadsCachedSessions(t *testing.T) {
 	if len(m.sessions) != 1 || m.sessions[0].Name != "cached" {
 		t.Fatalf("cached sessions not hydrated: %+v", m.sessions)
 	}
-	if m.loadedFromCache != 1 || len(m.loadQueue) != 1 {
-		t.Fatalf("bad cache load state: fromCache=%d queue=%d", m.loadedFromCache, len(m.loadQueue))
+	if m.loadedFromCache != 1 || m.cacheEntries != 1 || m.cacheValid != 1 || len(m.loadQueue) != 1 {
+		t.Fatalf("bad cache load state: fromCache=%d entries=%d valid=%d queue=%d", m.loadedFromCache, m.cacheEntries, m.cacheValid, len(m.loadQueue))
 	}
 }
 
@@ -2240,6 +2240,9 @@ func TestDefaultDiscoveryUsesReportableSQLiteBackedSource(t *testing.T) {
 	}
 	if len(msg.files) != 0 {
 		t.Fatalf("default TUI discovery should skip sqlite-backed legacy files: %v", msg.files)
+	}
+	if msg.cacheEntries != 0 || msg.cacheValid != 0 {
+		t.Fatalf("sqlite-only discovery should not report unrelated file cache stats: entries=%d valid=%d", msg.cacheEntries, msg.cacheValid)
 	}
 	if len(msg.sessions) != 1 || msg.sessions[0].session.Metrics.SourceTool != "hermes_db" {
 		t.Fatalf("expected one sqlite-backed Hermes session, got %+v", msg.sessions)
@@ -2324,11 +2327,28 @@ func TestFooterShowsCacheStatusAfterLoad(t *testing.T) {
 	m.view = viewList
 	m.loadTotal = 3
 	m.loadedFromCache = 2
+	m.cacheEntries = 3
+	m.cacheValid = 2
 
 	rendered := m.View()
 
-	if !strings.Contains(rendered, "cache 2/3") {
+	if !strings.Contains(rendered, "cache hits 2/2 valid (3 entries)") {
 		t.Fatalf("footer should expose cache hit status:\n%s", rendered)
+	}
+}
+
+func TestFooterShowsUncachedStateWithValidCacheTerms(t *testing.T) {
+	m := resizeForTest(t, sampleModelForTest(), 120, 30)
+	m.view = viewList
+	m.loadTotal = 3
+
+	rendered := m.View()
+
+	if !strings.Contains(rendered, "cache hits 0/0 valid (0 entries)") {
+		t.Fatalf("footer should distinguish hits, valid entries, and cache entries:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "cache 0/3") {
+		t.Fatalf("footer should not map cache misses to discovered session total:\n%s", rendered)
 	}
 }
 
@@ -2343,10 +2363,12 @@ func TestChineseFooterShowsCacheStatus(t *testing.T) {
 	m.view = viewList
 	m.loadTotal = 3
 	m.loadedFromCache = 5
+	m.cacheEntries = 4
+	m.cacheValid = 3
 
 	rendered := m.View()
 
-	if !strings.Contains(rendered, "缓存 3/3") {
+	if !strings.Contains(rendered, "缓存命中 3/3 有效（4 条）") {
 		t.Fatalf("footer should expose translated clamped cache status:\n%s", rendered)
 	}
 }


### PR DESCRIPTION
Closes #110

## Summary

- Add a shared engine cache-valid counter and make doctor use it.
- Carry cache entry and valid-entry counts from TUI discovery into the model.
- Change the TUI footer from ambiguous `cache hits/total sessions` to explicit `cache hits / valid entries (entries)` wording.
- Add cached and uncached footer regression tests plus a metadata-valid cache count test.

## User-facing value

The TUI footer now clearly maps cache usage to doctor terminology instead of making a valid cache look unused. Users can distinguish discovered/loaded sessions from cache entries, valid entries, and actual cache hits.

## Test plan

- `go test ./cmd/agenttrace ./internal/engine ./internal/tui`
- `go test ./...`
- `go build -o /tmp/agenttrace-quality-110 ./cmd/agenttrace`
- `git diff --check`
- `/tmp/agenttrace-quality-110 --doctor || true`
- `/tmp/agenttrace-quality-110 --demo --overview -f json`
- `/tmp/agenttrace-quality-110 --overview -f json | jq '.summary | {total_sessions,total_tokens,total_cost,avg_health,critical,tool_fail_rate}'`

## Notes

- Progressive loading is unchanged.
- Cache file location is unchanged.
- No local file contents are exposed in the UI.
- No database create/drop/delete logic added.
