### PR TITLE
[Quality] Add repeatable CI gates for agent validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,8 +10,16 @@ What changed and why?
 
 ## Validation
 
+- [ ] `test -z "$(gofmt -l .)"`
+- [ ] `go vet ./...`
 - [ ] `go test ./...`
 - [ ] `go build ./cmd/agenttrace`
+- [ ] `scripts/ci/check-output-contract.sh`
+- [ ] `scripts/ci/check-deterministic-output.sh`
+- [ ] `scripts/ci/check-report-semantics.sh`
+- [ ] `scripts/ci/check-release-surfaces.sh`
+- [ ] `scripts/ci/check-docs-commands.sh`
+- [ ] `scripts/ci/check-pages-artifact.sh site`
 - [ ] `node --check npm/install.js && node --check npm/run.js`
 - [ ] `ruby -c homebrew/Formula/agenttrace.rb`
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [master]
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * *"
 
 jobs:
   test:
@@ -18,8 +21,18 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Check Go formatting
+        run: test -z "$(gofmt -l .)"
+
+      - name: Go vet
+        run: go vet ./...
+
       - name: Go tests
         run: go test ./...
+
+      - name: Race tests
+        if: github.event_name != 'pull_request'
+        run: go test -race ./...
 
       - name: Build CLI
         run: go build -o /tmp/agenttrace ./cmd/agenttrace
@@ -34,8 +47,46 @@ jobs:
           node --check npm/install.js
           node --check npm/run.js
 
+      - name: Demo and report output contract
+        run: |
+          AGENTTRACE_BIN=/tmp/agenttrace \
+          AGENTTRACE_CI_OUT=ci-artifacts \
+            scripts/ci/check-output-contract.sh
+
+      - name: Deterministic demo output
+        run: |
+          AGENTTRACE_BIN=/tmp/agenttrace \
+          AGENTTRACE_CI_OUT=ci-artifacts \
+            scripts/ci/check-deterministic-output.sh
+
+      - name: Report semantic consistency
+        run: |
+          AGENTTRACE_BIN=/tmp/agenttrace \
+          AGENTTRACE_CI_OUT=ci-artifacts \
+            scripts/ci/check-report-semantics.sh
+
+      - name: Release surface drift
+        run: scripts/ci/check-release-surfaces.sh
+
+      - name: Documented command smoke tests
+        run: |
+          AGENTTRACE_BIN=/tmp/agenttrace \
+          AGENTTRACE_CI_OUT=ci-artifacts \
+            scripts/ci/check-docs-commands.sh
+
+      - name: Pages source artifact check
+        run: scripts/ci/check-pages-artifact.sh site
+
+      - name: Upload demo report artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: agenttrace-ci-reports
+          path: ci-artifacts
+          if-no-files-found: warn
+
       - name: Validate Homebrew formula syntax
         run: ruby -c homebrew/Formula/agenttrace.rb
 
       - name: Validate helper scripts
-        run: bash -n scripts/record-demo.sh
+        run: bash -n scripts/record-demo.sh scripts/ci/*.sh

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,9 @@ jobs:
           cp -R site/. public/
           cp assets/agenttrace-demo.gif assets/hero-banner.png assets/logo-icon.png assets/tui-preview.png public/assets/
 
+      - name: Validate Pages artifact
+        run: scripts/ci/check-pages-artifact.sh public
+
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 go/agenttrace
 dist/
+ci-artifacts/
 agentwaste
 .claude/settings.local.json
 .playwright-mcp/

--- a/cmd/agenttrace/demo_test.go
+++ b/cmd/agenttrace/demo_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/luoyuctl/agenttrace/internal/engine"
@@ -28,5 +29,9 @@ func TestWriteDemoSessionsProducesUsableData(t *testing.T) {
 	ov := engine.ComputeOverview(sessions)
 	if ov.TotalSessions != 3 || len(ov.AnomaliesTop) == 0 {
 		t.Fatalf("demo overview should show multiple sessions and anomalies: %+v", ov)
+	}
+	latest := latestSessionFile(files)
+	if !strings.HasSuffix(latest, "03-shallow-chat.jsonl") {
+		t.Fatalf("demo latest session should be deterministic, got %q", latest)
 	}
 }

--- a/cmd/agenttrace/main.go
+++ b/cmd/agenttrace/main.go
@@ -308,20 +308,52 @@ func resolveDefaultDir() string {
 }
 
 func latestSessionFile(files []string) string {
-	var latestFile string
-	var latestTime time.Time
+	type candidate struct {
+		path           string
+		sessionTime    time.Time
+		hasSessionTime bool
+		modTime        time.Time
+	}
+
+	var latest candidate
 	for _, f := range files {
 		info, err := os.Stat(f)
 		if err != nil {
 			continue
 		}
-		modTime := info.ModTime()
-		if latestFile == "" || modTime.After(latestTime) || (modTime.Equal(latestTime) && f > latestFile) {
-			latestFile = f
-			latestTime = modTime
+		current := candidate{path: f, modTime: info.ModTime()}
+		if session, err := engine.LoadSession(f); err == nil && session.Metrics.SessionStart != "" {
+			if ts, err := time.Parse(time.RFC3339, session.Metrics.SessionStart); err == nil {
+				current.sessionTime = ts
+				current.hasSessionTime = true
+			}
+		}
+		if latest.path == "" || newerSessionCandidate(current, latest) {
+			latest = current
 		}
 	}
-	return latestFile
+	return latest.path
+}
+
+func newerSessionCandidate(a, b struct {
+	path           string
+	sessionTime    time.Time
+	hasSessionTime bool
+	modTime        time.Time
+}) bool {
+	if a.hasSessionTime != b.hasSessionTime {
+		return a.hasSessionTime
+	}
+	if a.hasSessionTime {
+		if !a.sessionTime.Equal(b.sessionTime) {
+			return a.sessionTime.After(b.sessionTime)
+		}
+		return a.path > b.path
+	}
+	if !a.modTime.Equal(b.modTime) {
+		return a.modTime.After(b.modTime)
+	}
+	return a.path > b.path
 }
 
 func tuiLaunchErrorMessage(err error, demo bool) string {

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -81,3 +81,30 @@ jobs:
 ```
 
 Tune thresholds per repository. A stricter team can start with health `90` and tool failure rate `5`; early adopters may start at `70` and `25` to avoid blocking useful experimentation.
+
+## Repository CI Gates
+
+This repository also runs agenttrace against its own demo and docs surfaces so repetitive Agent validation becomes a stable CI contract.
+
+The project CI builds `/tmp/agenttrace` and runs:
+
+```bash
+scripts/ci/check-output-contract.sh
+scripts/ci/check-deterministic-output.sh
+scripts/ci/check-report-semantics.sh
+scripts/ci/check-release-surfaces.sh
+scripts/ci/check-docs-commands.sh
+scripts/ci/check-pages-artifact.sh site
+```
+
+These checks cover:
+
+- demo JSON, Markdown, HTML, and doctor smoke output
+- `-o` stdout/stderr behavior and failing gate exit code `2`
+- repeated demo latest/overview JSON determinism
+- report cost-label and version metadata consistency
+- README, Homebrew formula, site metadata, and sample report version drift
+- non-interactive README/docs command smoke tests
+- Pages local asset references and sample report metadata
+
+CI uploads generated demo reports as artifacts so reviewers can inspect the JSON, Markdown, and HTML output without rerunning local commands.

--- a/scripts/ci/check-deterministic-output.sh
+++ b/scripts/ci/check-deterministic-output.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bin="${AGENTTRACE_BIN:-/tmp/agenttrace}"
+out_dir="${AGENTTRACE_CI_OUT:-/tmp/agenttrace-ci}"
+
+fail() {
+  echo "check-deterministic-output: $*" >&2
+  exit 1
+}
+
+[[ -x "$bin" ]] || fail "agenttrace binary is not executable: $bin"
+mkdir -p "$out_dir/determinism"
+
+for i in 1 2 3; do
+  "$bin" --demo --latest -f json >"$out_dir/determinism/latest-$i.json"
+  "$bin" --demo --overview -f json >"$out_dir/determinism/overview-$i.json"
+done
+
+for path in "$out_dir"/determinism/*.json; do
+  node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$path" \
+    || fail "invalid JSON: $path"
+done
+
+cmp -s "$out_dir/determinism/latest-1.json" "$out_dir/determinism/latest-2.json" \
+  || fail "--demo --latest -f json changed between run 1 and 2"
+cmp -s "$out_dir/determinism/latest-1.json" "$out_dir/determinism/latest-3.json" \
+  || fail "--demo --latest -f json changed between run 1 and 3"
+cmp -s "$out_dir/determinism/overview-1.json" "$out_dir/determinism/overview-2.json" \
+  || fail "--demo --overview -f json changed between run 1 and 2"
+cmp -s "$out_dir/determinism/overview-1.json" "$out_dir/determinism/overview-3.json" \
+  || fail "--demo --overview -f json changed between run 1 and 3"

--- a/scripts/ci/check-docs-commands.sh
+++ b/scripts/ci/check-docs-commands.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bin="${AGENTTRACE_BIN:-/tmp/agenttrace}"
+out_dir="${AGENTTRACE_CI_OUT:-/tmp/agenttrace-ci}"
+
+fail() {
+  echo "check-docs-commands: $*" >&2
+  exit 1
+}
+
+[[ -x "$bin" ]] || fail "agenttrace binary is not executable: $bin"
+mkdir -p "$out_dir/docs"
+
+"$bin" --version >"$out_dir/docs/version.txt"
+"$bin" --doctor -f json >"$out_dir/docs/doctor.json"
+"$bin" --demo --latest -f json >"$out_dir/docs/latest.json"
+"$bin" --demo --latest --lang zh -f json >"$out_dir/docs/latest-zh.json"
+"$bin" --demo --overview -f json >"$out_dir/docs/overview.json"
+"$bin" --demo --overview -f markdown -o "$out_dir/docs/overview.md" >/tmp/agenttrace-docs-md.stdout
+"$bin" --demo --overview -f html -o "$out_dir/docs/overview.html" >/tmp/agenttrace-docs-html.stdout
+
+for path in "$out_dir"/docs/*.json; do
+  node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$path" \
+    || fail "invalid JSON from documented command: $path"
+done
+
+set +e
+"$bin" --demo --overview \
+  --fail-under-health 80 \
+  --fail-on-critical \
+  --max-tool-fail-rate 15 \
+  >"$out_dir/docs/gate.stdout" \
+  2>"$out_dir/docs/gate.stderr"
+status=$?
+set -e
+[[ "$status" -eq 2 ]] || fail "documented CI gate command should exit 2 for demo data, got $status"
+grep -q 'Gate failed:' "$out_dir/docs/gate.stderr" \
+  || fail "documented CI gate command should explain gate failures on stderr"

--- a/scripts/ci/check-output-contract.sh
+++ b/scripts/ci/check-output-contract.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bin="${AGENTTRACE_BIN:-/tmp/agenttrace}"
+out_dir="${AGENTTRACE_CI_OUT:-/tmp/agenttrace-ci}"
+
+fail() {
+  echo "check-output-contract: $*" >&2
+  exit 1
+}
+
+require_file() {
+  local path="$1"
+  [[ -s "$path" ]] || fail "expected non-empty file: $path"
+}
+
+require_json() {
+  local path="$1"
+  node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$path" \
+    || fail "invalid JSON: $path"
+}
+
+[[ -x "$bin" ]] || fail "agenttrace binary is not executable: $bin"
+mkdir -p "$out_dir"
+
+"$bin" --doctor -f json >"$out_dir/doctor.json"
+require_file "$out_dir/doctor.json"
+require_json "$out_dir/doctor.json"
+
+"$bin" --demo --overview -f json >"$out_dir/agenttrace-demo.json"
+require_file "$out_dir/agenttrace-demo.json"
+require_json "$out_dir/agenttrace-demo.json"
+node -e '
+const report = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+if (!report.version) throw new Error("missing version");
+if (!report.summary || report.summary.total_sessions < 1) throw new Error("missing demo summary");
+if (!Array.isArray(report.recent_sessions) || report.recent_sessions.length < 1) throw new Error("missing recent sessions");
+' "$out_dir/agenttrace-demo.json"
+
+"$bin" --demo --overview -f markdown \
+  -o "$out_dir/agenttrace-demo.md" \
+  >"$out_dir/agenttrace-demo.md.stdout" \
+  2>"$out_dir/agenttrace-demo.md.stderr"
+require_file "$out_dir/agenttrace-demo.md"
+require_file "$out_dir/agenttrace-demo.md.stdout"
+grep -q '^# agenttrace overview' "$out_dir/agenttrace-demo.md.stdout" \
+  || fail "markdown stdout should contain the report body"
+grep -q '^# agenttrace overview' "$out_dir/agenttrace-demo.md" \
+  || fail "saved markdown should contain the report body"
+grep -q '^Saved: ' "$out_dir/agenttrace-demo.md.stderr" \
+  || fail "markdown -o should write saved-file status to stderr"
+! grep -q '^Saved: ' "$out_dir/agenttrace-demo.md.stdout" \
+  || fail "markdown stdout must not contain saved-file status"
+
+"$bin" --demo --overview -f html \
+  -o "$out_dir/agenttrace-demo.html" \
+  >"$out_dir/agenttrace-demo.html.stdout" \
+  2>"$out_dir/agenttrace-demo.html.stderr"
+require_file "$out_dir/agenttrace-demo.html"
+require_file "$out_dir/agenttrace-demo.html.stdout"
+grep -q '^<!doctype html>' "$out_dir/agenttrace-demo.html.stdout" \
+  || fail "html stdout should contain the report body"
+grep -q '^<!doctype html>' "$out_dir/agenttrace-demo.html" \
+  || fail "saved html should contain the report body"
+grep -q '^Saved: ' "$out_dir/agenttrace-demo.html.stderr" \
+  || fail "html -o should write saved-file status to stderr"
+! grep -q '^Saved: ' "$out_dir/agenttrace-demo.html.stdout" \
+  || fail "html stdout must not contain saved-file status"
+
+set +e
+"$bin" --demo --overview -f json \
+  --fail-under-health 80 \
+  --fail-on-critical \
+  --max-tool-fail-rate 15 \
+  -o "$out_dir/agenttrace-gate.json" \
+  >"$out_dir/agenttrace-gate.json.stdout" \
+  2>"$out_dir/agenttrace-gate.json.stderr"
+status=$?
+set -e
+
+[[ "$status" -eq 2 ]] || fail "expected gate failure exit code 2, got $status"
+require_file "$out_dir/agenttrace-gate.json"
+require_file "$out_dir/agenttrace-gate.json.stdout"
+require_json "$out_dir/agenttrace-gate.json"
+require_json "$out_dir/agenttrace-gate.json.stdout"
+node -e '
+const fs = require("fs");
+const saved = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const stdout = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+if (JSON.stringify(saved) !== JSON.stringify(stdout)) {
+  throw new Error("saved JSON and stdout JSON differ");
+}
+' "$out_dir/agenttrace-gate.json" "$out_dir/agenttrace-gate.json.stdout" \
+  || fail "gated json -o stdout should match the saved report"
+grep -q '^Saved: ' "$out_dir/agenttrace-gate.json.stderr" \
+  || fail "gated json -o should write saved-file status to stderr"
+grep -q 'Gate failed:' "$out_dir/agenttrace-gate.json.stderr" \
+  || fail "gated json should write gate failures to stderr"
+! grep -q '^Saved: ' "$out_dir/agenttrace-gate.json.stdout" \
+  || fail "gated json stdout must not contain saved-file status"

--- a/scripts/ci/check-pages-artifact.sh
+++ b/scripts/ci/check-pages-artifact.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+page_dir="${1:-site}"
+repo_root="$(git rev-parse --show-toplevel)"
+
+fail() {
+  echo "check-pages-artifact: $*" >&2
+  exit 1
+}
+
+[[ -d "$page_dir" ]] || fail "page directory not found: $page_dir"
+[[ -f "$page_dir/index.html" ]] || fail "missing index.html in $page_dir"
+[[ -f "$page_dir/demo-report.html" ]] || fail "missing demo-report.html in $page_dir"
+
+version="$(sed -nE 's/^const Version = "([^"]+)"/\1/p' "$repo_root/internal/engine/engine.go")"
+[[ -n "$version" ]] || fail "could not read internal/engine Version"
+
+if ! grep -q "<div class=\"meta\">v$version" "$page_dir/demo-report.html" &&
+  ! grep -qi "static sample data" "$page_dir/demo-report.html"; then
+  fail "demo-report.html must use current version metadata or clearly identify static sample data"
+fi
+
+for asset in \
+  assets/agenttrace-demo.gif \
+  assets/hero-banner.png \
+  assets/logo-icon.png \
+  assets/tui-preview.png; do
+  if [[ ! -f "$page_dir/$asset" && ! -f "$repo_root/$asset" ]]; then
+    fail "missing Pages asset: $asset"
+  fi
+done
+
+node - "$page_dir" "$repo_root" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const pageDir = process.argv[2];
+const repoRoot = process.argv[3];
+const files = ["index.html", "demo-report.html"];
+const attrPattern = /\b(?:href|src)=["']([^"']+)["']/g;
+
+function exists(ref) {
+  const clean = ref.split("#")[0].split("?")[0];
+  if (!clean || clean.startsWith("http://") || clean.startsWith("https://") || clean.startsWith("data:") || clean.startsWith("mailto:")) {
+    return true;
+  }
+  if (clean.startsWith("#")) return true;
+  const pageRelative = path.join(pageDir, clean);
+  const repoRelative = path.join(repoRoot, clean);
+  return fs.existsSync(pageRelative) || fs.existsSync(repoRelative);
+}
+
+for (const file of files) {
+  const html = fs.readFileSync(path.join(pageDir, file), "utf8");
+  for (const match of html.matchAll(attrPattern)) {
+    if (!exists(match[1])) {
+      throw new Error(`${file} references missing local asset ${match[1]}`);
+    }
+  }
+}
+NODE

--- a/scripts/ci/check-release-surfaces.sh
+++ b/scripts/ci/check-release-surfaces.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "check-release-surfaces: $*" >&2
+  exit 1
+}
+
+version="$(sed -nE 's/^const Version = "([^"]+)"/\1/p' internal/engine/engine.go)"
+[[ -n "$version" ]] || fail "could not read internal/engine Version"
+
+grep -q "Homebrew-v$version-" README.md \
+  || fail "README Homebrew badge is not aligned with engine version $version"
+grep -q "AGENTTRACE v$version" README.md \
+  || fail "README sample output is not aligned with engine version $version"
+grep -q "version \"$version\"" homebrew/Formula/agenttrace.rb \
+  || fail "Homebrew formula version is not aligned with engine version $version"
+grep -q "agenttrace v$version" homebrew/Formula/agenttrace.rb \
+  || fail "Homebrew formula test is not aligned with engine version $version"
+grep -q "\"softwareVersion\": \"$version\"" site/index.html \
+  || fail "site structured metadata is not aligned with engine version $version"
+
+if ! grep -q "<div class=\"meta\">v$version" site/demo-report.html &&
+  ! grep -qi "static sample data" site/demo-report.html; then
+  fail "site demo report must use current version metadata or clearly identify static sample data"
+fi
+
+node -e '
+const fs = require("fs");
+const version = process.argv[1];
+const files = ["README.md", "homebrew/Formula/agenttrace.rb", "site/index.html", "site/demo-report.html"];
+const pattern = /\bv?(\d+\.\d+\.\d+)\b/g;
+for (const file of files) {
+  const text = fs.readFileSync(file, "utf8");
+  for (const match of text.matchAll(pattern)) {
+    if (match[1] !== version) {
+      throw new Error(`${file} contains stale version ${match[0]}, expected ${version}`);
+    }
+  }
+}
+' "$version" || fail "release surface version drift detected"

--- a/scripts/ci/check-report-semantics.sh
+++ b/scripts/ci/check-report-semantics.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bin="${AGENTTRACE_BIN:-/tmp/agenttrace}"
+out_dir="${AGENTTRACE_CI_OUT:-/tmp/agenttrace-ci}"
+expected_cost_label="${AGENTTRACE_EXPECTED_COST_LABEL:-Money Wasted}"
+
+fail() {
+  echo "check-report-semantics: $*" >&2
+  exit 1
+}
+
+[[ -x "$bin" ]] || fail "agenttrace binary is not executable: $bin"
+mkdir -p "$out_dir/semantics"
+
+version="$("$bin" --version | sed -E 's/^agenttrace v//')"
+[[ -n "$version" ]] || fail "could not read agenttrace version"
+
+"$bin" --demo --overview >"$out_dir/semantics/overview.txt"
+"$bin" --demo --overview -f json >"$out_dir/semantics/overview.json"
+"$bin" --demo --overview -f markdown >"$out_dir/semantics/overview.md"
+"$bin" --demo --overview -f html >"$out_dir/semantics/overview.html"
+
+grep -q "AGENTTRACE v$version" "$out_dir/semantics/overview.txt" \
+  || fail "text overview missing current version"
+grep -q "$expected_cost_label" "$out_dir/semantics/overview.txt" \
+  || fail "text overview missing expected cost label"
+grep -q "| $expected_cost_label |" "$out_dir/semantics/overview.md" \
+  || fail "markdown overview missing expected cost label"
+grep -q "<span>$expected_cost_label</span>" "$out_dir/semantics/overview.html" \
+  || fail "html overview missing expected cost label"
+grep -q "<div class=\"meta\">v$version" "$out_dir/semantics/overview.html" \
+  || fail "html overview missing current version metadata"
+grep -q "Estimated session cost" "$out_dir/semantics/overview.html" \
+  || fail "html overview missing cost helper text"
+
+node -e '
+const fs = require("fs");
+const version = process.argv[2];
+const report = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (report.version !== version) throw new Error(`json version ${report.version} != ${version}`);
+if (!report.summary || typeof report.summary.total_cost !== "number") throw new Error("missing total_cost");
+if (report.summary.total_sessions !== 3) throw new Error("demo summary should contain 3 sessions");
+if (!Array.isArray(report.recent_sessions) || report.recent_sessions.length !== 3) throw new Error("demo should contain 3 recent sessions");
+' "$out_dir/semantics/overview.json" "$version"

--- a/site/demo-report.html
+++ b/site/demo-report.html
@@ -18,15 +18,17 @@ section{border:1px solid var(--line);background:rgba(16,20,25,.78);padding:20px;
 <main>
 <header>
 <div><div class="brand">agenttrace</div><h1>AI agent session overview</h1><p>Static report generated from local coding-agent traces.</p></div>
-<div class="meta">v0.3.48<br>3 sessions<br><code>agenttrace --overview -f html</code></div>
+<div class="meta">v0.3.48<br>3 Sessions<br><code>agenttrace --overview -f html</code></div>
 </header>
 <div class="grid" aria-label="summary metrics">
-<div class="metric"><span>Sessions</span><strong>3</strong><p>1 healthy / 1 warning / 1 critical</p></div>
+<div class="metric"><span>Sessions</span><strong>3</strong><p>1 Healthy / 1 Warning / 1 Critical</p></div>
+<div class="metric"><span>Total tokens</span><strong>278200</strong><p>+ live</p></div>
 <div class="metric"><span>Average health</span><strong>58.7</strong><p>Fleet quality score</p></div>
-<div class="metric"><span>Total cost</span><strong>$0.81</strong><p>Estimated session cost</p></div>
+<div class="metric"><span>Money Wasted</span><strong>$0.81</strong><p>Estimated session cost</p></div>
 <div class="metric bad"><span>Tool failures</span><strong>3/5</strong><p>60.0% failure rate</p></div>
 </div>
-<section><h2>Recent sessions</h2><table><thead><tr><th>Session</th><th>Source</th><th>Model</th><th class="num">Tokens</th><th class="num">Cost</th><th class="num">Health</th><th class="num">Anomalies</th></tr></thead><tbody>
+<section><h2>Health Trend</h2><p>Declining: 100→66</p></section>
+<section><h2>Recent sessions</h2><table><thead><tr><th>Session</th><th>Source</th><th>Model</th><th class="num">Total tokens</th><th class="num">Cost</th><th class="num">Health</th><th class="num">Anomalies</th></tr></thead><tbody>
 <tr><td>03-shallow-chat</td><td>Hermes Agent (JSONL)</td><td>gemini-2.5-pro</td><td class="num">30200</td><td class="num">$0.0570</td><td class="num health-warn">66</td><td class="num">2</td></tr>
 <tr><td>02-hanging-loop</td><td>Hermes Agent (JSONL)</td><td>gpt-5.1</td><td class="num">233000</td><td class="num">$0.7113</td><td class="num health-bad">10</td><td class="num">3</td></tr>
 <tr><td>01-healthy-ship</td><td>Hermes Agent (JSONL)</td><td>claude-sonnet-4</td><td class="num">15000</td><td class="num">$0.0423</td><td class="num health-good">100</td><td class="num">0</td></tr>
@@ -41,11 +43,11 @@ section{border:1px solid var(--line);background:rgba(16,20,25,.78);padding:20px;
 </tbody></table></section>
 <section><h2>Recent anomalies</h2>
 <table><thead><tr><th>Session</th><th>Type</th><th>Age</th></tr></thead><tbody>
-<tr><td>03-shallow-chat</td><td>shallow_thinking</td><td>now</td></tr>
-<tr><td>03-shallow-chat</td><td>no_tools</td><td>now</td></tr>
 <tr><td>02-hanging-loop</td><td>hanging</td><td>now</td></tr>
-<tr><td>02-hanging-loop</td><td>tool_failures</td><td>now</td></tr>
-<tr><td>02-hanging-loop</td><td>shallow_thinking</td><td>now</td></tr>
+<tr><td>02-hanging-loop</td><td>shallow thinking</td><td>now</td></tr>
+<tr><td>02-hanging-loop</td><td>tool failures</td><td>now</td></tr>
+<tr><td>03-shallow-chat</td><td>shallow thinking</td><td>now</td></tr>
+<tr><td>03-shallow-chat</td><td>no tools</td><td>now</td></tr>
 </tbody></table>
 </section>
 </main>


### PR DESCRIPTION
## Summary

Adds repeatable CI gates that move the mechanical checks agents have been doing by hand into reusable scripts and GitHub Actions.

## Scope

- Adds scripts for demo/report output contract, deterministic demo output, report semantic consistency, release surface drift, documented command smoke tests, and Pages artifact validation.
- Extends CI with gofmt, go vet, scheduled/non-PR race tests, the new scripts, and uploaded demo report artifacts.
- Validates Pages artifacts before deployment.
- Regenerates the sample HTML report with current version metadata.
- Makes demo latest session selection deterministic by preferring session timestamps over file mtimes.
- Updates PR validation checklist and CI docs.

## Test plan

- `test -z "$(gofmt -l .)"`
- `go vet ./...`
- `go test ./...`
- `go test -race ./...`
- `go build -o /tmp/agenttrace ./cmd/agenttrace`
- `AGENTTRACE_BIN=/tmp/agenttrace AGENTTRACE_CI_OUT=ci-artifacts scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace AGENTTRACE_CI_OUT=ci-artifacts scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace AGENTTRACE_CI_OUT=ci-artifacts scripts/ci/check-report-semantics.sh`
- `scripts/ci/check-release-surfaces.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace AGENTTRACE_CI_OUT=ci-artifacts scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-pages-artifact.sh site`
- `bash -n scripts/record-demo.sh scripts/ci/*.sh`
- `node --check npm/install.js && node --check npm/run.js`
- `ruby -c homebrew/Formula/agenttrace.rb`

## Risk

Medium. This broadens CI coverage and intentionally makes release/demo drift visible, but the scripts are small and locally reusable.

## Non-goals

- No release/tag changes.
- No parser format changes.
- No hosted telemetry or external network checks.

## Blackboard events

Event: Evidence
Actor: Quality
Scope: CI gates
State change: repeatable local scripts + CI coverage added
Evidence: local validation commands above
Next owner: Quality
