### PR TITLE
[Quality] Isolate auto-discovery tests from runner config

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -661,6 +661,7 @@ func TestParseQwenCodeStreamJSONL_NoMessages(t *testing.T) {
 func TestFindSessionFilesIncludesQwenProjectChats(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	chatDir := filepath.Join(home, ".qwen", "projects", "repo", "chats")
 	if err := os.MkdirAll(chatDir, 0755); err != nil {
 		t.Fatal(err)
@@ -787,6 +788,7 @@ func TestDetectLargeParams_UsesToolArguments(t *testing.T) {
 func TestFindSessionFilesAutoDiscoverySortsByModTime(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	oldDir := filepath.Join(home, ".codex", "sessions")
 	newDir := filepath.Join(home, ".gemini", "sessions")
 	if err := os.MkdirAll(oldDir, 0755); err != nil {
@@ -941,6 +943,7 @@ func TestValidCachedSessionCountUsesCurrentFileMetadata(t *testing.T) {
 func TestFindReportableSessionFilesCachedSkipsSQLiteBackedDirs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	sessionsDir := filepath.Join(home, ".hermes", "sessions")
 	if err := os.MkdirAll(sessionsDir, 0755); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Fixes the master `go test -race ./...` failure exposed by the new CI gate. The affected auto-discovery tests set `HOME` to a temp directory but did not isolate `XDG_CONFIG_HOME`, so GitHub runner Cline config could leak into test discovery.

## Scope

- Sets `XDG_CONFIG_HOME` alongside `HOME` in auto-discovery tests that expect a fully isolated home tree.
- No production behavior changes.

## Test plan

- `go test ./internal/engine`
- `go test -race ./internal/engine`
- `test -z "$(gofmt -l .)" && go vet ./... && go test ./...`
- `go test -race ./...`
- `AGENTTRACE_BIN=/tmp/agenttrace AGENTTRACE_CI_OUT=ci-artifacts scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace AGENTTRACE_CI_OUT=ci-artifacts scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace AGENTTRACE_CI_OUT=ci-artifacts scripts/ci/check-report-semantics.sh`
- `scripts/ci/check-release-surfaces.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace AGENTTRACE_CI_OUT=ci-artifacts scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-pages-artifact.sh site`

## Risk

Low. Test-only environment isolation.
