### PR TITLE
[Growth] Surface repeatable validation gates in launch kit

### DIFF
--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -215,6 +215,16 @@ go build -o /tmp/agenttrace ./cmd/agenttrace
 /tmp/agenttrace --demo --overview -f json
 ```
 
+For public demo, report, or release-surface checks, run the reusable gates from [CI Integration](ci-integration.md):
+
+```bash
+AGENTTRACE_BIN=/tmp/agenttrace scripts/ci/check-output-contract.sh
+AGENTTRACE_BIN=/tmp/agenttrace scripts/ci/check-deterministic-output.sh
+AGENTTRACE_BIN=/tmp/agenttrace scripts/ci/check-report-semantics.sh
+scripts/ci/check-release-surfaces.sh
+scripts/ci/check-pages-artifact.sh site
+```
+
 ## Release Consistency Checklist
 
 Before sharing a release publicly, compare these surfaces against `gh release list --repo luoyuctl/agenttrace --limit 1`:


### PR DESCRIPTION
Closes #119

## Summary

- Adds the reusable demo/report/release-surface validation gates to the launch kit's sharing checklist.
- Links the launch kit back to the CI Integration guide for the full gate details.

## User-facing value

Maintainers preparing public demos, sample reports, screenshots, or support artifacts can now run the same repeatable gates that CI uses before sharing material.

## Adoption rationale

Stable public artifacts reduce onboarding friction and make launch/support material easier to trust. This keeps the launch kit aligned with the validation coverage added in #118 without duplicating the full CI documentation.

## Scope

- Documentation-only change in `docs/launch-kit.md`.
- No Go source, parser, workflow, release, tag, or external posting changes.

## Test plan

- `git diff --check`
- `markdownlint README.md docs/**/*.md || true` (local command missing: `markdownlint`)
- `go test ./... || true`
- `go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace || true`
- `/tmp/agenttrace-growth-check --doctor || true`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-119-contract scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-119-deterministic scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-119-semantics scripts/ci/check-report-semantics.sh`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`

## Safety checklist

- [x] Linked Issue exists.
- [x] Branch was created from `origin/master` and pushed before edits.
- [x] No same-Issue open PR or remote `growth/119-*` branch existed before claiming.
- [x] Public copy avoids restricted wording from the growth rules.
- [x] No release, tag, merge, or external post was created.
