### PR TITLE
[Impl] Polish TUI loading, diff empty state, and command feedback

### DIFF
--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -958,6 +958,7 @@ var translations = map[string]map[Lang]string{
 	"risk_normal":                   {EN: "normal", ZH: "正常"},
 	"risk_rare":                     {EN: "rare", ZH: "低频"},
 	"diff_need_two":                 {EN: "Need at least two visible sessions to compare.", ZH: "至少需要两个可见会话才能对比。"},
+	"diff_recovery_hint":            {EN: "Clear filters, return to the list, or select another visible session.", ZH: "清除筛选、返回列表，或选择另一个可见会话。"},
 	"diff_select_neighbor":          {EN: "Select a session and press d to compare nearby sessions.", ZH: "选择会话后按 d 对比相邻会话。"},
 	"diff_comparison":               {EN: "COMPARISON", ZH: "对比"},
 	"diff_winner_label":             {EN: "Winner: %s", ZH: "胜出: %s"},

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -227,7 +227,7 @@ func (m Model) Init() tea.Cmd {
 
 const (
 	cacheSaveInterval = 10
-	loadBatchSize     = 32
+	loadBatchSize     = 8
 )
 
 // startReload 启动渐进式缓存加载。
@@ -418,6 +418,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.loading {
 			switch msg.String() {
 			case "q", "ctrl+c":
+				m.loading = false
+				m.loadQueue = nil
 				return m, tea.Quit
 			}
 			return m, nil
@@ -1034,6 +1036,8 @@ func (m Model) View() string {
 	}
 	if m.commandActive {
 		content = lipgloss.JoinVertical(lipgloss.Left, m.renderCommandBar(), content)
+	} else if m.commandFeedback != "" {
+		content = lipgloss.JoinVertical(lipgloss.Left, m.renderCommandFeedbackBar(), content)
 	}
 
 	help := m.renderHelp()
@@ -1048,6 +1052,16 @@ func (m Model) renderCommandBar() string {
 		BorderForeground(lipgloss.Color("39")).
 		Padding(0, 1)
 	body := truncate(fmt.Sprintf(": %s_", m.commandInput), maxInt(1, width-4))
+	return styleForOuterWidth(style, width).Render(body)
+}
+
+func (m Model) renderCommandFeedbackBar() string {
+	width := m.contentWidth()
+	body := truncate(m.commandFeedback, maxInt(1, width-4))
+	style := lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("63")).
+		Padding(0, 1)
 	return styleForOuterWidth(style, width).Render(body)
 }
 
@@ -2037,7 +2051,7 @@ func (m Model) renderDiff() string {
 			visibleCount = len(m.sessions)
 		}
 		if len(m.sessions) < 2 || visibleCount < 2 {
-			hint = i18n.T("diff_need_two")
+			hint = i18n.T("diff_need_two") + "\n" + i18n.T("diff_recovery_hint")
 		} else {
 			hint = i18n.T("diff_select_neighbor")
 		}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1276,6 +1276,26 @@ func TestCommandModeFiltersAndSorts(t *testing.T) {
 	}
 }
 
+func TestCommandFeedbackRendersAcrossMajorViews(t *testing.T) {
+	for _, v := range []view{viewOverview, viewList, viewDetail, viewDiagnostics, viewDiff} {
+		m := resizeForTest(t, sampleModelForTest(), 100, 30)
+		m.view = v
+		if v == viewDetail {
+			m.openDetail()
+		}
+		if v == viewDiff {
+			m.diffResult = engine.DiffSessions(m.sessions[0], m.sessions[1])
+		}
+
+		m.runCommand("sort cost desc")
+
+		rendered := m.View()
+		if !strings.Contains(rendered, strings.TrimSpace(m.commandFeedback)) {
+			t.Fatalf("expected command feedback in view=%d, got:\n%s", v, rendered)
+		}
+	}
+}
+
 func TestCostFilterUsesSafeDisplayValue(t *testing.T) {
 	m := sampleModelForTest()
 	m.sessions[0].Metrics.CostEstimated = math.Inf(1)
@@ -2077,6 +2097,9 @@ func TestDiffEmptyStateExplainsSingleVisibleSession(t *testing.T) {
 	if !strings.Contains(rendered, strings.TrimSpace(i18n.T("diff_need_two"))) {
 		t.Fatalf("expected single-visible diff hint, got:\n%s", rendered)
 	}
+	if !strings.Contains(rendered, strings.TrimSpace(i18n.T("diff_recovery_hint"))) {
+		t.Fatalf("expected diff recovery hint, got:\n%s", rendered)
+	}
 	if strings.Contains(rendered, strings.TrimSpace(i18n.T("diff_select_neighbor"))) {
 		t.Fatalf("diff empty state should not ask for a neighbor when only one row is visible:\n%s", rendered)
 	}
@@ -2168,6 +2191,25 @@ func TestAppendSessionKeepsFilteredRowsInSync(t *testing.T) {
 	}
 	if idx := m.findSessionIndex(); idx < 0 || m.sessions[idx].Name != "match" {
 		t.Fatalf("appended filtered row selected wrong session: idx=%d", idx)
+	}
+}
+
+func TestLoadingQuitStopsImmediately(t *testing.T) {
+	m := resizeForTest(t, New("__missing_test_sessions__"), 100, 30)
+	m.loading = true
+	m.loadQueue = []string{"/tmp/session-a.jsonl", "/tmp/session-b.jsonl"}
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	got := next.(Model)
+
+	if cmd == nil {
+		t.Fatalf("expected quit command")
+	}
+	if got.loading {
+		t.Fatalf("loading should stop immediately after q")
+	}
+	if len(got.loadQueue) != 0 {
+		t.Fatalf("load queue should be cleared after q, got %d", len(got.loadQueue))
 	}
 }
 


### PR DESCRIPTION
Closes #113

## Summary
- Make loading quits feel more immediate by reducing progressive load batch size and clearing loading state/queue before returning `tea.Quit`.
- Add an actionable diff empty-state recovery hint when fewer than two sessions are visible.
- Render command feedback through a consistent cross-view status bar for overview, list, detail, diagnostics, and diff views.

## User value
- Large local scans respond more predictably to quit input.
- Diff empty states now explain both why comparison is unavailable and how to recover.
- Command results are visible in the same place across major TUI views, improving Developer experience during keyboard-first triage.

## Scope
- TUI loading behavior.
- TUI diff empty-state copy.
- TUI command feedback rendering.
- Focused regression tests for the above.

## Changed files
- `internal/tui/tui.go`
- `internal/tui/tui_test.go`
- `internal/i18n/i18n.go`

## Test plan
- `go test ./internal/tui`
- `go test ./...`
- `go build -o /tmp/agenttrace-parser-check ./cmd/agenttrace`
- `/tmp/agenttrace-parser-check --doctor || true`
- `/tmp/agenttrace-parser-check --demo --overview -f json`

## Fixture/privacy note
- No real user session content, prompts, tokens, secrets, or logs were added.
- Tests use existing synthetic TUI sample sessions and temporary paths only.

## Risk
- Low to medium. Smaller load batches improve input responsiveness but may slightly increase the number of progressive loading steps for very large scans.
- Command feedback now occupies a visible status row while feedback is present; existing terminal-fit tests still pass.

## Non-goals
- No metric, parser, health, cost, or anomaly calculation changes.
- No redesign of TUI navigation.
- No release automation or packaging changes.

## Blackboard events
- Claimed #113 with an Issue comment.
- Moved #113 from `status/ready-for-agent` to `status/in-progress`.
- Pushed branch `impl/113-tui-polish-feedback`.
- Added progress comment with changed files and partial validation.

## Handoff suggestion: Growth
- Mention the TUI polish in release notes or demo copy if this lands, especially the clearer diff recovery hint and cross-view command feedback.
