### PR TITLE
[Growth] Release follow-up for polished TUI demo path and assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+## Unreleased
+
+These notes cover changes merged after `v0.3.48`, the latest public release.
+They are release-draft notes for the default branch and are not a published tag
+yet.
+
+### Changed
+
+- Polished the first-run TUI demo path with clearer selected-session context,
+  scan-friendly status text, refreshed demo assets, and an updated recording
+  script. (#91)
+- Improved TUI feedback around loading, empty diff states, and command-mode
+  results so users get immediate guidance while navigating. (#122)
+- Made `--waste` use the same latest-session selection behavior as `--latest`,
+  reuse loaded diagnostics, and show clearer waste-report copy. (#95)
+
+### Fixed
+
+- Stabilized overview report ordering for recent sessions and anomaly tie
+  breakers across JSON, Markdown, and HTML outputs. (#104)
+- Aligned overview aggregate metrics with TUI discovery, including cache
+  read/write tokens in the exported totals. (#114)
+- Clamped loop waste so reported waste cannot exceed total session cost. (#116)
+- Aligned TUI cache status wording with `agenttrace --doctor`. (#117)
+- Isolated auto-discovery tests from runner-specific environment configuration.
+  (#120)
+
+### Validation
+
+- Added repeatable CI gates for output contracts, deterministic demo output,
+  report semantics, release surfaces, and Pages artifacts. (#118)
+- Documented the launch-kit validation gates and release consistency checklist
+  for public demo and install surfaces. (#115, #121)


### PR DESCRIPTION
Closes #93

## Summary

- Add `CHANGELOG.md` with Unreleased release-draft notes for post-`v0.3.48` merged work.
- Group the already-merged demo/TUI, report correctness, cache/status, test isolation, and validation-gate changes without claiming they are published in a tag.
- Leave the latest public release at `v0.3.48`; no tag or GitHub release is created from this PR.

## User-facing value

Users and maintainers can see which default-branch improvements are ready for the next release while install surfaces still point at the latest shipped version.

## Adoption rationale

A clear unreleased changelog reduces branch-vs-release ambiguity for README, site, demo assets, and release-note preparation.

## Scope

- Documentation only: `CHANGELOG.md`.
- No Go source, parser, generated report logic, installer automation, assets, or workflow files changed.

## Test plan

- `git diff --check`
- `markdownlint CHANGELOG.md README.md docs/**/*.md || true` (local `markdownlint` is not installed: `command not found`)
- `go test ./...`
- `go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace`
- `/tmp/agenttrace-growth-check --doctor`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check scripts/ci/check-report-semantics.sh`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`

## Safety checklist

- [x] Growth write scope only.
- [x] No release, tag, or merge performed.
- [x] No external community posting or commenting.
- [x] No forbidden public growth phrasing added.
- [x] No `CLAUDE.md` update needed; none exists in this worktree.

## Release action

None. This PR prepares release notes for already-merged work only; a release still needs explicit release approval and the normal validation checklist.