### PR TITLE
[Growth] Add install freshness guidance for stale Homebrew links

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ Recommended when you prefer package-manager upgrades:
 brew install luoyuctl/tap/agenttrace
 ```
 
+If Homebrew is current but your shell still reports an older binary, confirm the
+local version first:
+
+```bash
+agenttrace --version
+agenttrace --doctor
+brew update && brew upgrade luoyuctl/tap/agenttrace
+which agenttrace
+```
+
 ### Go install
 
 Recommended when your `$GOBIN` or `$GOPATH/bin` is already on `PATH`:


### PR DESCRIPTION
Closes #94

## Summary

- Add a compact README note under Homebrew for stale local binaries.
- Show users how to compare `agenttrace --version` / `agenttrace --doctor`, refresh the Homebrew install, and confirm which binary their shell resolves.

## User-facing value

Homebrew users can quickly tell whether a version mismatch comes from a stale local link instead of a stale release surface.

## Adoption rationale

This keeps first-run and demo troubleshooting lightweight while reducing confusion around install freshness after new releases.

## Scope

- Documentation only: `README.md`.
- No installer behavior, release automation, npm publish, Go source, assets, or workflows changed.

## Test plan

- `git diff --check`
- `markdownlint README.md docs/**/*.md || true` (local `markdownlint` is not installed: `command not found`)
- `go test ./... || true`
- `go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace || true`
- `/tmp/agenttrace-growth-check --doctor || true`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`

## Safety checklist

- [x] Growth write scope only.
- [x] No release, tag, or merge performed.
- [x] No external community posting or commenting.
- [x] No forbidden public goal wording added.
- [x] No `CLAUDE.md` update needed; none exists in this worktree.

## Release action

None.