### PR TITLE
Fix session list metrics and tool warnings

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2240,10 +2240,12 @@ func localizedToolWarningDetail(tw ToolWarning) string {
 		return fmt.Sprintf(i18n.T("tool_warn_dead_loop_detail"), tw.ToolName, tw.Count)
 	case "empty_args":
 		return fmt.Sprintf(i18n.T("tool_warn_empty_args_detail"), tw.ToolName, tw.Count)
+	case "invalid_args":
+		return fmt.Sprintf(i18n.T("tool_warn_invalid_args_detail"), tw.ToolName, tw.Count)
 	case "fail_retry_chain":
 		return fmt.Sprintf(i18n.T("tool_warn_fail_retry_detail"), tw.ToolName, tw.Count)
 	case "redundant":
-		return fmt.Sprintf(i18n.T("tool_warn_redundant"), tw.ToolName, tw.Count)
+		return fmt.Sprintf(i18n.T("tool_warn_redundant_detail"), tw.ToolName, tw.Count)
 	default:
 		return ""
 	}
@@ -3219,7 +3221,7 @@ func AnalyzeHealthTrend(sessions []Session) HealthTrend {
 // ToolWarning 工具使用警告
 type ToolWarning struct {
 	ToolName string
-	Pattern  string // "dead_loop"/"empty_args"/"fail_retry_chain"/"redundant"
+	Pattern  string // "dead_loop"/"empty_args"/"invalid_args"/"fail_retry_chain"/"redundant"
 	Count    int    // 出现次数
 	Detail   string // 详细描述
 	Severity string
@@ -3228,114 +3230,126 @@ type ToolWarning struct {
 // ValidateToolPatterns 分析事件流中的工具调用模式，检测异常使用模式。
 func ValidateToolPatterns(events []Event) []ToolWarning {
 	var warnings []ToolWarning
-
-	// dead_loop: 同一 tool 连续调用 5+ 次（不管参数）
-	type consecKey struct {
-		name string
+	addWarning := func(name, pattern string, count int, severity string) {
+		if strings.TrimSpace(name) == "" || count <= 0 {
+			return
+		}
+		warning := ToolWarning{ToolName: name, Pattern: pattern, Count: count, Severity: severity}
+		warning.Detail = localizedToolWarningDetail(warning)
+		warnings = append(warnings, warning)
 	}
-	var lastTool string
+
+	// dead_loop: 同一 tool 用同一参数连续调用，才认为可能卡住。
+	var lastKey, lastTool string
 	consecutive := 0
+	flushLoop := func() {
+		if consecutive >= 4 && lastTool != "" {
+			addWarning(lastTool, "dead_loop", consecutive, "high")
+		}
+	}
 	for _, ev := range events {
+		if ev.Role == "user" {
+			flushLoop()
+			lastKey, lastTool = "", ""
+			consecutive = 0
+			continue
+		}
 		if ev.Role == "assistant" && len(ev.ToolCalls) > 0 {
 			for _, tc := range ev.ToolCalls {
-				if tc.Name == lastTool {
+				key := toolCallPatternKey(tc)
+				if key == lastKey {
 					consecutive++
 				} else {
-					if consecutive >= 5 {
-						warnings = append(warnings, ToolWarning{
-							ToolName: lastTool,
-							Pattern:  "dead_loop",
-							Count:    consecutive,
-							Detail:   fmt.Sprintf(i18n.T("tool_warn_dead_loop_detail"), lastTool, consecutive),
-							Severity: "high",
-						})
-					}
+					flushLoop()
 					consecutive = 1
+					lastKey = key
 					lastTool = tc.Name
 				}
 			}
 		}
 	}
-	// 检查最后一段
-	if consecutive >= 5 && lastTool != "" {
-		warnings = append(warnings, ToolWarning{
-			ToolName: lastTool,
-			Pattern:  "dead_loop",
-			Count:    consecutive,
-			Detail:   fmt.Sprintf(i18n.T("tool_warn_dead_loop_detail"), lastTool, consecutive),
-			Severity: "high",
-		})
-	}
+	flushLoop()
 
-	// empty_args: tool call 时 content 为空或 "{}"（近似检测）
+	// args: 只看真实 tool args，不再用 assistant content 近似推断。
 	emptyCounts := make(map[string]int)
+	invalidCounts := make(map[string]int)
 	for _, ev := range events {
 		if ev.Role == "assistant" && len(ev.ToolCalls) > 0 {
-			if ev.Content == "" || ev.Content == "{}" {
-				for _, tc := range ev.ToolCalls {
+			for _, tc := range ev.ToolCalls {
+				args := strings.TrimSpace(tc.Args)
+				if (args == "" || args == "{}") && toolRequiresArgs(tc.Name) {
 					emptyCounts[tc.Name]++
+					continue
+				}
+				if looksLikeStructuredArgs(args) && !json.Valid([]byte(args)) {
+					invalidCounts[tc.Name]++
 				}
 			}
 		}
 	}
 	for name, count := range emptyCounts {
-		if count > 0 {
-			warnings = append(warnings, ToolWarning{
-				ToolName: name,
-				Pattern:  "empty_args",
-				Count:    count,
-				Detail:   fmt.Sprintf(i18n.T("tool_warn_empty_args_detail"), name, count),
-				Severity: "medium",
-			})
-		}
+		addWarning(name, "empty_args", count, "medium")
+	}
+	for name, count := range invalidCounts {
+		addWarning(name, "invalid_args", count, "medium")
 	}
 
-	// fail_retry_chain: 失败后立即重试同一 tool 3+ 次
-	type failRetry struct {
-		lastFail string
-		chain    int
-		started  bool
+	// fail_retry_chain: 同一 tool 连续产生失败结果，才算失败重试链。
+	toolByID := make(map[string]string)
+	lastFailedTool := ""
+	failureChain := 0
+	flushFailureChain := func() {
+		if failureChain >= 3 && lastFailedTool != "" {
+			addWarning(lastFailedTool, "fail_retry_chain", failureChain, "high")
+		}
 	}
-	var fr failRetry
 	for _, ev := range events {
-		if ev.Role == "tool" && ev.IsError {
-			// 尝试找到关联的 tool call（通过 ToolCallID 或最近的 tool call）
-			fr.lastFail = ""
-			fr.chain = 0
-			fr.started = true
-		} else if ev.Role == "assistant" && len(ev.ToolCalls) > 0 && fr.started {
+		if ev.Role == "assistant" && len(ev.ToolCalls) > 0 {
 			for _, tc := range ev.ToolCalls {
-				if tc.Name == fr.lastFail || fr.lastFail == "" {
-					fr.lastFail = tc.Name
-					fr.chain++
-				} else {
-					if fr.chain >= 3 {
-						warnings = append(warnings, ToolWarning{
-							ToolName: fr.lastFail,
-							Pattern:  "fail_retry_chain",
-							Count:    fr.chain,
-							Detail:   fmt.Sprintf(i18n.T("tool_warn_fail_retry_detail"), fr.lastFail, fr.chain),
-							Severity: "high",
-						})
-					}
-					fr.lastFail = tc.Name
-					fr.chain = 1
+				if strings.TrimSpace(tc.ID) != "" {
+					toolByID[tc.ID] = tc.Name
 				}
 			}
+			continue
+		}
+		if ev.Role == "user" {
+			flushFailureChain()
+			lastFailedTool = ""
+			failureChain = 0
+			continue
+		}
+		if ev.Role != "tool" || strings.TrimSpace(ev.ToolCallID) == "" {
+			continue
+		}
+		name := toolByID[ev.ToolCallID]
+		if name == "" {
+			continue
+		}
+		if ev.IsError {
+			if name == lastFailedTool {
+				failureChain++
+			} else {
+				flushFailureChain()
+				lastFailedTool = name
+				failureChain = 1
+			}
+			continue
+		}
+		if name == lastFailedTool {
+			flushFailureChain()
+			lastFailedTool = ""
+			failureChain = 0
 		}
 	}
-	if fr.chain >= 3 && fr.lastFail != "" {
-		warnings = append(warnings, ToolWarning{
-			ToolName: fr.lastFail,
-			Pattern:  "fail_retry_chain",
-			Count:    fr.chain,
-			Detail:   fmt.Sprintf(i18n.T("tool_warn_fail_retry_detail"), fr.lastFail, fr.chain),
-			Severity: "high",
-		})
-	}
+	flushFailureChain()
 
-	// redundant: 在不同轮次调用同一 tool 多次（如 read_file 同一文件多次）
-	toolCallTurns := make(map[string][]int) // toolName → turn indices
+	// redundant: 多轮反复调用同一 tool 且参数相同，才算冗余。
+	type redundantStat struct {
+		name  string
+		count int
+		turns map[int]bool
+	}
+	redundant := make(map[string]*redundantStat)
 	turnIdx := 0
 	for _, ev := range events {
 		if ev.Role == "user" {
@@ -3343,30 +3357,110 @@ func ValidateToolPatterns(events []Event) []ToolWarning {
 		}
 		if ev.Role == "assistant" && len(ev.ToolCalls) > 0 {
 			for _, tc := range ev.ToolCalls {
-				toolCallTurns[tc.Name] = append(toolCallTurns[tc.Name], turnIdx)
+				args := normalizeToolArgs(tc.Args)
+				if args == "" {
+					continue
+				}
+				key := toolCallPatternKey(tc)
+				stat := redundant[key]
+				if stat == nil {
+					stat = &redundantStat{name: tc.Name, turns: make(map[int]bool)}
+					redundant[key] = stat
+				}
+				stat.count++
+				stat.turns[turnIdx] = true
 			}
 		}
 	}
-	for name, turns := range toolCallTurns {
-		if len(turns) >= 4 {
-			// 检查是否在多个不同轮次中调用
-			uniqueTurns := make(map[int]bool)
-			for _, t := range turns {
-				uniqueTurns[t] = true
-			}
-			if len(uniqueTurns) >= 3 {
-				warnings = append(warnings, ToolWarning{
-					ToolName: name,
-					Pattern:  "redundant",
-					Count:    len(turns),
-					Detail:   fmt.Sprintf(i18n.T("tool_warn_redundant_detail"), name, len(uniqueTurns), len(turns)),
-					Severity: "low",
-				})
-			}
+	for _, stat := range redundant {
+		if stat.count >= 4 && len(stat.turns) >= 3 {
+			addWarning(stat.name, "redundant", stat.count, "low")
 		}
 	}
 
+	sort.SliceStable(warnings, func(i, j int) bool {
+		if warnings[i].Severity != warnings[j].Severity {
+			return severityRank(warnings[i].Severity) > severityRank(warnings[j].Severity)
+		}
+		if warnings[i].ToolName != warnings[j].ToolName {
+			return warnings[i].ToolName < warnings[j].ToolName
+		}
+		return warnings[i].Pattern < warnings[j].Pattern
+	})
 	return warnings
+}
+
+func severityRank(severity string) int {
+	switch severity {
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}
+
+func toolCallPatternKey(tc ToolCall) string {
+	return tc.Name + "\x00" + normalizeToolArgs(tc.Args)
+}
+
+func normalizeToolArgs(args string) string {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return ""
+	}
+	var v interface{}
+	if json.Unmarshal([]byte(args), &v) == nil {
+		if normalized, err := json.Marshal(v); err == nil {
+			return string(normalized)
+		}
+	}
+	return strings.Join(strings.Fields(args), " ")
+}
+
+func looksLikeStructuredArgs(args string) bool {
+	args = strings.TrimSpace(args)
+	return strings.HasPrefix(args, "{") || strings.HasPrefix(args, "[")
+}
+
+func toolRequiresArgs(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return false
+	}
+	required := []string{
+		"apply_patch",
+		"bash",
+		"click",
+		"edit",
+		"exec_command",
+		"fetch",
+		"find",
+		"grep",
+		"image",
+		"open",
+		"patch",
+		"read",
+		"replace",
+		"rg",
+		"run_command",
+		"scrape",
+		"search",
+		"shell",
+		"terminal",
+		"view",
+		"web",
+		"write",
+	}
+	for _, token := range required {
+		if strings.Contains(name, token) {
+			return true
+		}
+	}
+	return false
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1811,7 +1812,7 @@ func TestAnalyzeHealthTrendUsesSessionTimeOrder(t *testing.T) {
 func TestValidateToolPatterns_DeadLoop(t *testing.T) {
 	events := make([]Event, 6)
 	for i := range events {
-		events[i] = Event{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file"}}}
+		events[i] = Event{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file", Args: `{"path":"README.md"}`}}}
 	}
 	warnings := ValidateToolPatterns(events)
 	for _, w := range warnings {
@@ -1820,6 +1821,49 @@ func TestValidateToolPatterns_DeadLoop(t *testing.T) {
 		}
 	}
 	t.Error("no dead_loop warning for 6 consecutive same tool calls")
+}
+
+func TestValidateToolPatterns_DifferentArgsAreNotDeadLoop(t *testing.T) {
+	events := make([]Event, 6)
+	for i := range events {
+		events[i] = Event{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file", Args: fmt.Sprintf(`{"path":"file%d.md"}`, i)}}}
+	}
+	for _, w := range ValidateToolPatterns(events) {
+		if w.Pattern == "dead_loop" || w.Pattern == "redundant" {
+			t.Fatalf("different args should not trigger %s warning: %+v", w.Pattern, w)
+		}
+	}
+}
+
+func TestValidateToolPatterns_EmptyContentDoesNotMeanEmptyArgs(t *testing.T) {
+	events := []Event{{
+		Role:      "assistant",
+		Content:   "",
+		ToolCalls: []ToolCall{{Name: "read_file", Args: `{"path":"README.md"}`}},
+	}}
+	for _, w := range ValidateToolPatterns(events) {
+		if w.Pattern == "empty_args" {
+			t.Fatalf("assistant content should not be treated as tool args: %+v", w)
+		}
+	}
+}
+
+func TestValidateToolPatterns_ConsecutiveFailedRetries(t *testing.T) {
+	events := []Event{
+		{Role: "assistant", ToolCalls: []ToolCall{{ID: "a", Name: "search", Args: `{"q":"x"}`}}},
+		{Role: "tool", ToolCallID: "a", IsError: true},
+		{Role: "assistant", ToolCalls: []ToolCall{{ID: "b", Name: "search", Args: `{"q":"x"}`}}},
+		{Role: "tool", ToolCallID: "b", IsError: true},
+		{Role: "assistant", ToolCalls: []ToolCall{{ID: "c", Name: "search", Args: `{"q":"x"}`}}},
+		{Role: "tool", ToolCallID: "c", IsError: true},
+	}
+	warnings := ValidateToolPatterns(events)
+	for _, w := range warnings {
+		if w.Pattern == "fail_retry_chain" && w.ToolName == "search" && w.Count == 3 {
+			return
+		}
+	}
+	t.Fatalf("expected fail_retry_chain warning, got %+v", warnings)
 }
 
 func TestValidateToolPatterns_NoIssues(t *testing.T) {

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -724,11 +724,12 @@ var translations = map[string]map[Lang]string{
 	"trend_improving":  {EN: "Improving: %s", ZH: "持续上升: %s"},
 
 	// ── Tool warnings ──
-	"tool_warn_title":      {EN: "⚠️ Tool Warnings", ZH: "⚠️ 工具调用警告"},
-	"tool_warn_dead_loop":  {EN: "%s called %dx consecutively — possible dead loop", ZH: "%s 连续调用 %d 次 — 疑似死循环"},
-	"tool_warn_empty_args": {EN: "%s called with empty arguments", ZH: "%s 调用参数为空"},
-	"tool_warn_retry":      {EN: "%s retried %dx after failures", ZH: "%s 失败后重试 %d 次"},
-	"tool_warn_redundant":  {EN: "%s called %dx with same args — redundant", ZH: "%s 重复调用 %d 次 — 冗余"},
+	"tool_warn_title":        {EN: "⚠️ Tool Warnings", ZH: "⚠️ 工具调用警告"},
+	"tool_warn_dead_loop":    {EN: "%s called %dx consecutively — possible dead loop", ZH: "%s 连续调用 %d 次 — 疑似死循环"},
+	"tool_warn_empty_args":   {EN: "%s called with empty arguments", ZH: "%s 调用参数为空"},
+	"tool_warn_invalid_args": {EN: "%s called with malformed arguments", ZH: "%s 调用参数格式错误"},
+	"tool_warn_retry":        {EN: "%s retried %dx after failures", ZH: "%s 失败后重试 %d 次"},
+	"tool_warn_redundant":    {EN: "%s called %dx with same args — redundant", ZH: "%s 重复调用 %d 次 — 冗余"},
 
 	// ── Prompt impact ──
 	"prompt_impact_title":     {EN: "📝 Prompt Impact", ZH: "📝 Prompt 影响"},
@@ -1101,10 +1102,11 @@ var translations = map[string]map[Lang]string{
 	"fix_no_tools_action":           {EN: "Currently in chat-only mode, consider configuring tools for the agent", ZH: "当前为纯对话模式，考虑为 agent 配置工具以提升效率"},
 
 	// ── Tool pattern validation details ──
-	"tool_warn_dead_loop_detail":  {EN: "Tool '%s' called %dx consecutively — possible dead loop", ZH: "工具 '%s' 连续调用 %d 次，可能存在死循环"},
-	"tool_warn_empty_args_detail": {EN: "Tool '%s' had %d call(s) with empty arguments", ZH: "工具 '%s' 有 %d 次调用参数为空"},
-	"tool_warn_fail_retry_detail": {EN: "Tool '%s' retried %dx after failures", ZH: "工具 '%s' 失败后连续重试 %d 次"},
-	"tool_warn_redundant_detail":  {EN: "Tool '%s' called %dx across %d turns — possibly redundant", ZH: "工具 '%s' 在 %d 个轮次中被调用 %d 次，可能存在冗余调用"},
+	"tool_warn_dead_loop_detail":    {EN: "Tool '%s' called %dx consecutively — possible dead loop", ZH: "工具 '%s' 连续调用 %d 次，可能存在死循环"},
+	"tool_warn_empty_args_detail":   {EN: "Tool '%s' had %d call(s) with empty arguments", ZH: "工具 '%s' 有 %d 次调用参数为空"},
+	"tool_warn_invalid_args_detail": {EN: "Tool '%s' had %d call(s) with malformed arguments", ZH: "工具 '%s' 有 %d 次调用参数格式错误"},
+	"tool_warn_fail_retry_detail":   {EN: "Tool '%s' retried %dx after failures", ZH: "工具 '%s' 失败后连续重试 %d 次"},
+	"tool_warn_redundant_detail":    {EN: "Tool '%s' called %dx with the same arguments — possibly redundant", ZH: "工具 '%s' 用相同参数调用 %d 次，可能存在冗余调用"},
 
 	// ── Cost alert ──
 	"cost_alert_no_history":       {EN: "No historical data for comparison", ZH: "无历史数据用于比较"},

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -834,11 +834,6 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 	healthCol := healthCell(health, healthWidth)
 
 	failStr := fmt.Sprintf("%d", failTools)
-	if failTools > 0 {
-		failStr = redStyle.Render(failStr)
-	} else {
-		failStr = dimStyle.Render(failStr)
-	}
 
 	tokensStr := compactInt(metricsTotalTokens(met))
 	issue := sessionIssueLabel(s)
@@ -849,7 +844,7 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 			sourceDisplay,
 			failStr,
 			fmt.Sprintf("%d", len(s.Anomalies)),
-			costColor(met.CostEstimated),
+			costCell(met.CostEstimated),
 			tokensStr,
 			healthCol,
 		}
@@ -862,7 +857,7 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 			fmt.Sprintf("%d", totalToolCalls),
 			sr,
 			failStr,
-			costColor(met.CostEstimated),
+			costCell(met.CostEstimated),
 			tokensStr,
 			engine.FmtDuration(chartValue(met.DurationSec)),
 			fmt.Sprintf("%d", len(s.Anomalies)),
@@ -878,7 +873,7 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 			fmt.Sprintf("%d", totalToolCalls),
 			sr,
 			failStr,
-			costColor(met.CostEstimated),
+			costCell(met.CostEstimated),
 			tokensStr,
 			engine.FmtDuration(chartValue(met.DurationSec)),
 			fmt.Sprintf("%d", len(s.Anomalies)),
@@ -892,7 +887,7 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 			fmt.Sprintf("%d", totalToolCalls),
 			sr,
 			failStr,
-			costColor(met.CostEstimated),
+			costCell(met.CostEstimated),
 			tokensStr,
 			healthCol,
 			issue,
@@ -904,7 +899,7 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 			fmt.Sprintf("%d", nonNegativeInt(met.AssistantTurns)),
 			fmt.Sprintf("%d", totalToolCalls),
 			failStr,
-			costColor(met.CostEstimated),
+			costCell(met.CostEstimated),
 			tokensStr,
 			healthCol,
 		}
@@ -917,7 +912,7 @@ func (m *Model) sessionRow(s engine.Session) table.Row {
 		fmt.Sprintf("%d", totalToolCalls),
 		sr,
 		failStr,
-		costColor(met.CostEstimated),
+		costCell(met.CostEstimated),
 		tokensStr,
 		healthCol,
 	}
@@ -2252,20 +2247,8 @@ func (m *Model) sortColTitle(base, field string) string {
 	return base + " ▲"
 }
 
-// costColor returns a styled cost string based on amount thresholds.
-func costColor(amount float64) string {
-	amount = safeAmount(amount)
-	s := money4(amount)
-	switch {
-	case amount >= 0.50:
-		return redStyle.Render(s)
-	case amount >= 0.10:
-		return orangeStyle.Render(s)
-	case amount >= 0.03:
-		return yellowStyle.Render(s)
-	default:
-		return greenStyle.Render(s)
-	}
+func costCell(amount float64) string {
+	return money4(safeAmount(amount))
 }
 
 func healthCell(health int, width int) string {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -548,6 +548,9 @@ func TestCompactListKeepsTokensAndHealthReadable(t *testing.T) {
 	if row[2] != "1" || row[3] != "0" {
 		t.Fatalf("expected compact triage signals, got row=%v", row)
 	}
+	if row[4] != "$0.4200" || strings.Contains(row[4], "\x1b") {
+		t.Fatalf("expected compact cost to be stable table text, got %q", row[4])
+	}
 	if row[5] != "214.0K" {
 		t.Fatalf("expected full compact token value, got %q", row[5])
 	}
@@ -602,6 +605,9 @@ func TestWideListKeepsFullOperationalColumns(t *testing.T) {
 	row := m.table.Rows()[0]
 	if row[3] != "8" || row[4] != "12" || row[5] != "92" || row[6] != "1" {
 		t.Fatalf("expected turns/tools/success/fail columns, got row=%v", row)
+	}
+	if row[7] != "$0.4200" || strings.Contains(row[6], "\x1b") || strings.Contains(row[7], "\x1b") {
+		t.Fatalf("expected fail/cost columns to be stable table text, got row=%v", row)
 	}
 	if row[12] != "No major anomaly" {
 		t.Fatalf("expected issue column, got row=%v", row)


### PR DESCRIPTION
Summary
- Keep Fail and Cost session-list cells as plain table text so values remain visible across terminal widths.
- Tighten Tool Warnings to actionable patterns: same-tool same-args loops, real empty/malformed args, consecutive failed retries, and same-args redundant calls across turns.
- Add regression coverage for compact/wide list metrics and warning false positives.

Research note
- Agent observability guidance consistently points to tool success/error rates, argument validation failures, retries, latency/timeouts, and loop detection as useful warning signals.

Test plan
- go test ./internal/engine ./internal/tui
- go test ./...
- go build -o /tmp/agenttrace-session-warnings-check ./cmd/agenttrace
- /tmp/agenttrace-session-warnings-check --demo --overview -f json
- /tmp/agenttrace-session-warnings-check --doctor || true
- AGENTTRACE_BIN=/tmp/agenttrace-session-warnings-check AGENTTRACE_CI_OUT=/tmp/agenttrace-session-warnings-ci scripts/ci/check-report-semantics.sh
- AGENTTRACE_BIN=/tmp/agenttrace-session-warnings-check AGENTTRACE_CI_OUT=/tmp/agenttrace-session-warnings-ci scripts/ci/check-output-contract.sh

Risk
- Tool warnings are intentionally quieter now; broad same-tool-but-different-args workflows no longer show as loops/redundancy.

Non-goals
- No pricing/parser/source format changes.
