### PR TITLE
[Growth] Decide stdout behavior when writing reports with -o

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ agenttrace --update-pricing --list-models
 agenttrace --latest --lang zh    # Chinese (supports zh, en)
 ```
 
+When `-o` is present, agenttrace writes the file and still prints the report body to stdout.
+Saved-file confirmations and gate diagnostics go to stderr, so JSON output remains parseable
+and Markdown/HTML reports can still be piped or previewed.
+
 ### Cursor Import
 
 Cursor keeps local composer/chat state in SQLite `state.vscdb` files. Export the relevant JSON keys once, then point `agenttrace` at the exported file:

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -22,6 +22,10 @@ agenttrace --overview \
 
 The command exits with code `2` when a gate fails. Add `-f json -o agenttrace-overview.json` when CI should upload machine-readable data, `-f markdown -o agenttrace-overview.md` when the report should be pasted into a PR comment, or `-f html -o agenttrace-overview.html` for a self-contained visual artifact.
 
+With `-o`, agenttrace keeps the report body on stdout while also writing the file.
+Saved-file confirmations and gate diagnostics are written to stderr; this keeps JSON stdout
+machine-readable and lets Markdown or HTML output remain useful for logs and previews.
+
 For the first few runs, keep the job non-blocking while still collecting evidence:
 
 ```bash


### PR DESCRIPTION
Closes #96

## Summary
- Document the existing `-o` output contract in README report examples.
- Add the same CI-focused stream guidance to `docs/ci-integration.md`.

## User-facing value
Users can tell that `-o` writes a file while the report body still remains on stdout.

## Adoption rationale
Clear stdout/stderr behavior helps CI and shell automation use JSON, Markdown, and HTML report artifacts without guessing where saved-file or gate diagnostics appear.

## Scope
- Docs only: `README.md`, `docs/ci-integration.md`.
- No CLI behavior, parser behavior, report metrics, release, tag, or package changes.

## Test plan
- `git diff --check`
- `markdownlint README.md docs/**/*.md || true` (tool unavailable locally: `command not found`)
- `go test ./... || true`
- `go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace || true`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-output-contract.sh || true`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-deterministic-output.sh || true`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-report-semantics.sh || true`
- `scripts/ci/check-release-surfaces.sh || true`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-docs-commands.sh || true`
- `scripts/ci/check-pages-artifact.sh site || true`
- `/tmp/agenttrace-growth-check --doctor || true`

## Safety checklist
- [x] Linked Issue exists.
- [x] No Go source, parser, report behavior, workflow, release, tag, or package publishing changes.
- [x] Public copy avoids internal growth-target language.
- [x] JSON plus Markdown/HTML report formats are covered by the docs wording.