### PR TITLE
[Quality] Align overview cost wording

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1495,6 +1495,33 @@ func TestReportOverviewMarkdownIncludesCISummary(t *testing.T) {
 	}
 }
 
+func TestReportOverviewCostLabelUsesEstimatedTotalCost(t *testing.T) {
+	sessions := []Session{{
+		Name:   "demo",
+		Health: 88,
+		Metrics: Metrics{
+			SourceTool:    "codex_cli",
+			ModelUsed:     "gpt-5.1",
+			TokensInput:   1000,
+			TokensOutput:  500,
+			CostEstimated: 0.42,
+		},
+	}}
+	ov := ComputeOverview(sessions)
+	for name, out := range map[string]string{
+		"text":     ReportOverview(ov, sessions),
+		"markdown": ReportOverviewMarkdown(ov, sessions),
+		"html":     ReportOverviewHTML(ov, sessions),
+	} {
+		if !strings.Contains(out, "Total estimated cost") {
+			t.Fatalf("%s overview missing estimated total cost label:\n%s", name, out)
+		}
+		if strings.Contains(out, "Money Wasted") {
+			t.Fatalf("%s overview kept old waste wording:\n%s", name, out)
+		}
+	}
+}
+
 func assertOrderedSubstrings(t *testing.T, haystack string, needles []string) {
 	t.Helper()
 	last := -1

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -572,8 +572,8 @@ var translations = map[string]map[Lang]string{
 		ZH: "检测到异常",
 	},
 	"total_cost": {
-		EN: "Money Wasted",
-		ZH: "烧掉的钱",
+		EN: "Total estimated cost",
+		ZH: "估算总费用",
 	},
 	"health_trend": {
 		EN: "Health Trend",

--- a/scripts/ci/check-report-semantics.sh
+++ b/scripts/ci/check-report-semantics.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 bin="${AGENTTRACE_BIN:-/tmp/agenttrace}"
 out_dir="${AGENTTRACE_CI_OUT:-/tmp/agenttrace-ci}"
-expected_cost_label="${AGENTTRACE_EXPECTED_COST_LABEL:-Money Wasted}"
+expected_cost_label="${AGENTTRACE_EXPECTED_COST_LABEL:-Total estimated cost}"
 
 fail() {
   echo "check-report-semantics: $*" >&2

--- a/site/demo-report.html
+++ b/site/demo-report.html
@@ -24,7 +24,7 @@ section{border:1px solid var(--line);background:rgba(16,20,25,.78);padding:20px;
 <div class="metric"><span>Sessions</span><strong>3</strong><p>1 Healthy / 1 Warning / 1 Critical</p></div>
 <div class="metric"><span>Total tokens</span><strong>278200</strong><p>+ live</p></div>
 <div class="metric"><span>Average health</span><strong>58.7</strong><p>Fleet quality score</p></div>
-<div class="metric"><span>Money Wasted</span><strong>$0.81</strong><p>Estimated session cost</p></div>
+<div class="metric"><span>Total estimated cost</span><strong>$0.81</strong><p>Estimated session cost</p></div>
 <div class="metric bad"><span>Tool failures</span><strong>3/5</strong><p>60.0% failure rate</p></div>
 </div>
 <section><h2>Health Trend</h2><p>Declining: 100→66</p></section>


### PR DESCRIPTION
Closes #100.

## Summary
- Rename general overview/report cost label from `Money Wasted` to `Total estimated cost`.
- Keep JSON `summary.total_cost` and all cost calculations unchanged.
- Update report semantic CI default and static demo HTML sample.
- Add coverage for text, Markdown, and HTML overview wording.

## Validation
- `go test ./internal/engine ./internal/i18n`
- `go build -o /tmp/agenttrace-issue-100 ./cmd/agenttrace`
- `go test ./...`
- `/tmp/agenttrace-issue-100 --doctor || true`
- `/tmp/agenttrace-issue-100 --demo --overview -f json`
- `/tmp/agenttrace-issue-100 --demo --overview`
- `/tmp/agenttrace-issue-100 --demo --overview -f markdown`
- `/tmp/agenttrace-issue-100 --demo --overview -f html`
- `AGENTTRACE_BIN=/tmp/agenttrace-issue-100 AGENTTRACE_CI_OUT=/tmp/agenttrace-issue-100-semantics scripts/ci/check-report-semantics.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-issue-100 AGENTTRACE_CI_OUT=/tmp/agenttrace-issue-100-contract scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-issue-100 AGENTTRACE_CI_OUT=/tmp/agenttrace-issue-100-det scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-issue-100 AGENTTRACE_CI_OUT=/tmp/agenttrace-issue-100-docs scripts/ci/check-docs-commands.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-issue-100 AGENTTRACE_CI_OUT=/tmp/agenttrace-issue-100-rel scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`

Risk: Low. Narrow copy and golden-check update only; no parser, layout, CI gate, or calculation behavior change.