### PR TITLE
[Impl] Improve updated pricing model list UX

### DIFF
--- a/cmd/agenttrace/main.go
+++ b/cmd/agenttrace/main.go
@@ -105,17 +105,7 @@ func main() {
 
 	// List models
 	if *listModels {
-		fmt.Printf(i18n.T("supported_models")+"\n", engine.Version)
-		fmt.Println(strings.Repeat("=", 58))
-		fmt.Printf("  %-22s %10s %10s\n", i18n.T("model_header"), i18n.T("input_per_m"), i18n.T("output_per_m"))
-		fmt.Println("  " + strings.Repeat("-", 44))
-		for k, v := range engine.ListPricing() {
-			fmt.Printf("  %-22s $%8.2f  $%8.2f\n", k, v.Input, v.Output)
-		}
-		fmt.Println()
-		fmt.Printf(i18n.T("default_model_label")+"\n",
-			engine.LookupPrice("default").Input, engine.LookupPrice("default").Output)
-		fmt.Println("  " + engine.PricingSource())
+		fmt.Print(renderModelPricingList(engine.Version, engine.PricingSource(), engine.ListPricing(), engine.LookupPrice("default")))
 		return
 	}
 

--- a/cmd/agenttrace/pricing_list.go
+++ b/cmd/agenttrace/pricing_list.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/luoyuctl/agenttrace/internal/engine"
+	"github.com/luoyuctl/agenttrace/internal/i18n"
+)
+
+var commonPricingModels = []string{
+	"claude-sonnet-4",
+	"claude-opus-4.5",
+	"gpt-5.1",
+	"gpt-5.1-mini",
+	"gpt-4.1",
+	"gpt-4.1-mini",
+	"gemini-2.5-pro",
+	"gemini-2.5-flash",
+	"deepseek-chat",
+	"deepseek-reasoner",
+	"grok-code-fast-1",
+}
+
+func renderModelPricingList(version, source string, prices map[string]engine.Price, defaultPrice engine.Price) string {
+	names := sortedPricingNames(prices)
+	nameWidth := pricingNameWidth(names)
+	var b strings.Builder
+
+	fmt.Fprintf(&b, i18n.T("supported_models")+"\n", version)
+	fmt.Fprintln(&b, strings.Repeat("=", maxPricingInt(58, nameWidth+28)))
+	fmt.Fprintf(&b, "%s: %s\n", i18n.T("pricing_source_label"), source)
+	fmt.Fprintf(&b, i18n.T("pricing_catalog_hint")+"\n", len(names))
+	fmt.Fprintln(&b)
+
+	fmt.Fprintln(&b, i18n.T("pricing_common_section"))
+	writePricingHeader(&b, nameWidth)
+	fmt.Fprintf(&b, "  %-*s $%8.2f  $%8.2f\n", nameWidth, "default", defaultPrice.Input, defaultPrice.Output)
+	for _, name := range commonPricingModels {
+		price, ok := prices[name]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&b, "  %-*s $%8.2f  $%8.2f\n", nameWidth, name, price.Input, price.Output)
+	}
+	fmt.Fprintln(&b)
+
+	fmt.Fprintf(&b, i18n.T("pricing_full_catalog_section")+"\n", len(names))
+	writePricingHeader(&b, nameWidth)
+	for _, name := range names {
+		price := prices[name]
+		fmt.Fprintf(&b, "  %-*s $%8.2f  $%8.2f\n", nameWidth, name, price.Input, price.Output)
+	}
+	fmt.Fprintln(&b)
+	return b.String()
+}
+
+func sortedPricingNames(prices map[string]engine.Price) []string {
+	names := make([]string, 0, len(prices))
+	for name := range prices {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func pricingNameWidth(names []string) int {
+	width := len(i18n.T("model_header"))
+	for _, name := range names {
+		if len(name) > width {
+			width = len(name)
+		}
+	}
+	if width < 22 {
+		return 22
+	}
+	return width
+}
+
+func writePricingHeader(b *strings.Builder, nameWidth int) {
+	fmt.Fprintf(b, "  %-*s %10s %10s\n", nameWidth, i18n.T("model_header"), i18n.T("input_per_m"), i18n.T("output_per_m"))
+	fmt.Fprintf(b, "  %s\n", strings.Repeat("-", nameWidth+24))
+}
+
+func maxPricingInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/cmd/agenttrace/pricing_list_test.go
+++ b/cmd/agenttrace/pricing_list_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luoyuctl/agenttrace/internal/engine"
+	"github.com/luoyuctl/agenttrace/internal/i18n"
+)
+
+func TestRenderModelPricingListPrioritizesCommonModelsBeforeFullCatalog(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.EN)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	out := renderModelPricingList("test", "LiteLLM (cached now)", map[string]engine.Price{
+		"databricks-gpt-oss-120b": {Input: 0.10, Output: 0.20},
+		"claude-sonnet-4":         {Input: 3.00, Output: 15.00},
+		"aaa-provider-model":      {Input: 0.01, Output: 0.02},
+	}, engine.Price{Input: 3.00, Output: 15.00})
+
+	for _, want := range []string{
+		"Source: LiteLLM (cached now)",
+		"Common/default pricing",
+		"Full pricing catalog (3 models)",
+		"databricks-gpt-oss-120b",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("pricing list missing %q:\n%s", want, out)
+		}
+	}
+
+	commonIdx := strings.Index(out, "Common/default pricing")
+	commonModelIdx := strings.Index(out, "claude-sonnet-4")
+	fullIdx := strings.Index(out, "Full pricing catalog")
+	if commonIdx < 0 || commonModelIdx < commonIdx || commonModelIdx > fullIdx {
+		t.Fatalf("common model should appear in the quick-scan section before full catalog:\n%s", out)
+	}
+
+	full := out[fullIdx:]
+	if strings.Index(full, "aaa-provider-model") > strings.Index(full, "databricks-gpt-oss-120b") {
+		t.Fatalf("full catalog should be sorted by model name:\n%s", full)
+	}
+}
+
+func TestRenderModelPricingListKeepsFallbackDefaultVisible(t *testing.T) {
+	prev := i18n.Current
+	i18n.SetLang(i18n.EN)
+	t.Cleanup(func() { i18n.SetLang(prev) })
+
+	out := renderModelPricingList("test", "built-in fallback (use --update-pricing for latest)", map[string]engine.Price{
+		"qwen2p5-coder-32b-instruct-128k": {Input: 0.20, Output: 0.80},
+	}, engine.Price{Input: 3.00, Output: 15.00})
+
+	for _, want := range []string{
+		"Source: built-in fallback",
+		"default",
+		"$    3.00",
+		"qwen2p5-coder-32b-instruct-128k",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("fallback pricing list missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1076,6 +1076,21 @@ func TestSessionCachePathUsesOverride(t *testing.T) {
 	}
 }
 
+func TestPricingSourceLabelsStaleLiteLLMCache(t *testing.T) {
+	prev := dynamicPricing
+	dynamicPricing = &pricingStore{
+		entries:  map[string]Price{"gpt-test": {Input: 1, Output: 2}},
+		loadedAt: time.Date(2026, 5, 4, 9, 0, 0, 0, time.UTC),
+		source:   "cache(stale)",
+	}
+	t.Cleanup(func() { dynamicPricing = prev })
+
+	got := PricingSource()
+	if !strings.Contains(got, "LiteLLM") || !strings.Contains(got, "stale cache") {
+		t.Fatalf("stale cache should still be labeled as LiteLLM datasource, got %q", got)
+	}
+}
+
 func TestWasteReportTextLocalizesSuggestionLabel(t *testing.T) {
 	prev := i18n.Current
 	i18n.SetLang(i18n.ZH)

--- a/internal/engine/pricing.go
+++ b/internal/engine/pricing.go
@@ -261,6 +261,8 @@ func PricingSource() string {
 		return fmt.Sprintf(i18n.T("pricing_litellm_fetched"), dynamicPricing.loadedAt.Format("2006-01-02 15:04"))
 	case "cache":
 		return fmt.Sprintf(i18n.T("pricing_litellm_cached"), dynamicPricing.loadedAt.Format("2006-01-02 15:04"))
+	case "cache(stale)":
+		return fmt.Sprintf(i18n.T("pricing_litellm_stale"), dynamicPricing.loadedAt.Format("2006-01-02 15:04"))
 	default:
 		return "built-in fallback (use --update-pricing for latest)"
 	}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -1177,7 +1177,15 @@ var translations = map[string]map[Lang]string{
 	// ── Pricing ──
 	"pricing_litellm_fetched": {EN: "LiteLLM (fetched %s)", ZH: "LiteLLM (获取于 %s)"},
 	"pricing_litellm_cached":  {EN: "LiteLLM (cached %s)", ZH: "LiteLLM (缓存于 %s)"},
+	"pricing_litellm_stale":   {EN: "LiteLLM (stale cache %s)", ZH: "LiteLLM (过期缓存 %s)"},
 	"pricing_save_warning":    {EN: "Warning: failed to save pricing cache: %v\n", ZH: "警告: 保存定价缓存失败: %v\n"},
+	"pricing_source_label":    {EN: "Source", ZH: "来源"},
+	"pricing_catalog_hint":    {EN: "%d model prices loaded. Common/default models are shown first; the complete catalog follows.", ZH: "已加载 %d 个模型定价。常用/默认模型优先展示，完整目录随后列出。"},
+	"pricing_common_section":  {EN: "Common/default pricing", ZH: "常用/默认模型定价"},
+	"pricing_full_catalog_section": {
+		EN: "Full pricing catalog (%d models)",
+		ZH: "完整定价目录（%d 个模型）",
+	},
 
 	// ── Impact labels (for prompt impact) ──
 	"impact_positive":      {EN: "positive", ZH: "正面"},


### PR DESCRIPTION
Closes #106

## Summary
- Rework `--list-models` output into a stable, source-labeled pricing view.
- Show common/default coding-agent models first for quick scanning.
- Keep the complete pricing catalog reachable below, sorted by model name.
- Preserve LiteLLM datasource pricing for updated pricing and label stale LiteLLM cache as LiteLLM rather than built-in fallback.

## User value
Users can confirm the active pricing datasource and quickly find default/common model prices without losing access to the full LiteLLM-derived catalog.

## Scope
- CLI presentation for `--list-models` and `--update-pricing --list-models`.
- Pricing source labeling for stale LiteLLM cache.
- Tests for common-model priority, full catalog sorting, fallback visibility, and stale cache labeling.

## Changed files
- `cmd/agenttrace/main.go`
- `cmd/agenttrace/pricing_list.go`
- `cmd/agenttrace/pricing_list_test.go`
- `internal/engine/pricing.go`
- `internal/engine/engine_test.go`
- `internal/i18n/i18n.go`

## Test plan
- `go test ./cmd/agenttrace ./internal/engine ./internal/i18n`
- `go test ./...`
- `go build -o /tmp/agenttrace-parser-check ./cmd/agenttrace`
- `HOME=$(mktemp -d) /tmp/agenttrace-parser-check --list-models | sed -n '1,12p'`
- `HOME=$(mktemp -d) /tmp/agenttrace-parser-check --update-pricing --list-models | sed -n '1,14p'`
- `/tmp/agenttrace-parser-check --doctor || true`
- `/tmp/agenttrace-parser-check --demo --overview -f json`
- `git diff --check`

## Fixture/privacy note
No real session logs, prompts, token payloads, secrets, or user traces were added. Pricing-list tests use small synthetic in-memory price maps. The temporary `--update-pricing --list-models` validation used a throwaway HOME/cache directory.

## Risk
Low to medium. This changes CLI list presentation but not pricing calculation, LiteLLM download behavior, cache schema, parser compatibility, or report contracts.

## Non-goals
- No pricing calculation changes.
- No LiteLLM cache schema changes.
- No new network dependency beyond the existing `--update-pricing` path.
- No filtering flags or pagination in this PR.

## Blackboard events
- Claimed #106 after Product handoff and maintainer direction that LiteLLM datasource pricing must remain canonical for updated pricing.
- Self-healed from stale local branch `impl/111-large-dataset-scanability` because PR #127 was merged and the origin branch was pruned.
- Created and pushed `impl/106-litellm-pricing-list` from `origin/master`.

## Release impact
- CLI behavior: yes, `--list-models` output is now grouped and sorted with datasource labeling.
- Parser/source compatibility: no.
- JSON/Markdown/HTML report contract: no.
- TUI visible behavior: no.
- Install/package docs: no.

## Handoff suggestion: Growth
Suggested release note: `--list-models` now shows default/common model pricing first while preserving the full sorted LiteLLM pricing catalog and clearer datasource labels.
Validation commands: see Test plan.
Risk: users relying on exact text layout of `--list-models` may need to adapt, but the command remains plain text and full catalog access is preserved.
