### PR TITLE
[codex] Polish README and product page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,29 @@
   <img src="https://img.shields.io/badge/Homebrew-v0.4.0-2bbc8a.svg" alt="Homebrew">
 </p>
 
-<h3 align="center">💸 Stop burning cash and hours on invisible AI agent waste</h3>
+<h3 align="center">💸 See where AI coding agents burn tokens, time, and trust</h3>
 
 ---
 
 ## What is agenttrace?
 
-AI coding agents (Claude Code, Gemini CLI, Codex CLI) burn tokens in loops, retry failures silently, and leave you with a surprise bill. You're wasting **money** on dead tokens and **time** on broken sessions — and you can't even see where.
+AI coding agents are now part of the build loop. They plan, call tools, retry failures, hit long gaps, and spend tokens while you only see the final answer.
 
-**agenttrace** finds the waste in both — so you stop paying for nothing and start shipping faster.
+**agenttrace** is a local TUI and report generator that reads the session logs already on your machine and turns them into health scores, cost evidence, anomaly detection, diffs, and CI gates.
+
+In the built-in demo, one command surfaces the exact kind of waste teams miss:
+
+- **278,200 tokens** across 3 sessions
+- **$0.81 estimated cost**
+- **60% tool failure rate**
+- **1 critical session** with hanging, shallow thinking, and tool failures
+- a health trend that drops from **100 → 66**
 
 Site: https://luoyuctl.github.io/agenttrace/
 
 Sample HTML report: https://luoyuctl.github.io/agenttrace/demo-report.html
 
-Featured in: [Awesome Codex CLI](https://github.com/RoggeOhta/awesome-codex-cli), [Awesome Gemini CLI](https://github.com/Piebald-AI/awesome-gemini-cli), [Charm in the Wild](https://github.com/charm-and-friends/charm-in-the-wild), [Awesome Claude Code and Skills](https://github.com/GetBindu/awesome-claude-code-and-skills), and [Awesome AI Agents](https://github.com/ARUNAGIRINATHAN-K/awesome-ai-agents).
+Listed in: [Awesome Gemini CLI](https://github.com/Piebald-AI/awesome-gemini-cli), [Charm in the Wild](https://github.com/charm-and-friends/charm-in-the-wild), and [Awesome Claude Code and Skills](https://github.com/GetBindu/awesome-claude-code-and-skills).
 
 <p align="center">
   <img src="assets/agenttrace-demo.gif" alt="agenttrace TUI demo" width="100%">
@@ -39,7 +47,7 @@ The GIF follows the shortest first-run path: demo data -> critical sessions -> d
 
 ## Why it exists
 
-AI agents now behave like tiny build systems: they plan, call tools, retry, hang, and spend money while doing it. Most teams only see the final output, not the session health, token burn, tool failure rate, or whether the agent got stuck. agenttrace gives that missing operational view in the terminal.
+High-star CLI tools win because they make a painful workflow visible, fast, and local. agenttrace does that for AI agent sessions: open a terminal, sort the worst run, inspect the evidence, and decide whether the fix is a prompt, skill, tool wrapper, model choice, or CI rule.
 
 ## Where it fits
 
@@ -48,7 +56,7 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 | If you need... | Use agenttrace for... |
 |---|---|
 | Local-first privacy | Inspect sessions without uploading prompts, code, or tool logs |
-| Fast terminal triage | Open a TUI, sort bad sessions, and jump into detail/diagnostics |
+| Fast terminal triage | Open a TUI, sort bad sessions, and jump into detail, diagnostics, or diff |
 | Cross-agent comparison | Compare Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes, OpenCode, Oh My Pi, Kimi, and more |
 | Cost and token evidence | See cost, token usage, cache usage, retries, loops, latency, and health in one place |
 | Workflow improvement | Mine local sessions for repeated tool failures, hanging gaps, and costly loops before updating prompts, skills, or project instructions |
@@ -66,12 +74,23 @@ agenttrace is not a hosted tracing backend or another chat client. It is a local
 | Brittle prompts or skills | `tool_fail_rate`, anomaly mix, and expensive sessions that point to the workflow note, skill, or command wrapper to fix next |
 | CI blind spots | JSON reports and health gates for average health, critical sessions, and tool failure rate |
 
+## What you can do in 60 seconds
+
+```bash
+agenttrace --demo
+agenttrace --demo --overview -f json
+agenttrace --demo --overview -f html -o agenttrace-demo.html
+```
+
+Use the demo when you want to evaluate the product before granting it access to real local logs. It exercises the same parser, health scoring, anomaly detection, cost summary, Markdown/JSON/HTML exporters, and CI gate fields used by real scans.
+
 ## ✨ Features
 
 | Feature | Description |
 |---|---|
-| 🚀 **Single Binary** | 7.5 MB — `curl -sL ... \| sh` install, no runtime deps |
+| 🚀 **Single Binary** | About 12 MB — `curl -sL ... \| sh` install, no runtime deps |
 | 🖥️ **Bubble Tea TUI** | Modern terminal UI: Overview → Session List → Detail → Diagnostics → Diff |
+| 🧪 **Built-in Demo** | Try representative healthy, hanging, and shallow sessions before scanning real logs |
 | ⚡ **Persistent Cache** | Incremental session cache avoids a full disk parse on every startup |
 | 🩺 **Doctor Mode** | `--doctor` checks detected agent dirs, cache health, and next steps |
 | ⌨️ **Command Mode** | `:health <80`, `:cost >0.1`, `:sort cost desc`, `:anomalies` |

--- a/site/index.html
+++ b/site/index.html
@@ -3,20 +3,20 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>agenttrace - TUI observability for AI coding agents</title>
+    <title>agenttrace - local observability for AI coding agents</title>
     <meta
       name="description"
-      content="A local TUI for finding token waste, tool loops, failures, latency, anomalies, health regressions, diffs, and CI evidence across AI coding agent sessions."
+      content="A local TUI and report generator that finds token waste, tool loops, failures, latency, anomalies, health regressions, diffs, and CI evidence across AI coding agent sessions."
     />
     <link rel="canonical" href="https://luoyuctl.github.io/agenttrace/" />
-    <meta property="og:title" content="agenttrace - TUI observability for AI coding agents" />
+    <meta property="og:title" content="agenttrace - local observability for AI coding agents" />
     <meta property="og:description" content="Find token waste, tool loops, failures, latency, anomalies, health regressions, diffs, and CI evidence in local AI coding agent sessions." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://luoyuctl.github.io/agenttrace/" />
     <meta property="og:image" content="https://luoyuctl.github.io/agenttrace/assets/hero-banner.png" />
     <meta property="og:image:alt" content="agenttrace terminal dashboard showing AI coding agent session metrics" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="agenttrace - TUI observability for AI coding agents" />
+    <meta name="twitter:title" content="agenttrace - local observability for AI coding agents" />
     <meta name="twitter:description" content="Trace cost, tokens, tool failures, latency, anomalies, health, diffs, and CI gates from local AI coding agent logs." />
     <meta name="twitter:image" content="https://luoyuctl.github.io/agenttrace/assets/hero-banner.png" />
     <link rel="icon" href="assets/logo-icon.png" />
@@ -29,7 +29,7 @@
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows",
         "softwareVersion": "0.4.0",
-        "description": "TUI observability for AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes, OpenCode, Kimi, and Copilot-style logs.",
+        "description": "Local TUI and report generator for AI coding agent sessions across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes, OpenCode, OpenClaw, Oh My Pi, Kimi, and Copilot-style logs.",
         "url": "https://luoyuctl.github.io/agenttrace/",
         "codeRepository": "https://github.com/luoyuctl/agenttrace",
         "license": "https://github.com/luoyuctl/agenttrace/blob/master/LICENSE",
@@ -48,40 +48,57 @@
         <span>agenttrace</span>
       </a>
       <nav aria-label="Primary navigation">
-        <a href="#demo">Demo</a>
+        <a href="#evidence">Evidence</a>
+        <a href="#workflow">Workflow</a>
         <a href="demo-report.html">Report</a>
         <a href="#install">Install</a>
-        <a href="#ci">CI</a>
         <a href="https://github.com/luoyuctl/agenttrace/discussions/2">Feedback</a>
         <a class="nav-cta" href="#install">Get agenttrace</a>
       </nav>
     </header>
 
     <main>
-      <section class="hero">
+      <section class="hero" id="install">
         <img class="hero-bg" src="assets/hero-banner.png" alt="agenttrace dashboard showing AI agent observability metrics" />
         <div class="hero-shade"></div>
         <div class="hero-copy">
-          <h1>Find AI agent waste before it ships.</h1>
+          <h1>Your AI agents already leave traces. Read them.</h1>
           <p>
-            agenttrace turns Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports,
-            Hermes, OpenCode, Kimi, and Copilot-style logs into one fast local TUI.
+            agenttrace turns local coding-agent logs into a fast TUI, shareable HTML reports,
+            health scores, anomaly evidence, and CI gates. No hosted backend. No prompt upload.
           </p>
-          <div class="hero-actions" id="install">
+          <div class="hero-actions">
             <button class="copy-btn" data-copy="curl -sL https://raw.githubusercontent.com/luoyuctl/agenttrace/master/install.sh | sh">
               Copy install
             </button>
             <a href="demo-report.html">View sample report</a>
             <a href="https://github.com/luoyuctl/agenttrace/releases/latest">Latest release</a>
           </div>
-          <pre><code>curl -sL https://raw.githubusercontent.com/luoyuctl/agenttrace/master/install.sh | sh
-go install github.com/luoyuctl/agenttrace/cmd/agenttrace@latest
-agenttrace --demo
-agenttrace --demo --overview -f html -o report.html</code></pre>
+          <div class="hero-terminal" aria-label="Quick start terminal">
+            <div class="terminal-bar">
+              <span></span><span></span><span></span>
+              <strong>60-second proof</strong>
+            </div>
+            <pre><code>curl -sL https://raw.githubusercontent.com/luoyuctl/agenttrace/master/install.sh | sh
+agenttrace --demo --overview -f json
+
+# demo result
+sessions: 3  tokens: 278200  cost: $0.81
+health: 58.7  critical: 1  tool_fail_rate: 60%</code></pre>
+          </div>
         </div>
+        <aside class="hero-card" aria-label="Demo evidence">
+          <strong>Built-in demo surfaced</strong>
+          <dl>
+            <div><dt>278,200</dt><dd>tokens traced</dd></div>
+            <div><dt>$0.81</dt><dd>estimated cost</dd></div>
+            <div><dt>60%</dt><dd>tool failure rate</dd></div>
+            <div><dt>100→66</dt><dd>health trend</dd></div>
+          </dl>
+        </aside>
       </section>
 
-      <section class="proof-strip" aria-label="What agenttrace catches">
+      <section class="proof-strip" id="evidence" aria-label="What agenttrace catches">
         <article>
           <strong>Token bills</strong>
           <span>Input, output, cache tokens, estimated cost, and top burning sessions.</span>
@@ -102,10 +119,10 @@ agenttrace --demo --overview -f html -o report.html</code></pre>
 
       <section class="demo" id="demo">
         <div class="section-copy">
-          <h2>A terminal workbench for agent sessions.</h2>
+          <h2>Start with the worst run, not the loudest guess.</h2>
           <p>
-            Sort hot sessions, drill into details, compare nearby runs, and inspect diagnostics
-            without uploading logs to another service.
+            The TUI opens on the operating picture: cost, health, latency, recent anomalies,
+            and the sessions most likely to waste human review time.
           </p>
         </div>
         <div class="demo-frame">
@@ -116,53 +133,61 @@ agenttrace --demo --overview -f html -o report.html</code></pre>
       <section class="ops-grid">
         <article>
           <span>0 Overview</span>
-          <h3>See the operating picture.</h3>
+          <h3>See the fleet.</h3>
           <p>Sessions, tokens, cost, error rate, P95 latency, health score, recent anomalies, and top agents.</p>
         </article>
         <article>
           <span>1 Session List</span>
-          <h3>Find the expensive run.</h3>
+          <h3>Rank the waste.</h3>
           <p>Sort by health, cost, or turns; filter by source, model, anomaly, text, or health threshold.</p>
         </article>
         <article>
           <span>2 Detail</span>
-          <h3>Explain what went wrong.</h3>
+          <h3>Inspect evidence.</h3>
           <p>Primary issue, impact, evidence, next action, loop analysis, tool warnings, and cost alerts.</p>
         </article>
         <article>
           <span>3 Diag / 4 Diff</span>
-          <h3>Turn symptoms into fixes.</h3>
+          <h3>Ship the fix.</h3>
           <p>Fingerprint loops, tool latency, context pressure, large params, rare tools, and side-by-side diffs.</p>
         </article>
       </section>
 
-      <section class="workflow" id="ci">
+      <section class="workflow" id="workflow">
         <div class="section-copy">
-          <h2>Use it locally, then gate it in CI.</h2>
+          <h2>Use the same evidence locally and in CI.</h2>
           <p>
-            The same parser powers the TUI, Markdown and HTML reports, JSON output, GitHub artifacts,
-            and threshold-based build failures.
+            Run the TUI while debugging. Export Markdown for PRs. Attach HTML reports to builds.
+            Fail CI when agent health drops or tool failures spike.
           </p>
         </div>
-        <pre><code>agenttrace --overview -f html -o agenttrace-overview.html
-agenttrace --overview -f markdown -o agenttrace-overview.md
-agenttrace --overview \
-  --fail-under-health 80 \
-  --fail-on-critical \
-  --max-tool-fail-rate 15</code></pre>
+        <div class="command-stack">
+          <article>
+            <span>Shareable report</span>
+            <code>agenttrace --overview -f html -o agenttrace-overview.html</code>
+          </article>
+          <article>
+            <span>PR comment</span>
+            <code>agenttrace --overview -f markdown -o agenttrace-overview.md</code>
+          </article>
+          <article>
+            <span>Build gate</span>
+            <code>agenttrace --overview --fail-under-health 80 --fail-on-critical --max-tool-fail-rate 15</code>
+          </article>
+        </div>
       </section>
 
       <section class="formats">
         <h2>Multi-agent logs, one operational view.</h2>
-        <p>Claude Code · Codex CLI · Gemini CLI · Qwen Code · Aider · Cursor exports · Hermes Agent · OpenCode · OpenClaw · Kimi CLI · Copilot-style traces</p>
+        <p>Claude Code · Codex CLI · Gemini CLI · Qwen Code · Cline · Aider · Cursor exports · Hermes Agent · OpenCode · OpenClaw · Oh My Pi · Kimi CLI · Copilot-style traces</p>
       </section>
 
       <section class="community">
         <div class="section-copy">
           <h2>Built in the open for agent operators.</h2>
           <p>
-            agenttrace is being submitted to terminal, AI agent, observability, and LLMOps directories.
-            Feedback is tracked publicly so the TUI can keep following real coding-agent pain.
+            agenttrace is listed in AI agent and terminal-tool communities, and feedback is tracked
+            publicly so the TUI can keep following real coding-agent pain.
           </p>
         </div>
         <div class="community-links" aria-label="Community links">

--- a/site/styles.css
+++ b/site/styles.css
@@ -11,6 +11,7 @@
   --cyan: #00d8ff;
   --amber: #ffb000;
   --red: #ff4a4a;
+  --blue: #7aa7ff;
   --shadow: rgba(0, 0, 0, 0.5);
 }
 
@@ -111,6 +112,8 @@ main {
   position: relative;
   min-height: 74svh;
   display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 27rem);
+  gap: clamp(1.5rem, 4vw, 4rem);
   align-items: start;
   padding: clamp(3.8rem, 7vw, 5.8rem) clamp(1rem, 4vw, 4.5rem) clamp(2.8rem, 6vw, 4rem);
   border-bottom: 1px solid var(--line);
@@ -133,22 +136,26 @@ main {
 
 .hero-shade {
   background:
-    linear-gradient(90deg, rgba(5, 6, 7, 0.97) 0%, rgba(5, 6, 7, 0.84) 37%, rgba(5, 6, 7, 0.18) 100%),
+    linear-gradient(90deg, rgba(5, 6, 7, 0.98) 0%, rgba(5, 6, 7, 0.82) 42%, rgba(5, 6, 7, 0.34) 100%),
     linear-gradient(180deg, rgba(5, 6, 7, 0.05) 0%, rgba(5, 6, 7, 0.88) 100%);
 }
 
-.hero-copy {
+.hero-copy,
+.hero-card {
   position: relative;
   z-index: 1;
+}
+
+.hero-copy {
   width: 100%;
   min-width: 0;
-  max-width: 46rem;
+  max-width: 52rem;
 }
 
 .hero h1 {
   margin: 0;
-  max-width: 14ch;
-  font-size: clamp(3.4rem, 6.4vw, 6.8rem);
+  max-width: 15ch;
+  font-size: clamp(3.2rem, 6vw, 6.4rem);
   line-height: 0.92;
   font-weight: 900;
 }
@@ -198,6 +205,97 @@ pre {
   box-shadow: 0 1rem 3rem var(--shadow);
 }
 
+.hero-terminal {
+  width: min(100%, 51rem);
+  border: 1px solid rgba(243, 239, 216, 0.16);
+  background: rgba(5, 6, 7, 0.84);
+  box-shadow: 0 1rem 3rem var(--shadow);
+}
+
+.hero-terminal pre {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-height: 2.4rem;
+  padding: 0 0.9rem;
+  border-bottom: 1px solid rgba(243, 239, 216, 0.12);
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.terminal-bar span {
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 999px;
+  background: var(--red);
+}
+
+.terminal-bar span:nth-child(2) {
+  background: var(--amber);
+}
+
+.terminal-bar span:nth-child(3) {
+  margin-right: 0.45rem;
+  background: var(--green);
+}
+
+.hero-card {
+  align-self: end;
+  margin-top: clamp(2rem, 8vw, 7rem);
+  border: 1px solid rgba(0, 216, 255, 0.26);
+  background: linear-gradient(180deg, rgba(16, 19, 23, 0.9) 0%, rgba(6, 8, 10, 0.92) 100%);
+  box-shadow: 0 1.4rem 4rem var(--shadow);
+}
+
+.hero-card > strong {
+  display: block;
+  padding: 1.05rem 1.1rem;
+  border-bottom: 1px solid rgba(243, 239, 216, 0.12);
+  color: var(--cyan);
+  text-transform: uppercase;
+  font-size: 0.82rem;
+}
+
+.hero-card dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+}
+
+.hero-card div {
+  min-height: 8.2rem;
+  padding: 1.05rem;
+  border-right: 1px solid rgba(243, 239, 216, 0.12);
+  border-bottom: 1px solid rgba(243, 239, 216, 0.12);
+}
+
+.hero-card div:nth-child(2n) {
+  border-right: 0;
+}
+
+.hero-card div:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.hero-card dt {
+  color: var(--ink);
+  font-size: clamp(1.7rem, 3vw, 2.35rem);
+  font-weight: 900;
+}
+
+.hero-card dd {
+  margin: 0.55rem 0 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
 code {
   font-family: inherit;
 }
@@ -225,6 +323,18 @@ code {
   color: var(--cyan);
   font-size: 0.95rem;
   text-transform: uppercase;
+}
+
+.proof-strip article:nth-child(2) strong {
+  color: var(--amber);
+}
+
+.proof-strip article:nth-child(3) strong {
+  color: var(--blue);
+}
+
+.proof-strip article:nth-child(4) strong {
+  color: var(--green);
 }
 
 .proof-strip span,
@@ -309,6 +419,32 @@ code {
   border-bottom: 1px solid var(--line);
 }
 
+.command-stack {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.command-stack article {
+  display: grid;
+  gap: 0.65rem;
+  padding: 1rem;
+  border: 1px solid rgba(243, 239, 216, 0.14);
+  background: rgba(5, 6, 7, 0.72);
+}
+
+.command-stack span {
+  color: var(--cyan);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+}
+
+.command-stack code {
+  display: block;
+  color: #ddd7bc;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
 .formats {
   max-width: 68rem;
   padding: clamp(4rem, 8vw, 7rem) clamp(1rem, 4vw, 4.5rem);
@@ -389,12 +525,18 @@ footer a {
 
   .hero {
     min-height: 76svh;
+    grid-template-columns: 1fr;
   }
 
   .hero-shade {
     background:
       linear-gradient(90deg, rgba(5, 6, 7, 0.98) 0%, rgba(5, 6, 7, 0.76) 70%, rgba(5, 6, 7, 0.42) 100%),
       linear-gradient(180deg, rgba(5, 6, 7, 0.08) 0%, rgba(5, 6, 7, 0.9) 100%);
+  }
+
+  .hero-card {
+    align-self: stretch;
+    margin-top: 0;
   }
 
   .proof-strip,
@@ -463,7 +605,23 @@ footer a {
     font-size: 0.78rem;
   }
 
-  .hero pre {
+  .hero-terminal {
     display: none;
+  }
+
+  .hero-card dl {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-card div,
+  .hero-card div:nth-child(2n),
+  .hero-card div:nth-last-child(-n + 2) {
+    min-height: 0;
+    border-right: 0;
+    border-bottom: 1px solid rgba(243, 239, 216, 0.12);
+  }
+
+  .hero-card div:last-child {
+    border-bottom: 0;
   }
 }


### PR DESCRIPTION
## Summary

Polish the README and GitHub Pages product page so agenttrace explains its value faster and uses facts verified from the current project.

## What changed

- Reworked the README opening around local AI-agent session observability, 60-second demo proof, and concrete waste signals.
- Refreshed `site/index.html` and `site/styles.css` with a stronger hero, demo evidence card, product workflow, and CI command cards.
- Updated fact-sensitive copy: binary size is now described as about 12 MB, verified community listings are named conservatively, and supported sources in JSON-LD match the parser surface more closely.

## Validation

- `go run ./cmd/agenttrace --demo --overview -f json`
- `go run ./cmd/agenttrace --demo --overview -f markdown`
- `go run ./cmd/agenttrace --demo --overview -f html -o /tmp/agenttrace-demo-report.html`
- `go run ./cmd/agenttrace --demo --doctor -f json`
- `go test ./...`
- `go build -o /tmp/agenttrace-verify ./cmd/agenttrace`
- `go vet ./...`
- `scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`
- `node --check site/script.js`
- `git diff --check`
- Playwright desktop and mobile preview of the built Pages artifact

## Fact checks

- Release `v0.4.0` exists and is current in the repo metadata checked via GitHub CLI.
- Release-style local build is about 12 MB.
- `npm view agenttrace` returns 404, so the README note that npm is not published remains correct.
- Verified listings found for Awesome Gemini CLI, Charm in the Wild, and Awesome Claude Code and Skills.
