### PR TITLE
[Quality] Exit after standalone pricing update

### DIFF
--- a/cmd/agenttrace/main.go
+++ b/cmd/agenttrace/main.go
@@ -62,7 +62,9 @@ func main() {
 		}
 		fmt.Printf(i18n.T("cli_loaded_pricing"), n)
 		fmt.Printf(i18n.T("cli_cache_saved"), engine.CachePath())
-		// Fall through to allow --list-models after update
+		if !hasPostPricingAction(flag.Arg(0), *listModels, *testMatch, *doctor, *latest, *compare, *overview, *wasteFlag) {
+			return
+		}
 	}
 
 	// Test fuzzy matching (dev helper)
@@ -367,4 +369,8 @@ func isTTYOpenError(err error) bool {
 	return strings.Contains(msg, "/dev/tty") ||
 		strings.Contains(msg, "not a terminal") ||
 		strings.Contains(msg, "could not open a new tty")
+}
+
+func hasPostPricingAction(path string, listModels, testMatch, doctor, latest, compare, overview, waste bool) bool {
+	return path != "" || listModels || testMatch || doctor || latest || compare || overview || waste
 }

--- a/cmd/agenttrace/main_test.go
+++ b/cmd/agenttrace/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+func TestHasPostPricingAction(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		listModels bool
+		testMatch  bool
+		doctor     bool
+		latest     bool
+		compare    bool
+		overview   bool
+		waste      bool
+		want       bool
+	}{
+		{name: "update pricing alone exits", want: false},
+		{name: "list models continues", listModels: true, want: true},
+		{name: "test match continues", testMatch: true, want: true},
+		{name: "doctor continues", doctor: true, want: true},
+		{name: "overview continues", overview: true, want: true},
+		{name: "latest continues", latest: true, want: true},
+		{name: "compare continues", compare: true, want: true},
+		{name: "waste continues", waste: true, want: true},
+		{name: "path continues", path: "session.jsonl", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasPostPricingAction(tt.path, tt.listModels, tt.testMatch, tt.doctor, tt.latest, tt.compare, tt.overview, tt.waste)
+			if got != tt.want {
+				t.Fatalf("hasPostPricingAction() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- make `agenttrace --update-pricing` return after updating when no follow-up action is requested
- keep `--update-pricing --list-models`, `--doctor`, `--overview`, path analysis, and other explicit actions flowing through
- add focused coverage for the post-pricing action gate

Fixes #148.

## Validation
- `go test ./cmd/agenttrace`
- `go test ./...`
- `go build -o /tmp/agenttrace-quality-148 ./cmd/agenttrace`
- `HOME=/tmp/agenttrace-quality-148-home /tmp/agenttrace-quality-148 --update-pricing`
- `HOME=/tmp/agenttrace-quality-148-home-list /tmp/agenttrace-quality-148 --update-pricing --list-models`
- `HOME=/tmp/agenttrace-quality-148-home /tmp/agenttrace-quality-148 --demo --overview -f json`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-148 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-148-ci scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-148 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-148-ci scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-148 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-148-ci scripts/ci/check-report-semantics.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-148 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-148-ci scripts/ci/check-docs-commands.sh`