### PR TITLE
[Quality] Recurse explicit session roots

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2292,50 +2292,7 @@ func FindSessionFiles(dir string) []string {
 		}
 		return sortFilesByModTime(all)
 	}
-	if isOpenCodeStoragePath(dir) {
-		return collectSessionFiles(dir)
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil
-	}
-	type entryInfo struct {
-		path string
-		t    time.Time
-	}
-	var items []entryInfo
-	for _, e := range entries {
-		path := filepath.Join(dir, e.Name())
-		if e.IsDir() {
-			if isClineTaskDir(path) {
-				info, err := e.Info()
-				mt := time.Time{}
-				if err == nil {
-					mt = info.ModTime()
-				}
-				items = append(items, entryInfo{path: path, t: mt})
-			}
-			continue
-		}
-		name := e.Name()
-		if !isSessionFileName(name) {
-			continue
-		}
-		info, err := e.Info()
-		mt := time.Time{}
-		if err == nil {
-			mt = info.ModTime()
-		}
-		items = append(items, entryInfo{path: path, t: mt})
-	}
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].t.After(items[j].t)
-	})
-	files := make([]string, len(items))
-	for i, it := range items {
-		files[i] = it.path
-	}
-	return files
+	return collectSessionFiles(dir)
 }
 
 func sortFilesByModTime(paths []string) []string {

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -191,6 +191,24 @@ func TestLoadAllSkipsBadFilesAndSortsBySessionStart(t *testing.T) {
 	}
 }
 
+func TestFindSessionFilesCustomDirIncludesNestedSessionRoots(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "2026", "05", "04")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	top := writeLoadableHermesSession(t, dir, "top", "2026-01-02T10:00:00Z")
+	deep := writeLoadableHermesSession(t, nested, "deep", "2026-01-02T11:00:00Z")
+
+	files := FindSessionFiles(dir)
+	if !containsPath(files, top) || !containsPath(files, deep) {
+		t.Fatalf("expected explicit dir discovery to include top and nested sessions, got %v", files)
+	}
+	if files[0] != deep {
+		t.Fatalf("expected nested newer session first, got %v", files)
+	}
+}
+
 func TestParseClaudeCode_ToolResultArray(t *testing.T) {
 	doc := map[string]interface{}{
 		"model": "claude",


### PR DESCRIPTION
## Summary
- make explicit `-d <dir>` discovery use the same bounded recursive scanner as auto/cached discovery
- keep existing skip rules for Gemini temp, OpenCode storage, and Cline task directories
- add regression coverage for nested session roots under a custom directory

Fixes #149.

## Validation
- `go test ./internal/engine`
- `go test ./...`
- `go build -o /tmp/agenttrace-quality-149 ./cmd/agenttrace`
- `/tmp/agenttrace-quality-149 -d /tmp/agenttrace-quality-149-sessions --overview -f json`
- `/tmp/agenttrace-quality-149 --doctor || true`
- `/tmp/agenttrace-quality-149 --demo --overview -f json`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-149 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-149-ci scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-149 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-149-ci scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-149 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-149-ci scripts/ci/check-report-semantics.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-149 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-149-ci scripts/ci/check-docs-commands.sh`