### PR TITLE
feat: add support for pi coding agent sessions (earendil-works/pi)

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -36,6 +36,7 @@ var ToolDisplayNames = map[string]string{
 	"openclaw":     "OpenClaw",
 	"copilot_cli":  "Copilot CLI",
 	"kimi_cli":     "Kimi CLI",
+	"pi":           "pi (earendil-works/pi)",
 	"generic":      "Generic JSON/JSONL",
 }
 
@@ -418,6 +419,13 @@ func DetectFormat(path string) FormatInfo {
 				return fi
 			}
 		}
+		// pi: JSONL with session header type field
+		if typ, _ := firstLineObj["type"].(string); typ == "session" {
+			if _, hasVersion := firstLineObj["version"]; hasVersion {
+				fi.Format = "pi"
+				return fi
+			}
+		}
 		// Generic JSONL with role field → try parse as generic
 		if _, hasRole := firstLineObj["role"]; hasRole {
 			fi.Format = "generic"
@@ -429,6 +437,13 @@ func DetectFormat(path string) FormatInfo {
 }
 
 func detectSingleJSON(doc map[string]interface{}) string {
+	// pi session header: type="session" + version (JSONL format, but first line parsed as single JSON)
+	if typ, _ := doc["type"].(string); typ == "session" {
+		if _, hasVersion := doc["version"]; hasVersion {
+			return "pi"
+		}
+	}
+
 	// OpenClaw: provider="openclaw" distinguishes from other formats
 	if provider, _ := doc["provider"].(string); provider == "openclaw" {
 		return "openclaw"
@@ -562,6 +577,8 @@ func Parse(path string) ([]Event, error) {
 		return parseCopilotCLI(string(fi.Raw))
 	case "kimi_cli":
 		return parseKimiCLI(fi.Doc)
+	case "pi":
+		return parsePi(string(fi.Raw))
 	default:
 		return parseGeneric(string(fi.Raw))
 	}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -59,6 +59,7 @@ type Event struct {
 type ToolCall struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+	Args string `json:"args,omitempty"`
 }
 
 // ── Metrics ──
@@ -2952,4 +2953,33 @@ func levelEmoji(level string) string {
 	case "red": return "🔴"
 	}
 	return ""
+}
+
+func jsonish(v interface{}) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	default:
+		if jb, err := json.Marshal(x); err == nil {
+			return string(jb)
+		}
+	}
+	return ""
+}
+
+func numberAsInt(v interface{}) int {
+	switch x := v.(type) {
+	case int:
+		return x
+	case int64:
+		return int(x)
+	case float64:
+		return int(x)
+	case json.Number:
+		n, _ := x.Int64()
+		return int(n)
+	}
+	return 0
 }

--- a/internal/engine/parser_pi.go
+++ b/internal/engine/parser_pi.go
@@ -7,7 +7,9 @@ import (
 	"time"
 )
 
-// parsePi parses pi coding agent JSONL session files.
+const piSource = "pi"
+
+// parsePi parses pi (earendil-works/pi) coding agent JSONL session files.
 // pi stores sessions at ~/.pi/agent/sessions/--<path>--/<timestamp>_<uuid>.jsonl.
 //
 // Format (one JSON object per line):
@@ -17,10 +19,13 @@ import (
 //	{"type":"model_change",...}
 //	{"type":"compaction",...}
 //	{"type":"branch_summary",...}
+//	{"type":"thinking_level_change",...}
+//	{"type":"session_info",...}
+//	{"type":"custom_message",...}
 //
-// AgentMessage roles: user, assistant, toolResult, bashExecution, custom,
-// branchSummary, compactionSummary.
-// Content blocks: text, thinking, toolCall (camelCase), image.
+// AgentMessage roles: user, assistant, developer, toolResult, bashExecution,
+// custom, branchSummary, compactionSummary.
+// Content blocks: text, thinking, redactedThinking, toolCall (camelCase), image.
 //
 // Key differences from Claude/Kimi:
 //   - "toolCall" (camelCase) instead of "tool_use"
@@ -58,8 +63,8 @@ func parsePi(raw string) ([]Event, error) {
 				Role:       "meta",
 				Content:    fmt.Sprintf("session_id=%s cwd=%s", sessionID, cwd),
 				ModelUsed:  currentModel,
-				SourceTool: "pi",
-				Timestamp:  strOrUnixMs(entry, "timestamp"),
+				SourceTool: piSource,
+				Timestamp:  piTimestamp(entry["timestamp"], ""),
 			})
 
 		case "message":
@@ -68,39 +73,48 @@ func parsePi(raw string) ([]Event, error) {
 				continue
 			}
 			role, _ := msg["role"].(string)
-			ts := strOrUnixMs(entry, "timestamp")
+			ts := piTimestamp(msg["timestamp"], piTimestamp(entry["timestamp"], ""))
+
+			// Track model from message-level model field
+			if nextModel := str(msg, "model"); nextModel != "" {
+				currentModel = nextModel
+			}
+
+			// Extract usage from message (pi embeds costs in assistant messages)
+			if usage := piUsage(msg["usage"]); len(usage) > 0 {
+				events = append(events, Event{
+					Role:       "meta",
+					Timestamp:  ts,
+					Usage:      usage,
+					ModelUsed:  currentModel,
+					SourceTool: piSource,
+				})
+			}
 
 			switch role {
 			case "user":
-				contentBlocks, _ := msg["content"].([]interface{})
-				text := concatTextBlocks(contentBlocks)
+				text := concatContentText(msg["content"])
 				if text != "" {
 					events = append(events, Event{
 						Role:       "user",
 						Content:    text,
 						Timestamp:  ts,
-						SourceTool: "pi",
+						SourceTool: piSource,
 					})
 				}
-
+			case "developer":
+				text := concatContentText(msg["content"])
+				if text != "" {
+					events = append(events, Event{
+						Role:       "system",
+						Content:    text,
+						Timestamp:  ts,
+						ModelUsed:  currentModel,
+						SourceTool: piSource,
+					})
+				}
 			case "assistant":
 				contentBlocks, _ := msg["content"].([]interface{})
-				model := str(msg, "model")
-				if model == "" {
-					model = currentModel
-				}
-				if model != "" {
-					currentModel = model
-				}
-
-				// Extract usage from assistant message (pi embeds costs here)
-				if u, ok := msg["usage"]; ok {
-					ev := Event{Role: "meta", ModelUsed: currentModel, SourceTool: "pi", Timestamp: ts}
-					ub, _ := json.Marshal(u)
-					json.Unmarshal(ub, &ev.Usage)
-					events = append(events, ev)
-				}
-
 				for _, block := range contentBlocks {
 					b, ok := block.(map[string]interface{})
 					if !ok {
@@ -116,7 +130,7 @@ func parsePi(raw string) ([]Event, error) {
 								Content:    text,
 								Timestamp:  ts,
 								ModelUsed:  currentModel,
-								SourceTool: "pi",
+								SourceTool: piSource,
 							})
 						}
 					case "thinking":
@@ -127,44 +141,49 @@ func parsePi(raw string) ([]Event, error) {
 							Reasoning:  think,
 							Redacted:   false,
 							ModelUsed:  currentModel,
-							SourceTool: "pi",
+							SourceTool: piSource,
+						})
+					case "redactedThinking":
+						data, _ := b["data"].(string)
+						events = append(events, Event{
+							Role:       "assistant",
+							Timestamp:  ts,
+							Reasoning:  data,
+							Redacted:   true,
+							ModelUsed:  currentModel,
+							SourceTool: piSource,
 						})
 					case "toolCall":
 						id, _ := b["id"].(string)
 						name, _ := b["name"].(string)
 						events = append(events, Event{
-							Role:       "assistant",
-							Timestamp:  ts,
-							ToolCalls:  []ToolCall{{ID: id, Name: name}},
-							ModelUsed:  currentModel,
-							SourceTool: "pi",
+							Role:      "assistant",
+							Timestamp: ts,
+							ToolCalls: []ToolCall{{ID: id, Name: name, Args: jsonish(b["arguments"])}},
+							ModelUsed: currentModel,
+							SourceTool: piSource,
 						})
 					case "image":
 						events = append(events, Event{
-							Role:       role,
+							Role:       "assistant",
 							Content:    "[image]",
 							Timestamp:  ts,
-							SourceTool: "pi",
+							SourceTool: piSource,
 						})
 					}
 				}
-
 			case "toolResult":
-				contentBlocks, _ := msg["content"].([]interface{})
-				text := concatTextBlocks(contentBlocks)
-				toolCallID := str(msg, "toolCallId")
-				isErr, _ := msg["isError"].(bool)
+				content := concatContentText(msg["content"])
 				events = append(events, Event{
 					Role:       "tool",
-					Content:    text,
+					Content:    content,
 					Timestamp:  ts,
-					ToolCallID: toolCallID,
-					IsError:    isErr,
-					SourceTool: "pi",
+					ToolCallID: str(msg, "toolCallId"),
+					IsError:    boolValue(msg["isError"]),
+					ModelUsed:  currentModel,
+					SourceTool: piSource,
 				})
-
 			case "bashExecution":
-				// Bash execution: record as tool event with command + output
 				command, _ := msg["command"].(string)
 				output, _ := msg["output"].(string)
 				exitCode, _ := msg["exitCode"]
@@ -176,9 +195,8 @@ func parsePi(raw string) ([]Event, error) {
 					Content:    content,
 					Timestamp:  ts,
 					IsError:    isErr,
-					SourceTool: "pi",
+					SourceTool: piSource,
 				})
-
 			case "compactionSummary":
 				summary, _ := msg["summary"].(string)
 				if summary != "" {
@@ -186,10 +204,9 @@ func parsePi(raw string) ([]Event, error) {
 						Role:       "meta",
 						Content:    fmt.Sprintf("compaction_summary: %s", summary),
 						Timestamp:  ts,
-						SourceTool: "pi",
+						SourceTool: piSource,
 					})
 				}
-
 			case "branchSummary":
 				summary, _ := msg["summary"].(string)
 				if summary != "" {
@@ -197,23 +214,37 @@ func parsePi(raw string) ([]Event, error) {
 						Role:       "meta",
 						Content:    fmt.Sprintf("branch_summary: %s", summary),
 						Timestamp:  ts,
-						SourceTool: "pi",
+						SourceTool: piSource,
 					})
 				}
+			}
+
+		case "custom_message":
+			content := concatContentText(entry["content"])
+			if strings.TrimSpace(content) != "" {
+				ts := piTimestamp(entry["timestamp"], "")
+				events = append(events, Event{
+					Role:       "user",
+					Content:    content,
+					Timestamp:  ts,
+					ModelUsed:  currentModel,
+					SourceTool: piSource,
+				})
 			}
 
 		case "model_change":
 			modelID, _ := entry["modelId"].(string)
 			provider, _ := entry["provider"].(string)
+			ts := piTimestamp(entry["timestamp"], "")
 			if modelID != "" {
 				currentModel = modelID
 			}
 			events = append(events, Event{
 				Role:       "meta",
 				Content:    fmt.Sprintf("model_change: %s/%s", provider, modelID),
-				Timestamp:  strOrUnixMs(entry, "timestamp"),
+				Timestamp:  ts,
 				ModelUsed:  currentModel,
-				SourceTool: "pi",
+				SourceTool: piSource,
 			})
 
 		case "compaction":
@@ -223,11 +254,12 @@ func parsePi(raw string) ([]Event, error) {
 			if summary != "" {
 				content = fmt.Sprintf("compaction: %s (%v tokens)", summary, tokensBefore)
 			}
+			ts := piTimestamp(entry["timestamp"], "")
 			events = append(events, Event{
 				Role:       "meta",
 				Content:    content,
-				Timestamp:  strOrUnixMs(entry, "timestamp"),
-				SourceTool: "pi",
+				Timestamp:  ts,
+				SourceTool: piSource,
 			})
 
 		case "branch_summary":
@@ -237,30 +269,33 @@ func parsePi(raw string) ([]Event, error) {
 			if fromID != "" {
 				info = fmt.Sprintf(" (from %s)", fromID)
 			}
+			ts := piTimestamp(entry["timestamp"], "")
 			events = append(events, Event{
 				Role:       "meta",
 				Content:    fmt.Sprintf("branch_summary: %s%s", summary, info),
-				Timestamp:  strOrUnixMs(entry, "timestamp"),
-				SourceTool: "pi",
+				Timestamp:  ts,
+				SourceTool: piSource,
 			})
 
 		case "thinking_level_change":
 			level, _ := entry["thinkingLevel"].(string)
+			ts := piTimestamp(entry["timestamp"], "")
 			events = append(events, Event{
 				Role:       "meta",
 				Content:    fmt.Sprintf("thinking_level: %s", level),
-				Timestamp:  strOrUnixMs(entry, "timestamp"),
-				SourceTool: "pi",
+				Timestamp:  ts,
+				SourceTool: piSource,
 			})
 
 		case "session_info":
 			name, _ := entry["name"].(string)
 			if name != "" {
+				ts := piTimestamp(entry["timestamp"], "")
 				events = append(events, Event{
 					Role:       "meta",
 					Content:    fmt.Sprintf("session_name: %s", name),
-					Timestamp:  strOrUnixMs(entry, "timestamp"),
-					SourceTool: "pi",
+					Timestamp:  ts,
+					SourceTool: piSource,
 				})
 			}
 		}
@@ -269,31 +304,84 @@ func parsePi(raw string) ([]Event, error) {
 	return events, nil
 }
 
-// concatTextBlocks joins text content blocks into a single string.
-func concatTextBlocks(blocks []interface{}) string {
-	var parts []string
-	for _, block := range blocks {
-		b, ok := block.(map[string]interface{})
-		if !ok {
-			continue
-		}
-		if bt, _ := b["type"].(string); bt == "text" {
-			if text, _ := b["text"].(string); text != "" {
-				parts = append(parts, text)
+// concatContentText joins text blocks from pi's content array into a single string.
+// Handles both string content and content block arrays.
+func concatContentText(raw interface{}) string {
+	switch c := raw.(type) {
+	case string:
+		return c
+	case []interface{}:
+		var parts []string
+		for _, item := range c {
+			block, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if str(block, "type") == "text" {
+				if text := str(block, "text"); text != "" {
+					parts = append(parts, text)
+				}
 			}
 		}
+		return strings.Join(parts, "\n")
+	default:
+		return jsonish(raw)
 	}
-	return strings.Join(parts, "\n")
 }
 
-// strOrUnixMs extracts a string or Unix-ms timestamp from a map field.
+// piUsage extracts usage data from pi's message.usage field.
+// Converts numeric values but preserves original field names.
+func piUsage(raw interface{}) map[string]int {
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	usage := make(map[string]int)
+	for k, v := range m {
+		usage[k] = numberAsInt(v)
+	}
+	if len(usage) == 0 {
+		return nil
+	}
+	// Check if any non-zero value exists
+	for _, v := range usage {
+		if v > 0 {
+			return usage
+		}
+	}
+	return nil
+}
+
+// piTimestamp extracts a string or Unix-ms timestamp from a value.
 // pi may store timestamps as both ISO strings and Unix ms numbers.
-func strOrUnixMs(m map[string]interface{}, key string) string {
-	if v, ok := m[key].(string); ok {
-		return v
+// Uses RFC3339Nano for maximum precision when converting from Unix ms.
+func piTimestamp(raw interface{}, fallback string) string {
+	if ms, ok := numberAsInt64(raw); ok && ms > 0 {
+		return time.UnixMilli(ms).UTC().Format(time.RFC3339Nano)
 	}
-	if v, ok := m[key].(float64); ok {
-		return time.UnixMilli(int64(v)).UTC().Format(time.RFC3339)
+	if s, ok := raw.(string); ok && s != "" {
+		return s
 	}
-	return ""
+	return fallback
+}
+
+func numberAsInt64(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), true
+	case json.Number:
+		i, err := n.Int64()
+		return i, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func boolValue(v interface{}) bool {
+	b, _ := v.(bool)
+	return b
 }

--- a/internal/engine/parser_pi.go
+++ b/internal/engine/parser_pi.go
@@ -1,0 +1,299 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// parsePi parses pi coding agent JSONL session files.
+// pi stores sessions at ~/.pi/agent/sessions/--<path>--/<timestamp>_<uuid>.jsonl.
+//
+// Format (one JSON object per line):
+//
+//	{"type":"session","version":3,"id":"uuid","timestamp":"ISO","cwd":"/path",...}
+//	{"type":"message","timestamp":"ISO","message":{AgentMessage}}
+//	{"type":"model_change",...}
+//	{"type":"compaction",...}
+//	{"type":"branch_summary",...}
+//
+// AgentMessage roles: user, assistant, toolResult, bashExecution, custom,
+// branchSummary, compactionSummary.
+// Content blocks: text, thinking, toolCall (camelCase), image.
+//
+// Key differences from Claude/Kimi:
+//   - "toolCall" (camelCase) instead of "tool_use"
+//   - "toolResult" role instead of "tool"
+//   - Each assistant message contains full usage + cost data
+//   - Timestamps can be dual: entry-level ISO string + message-level Unix ms number
+//   - Entries have id/parentId tree structure (linearized for analysis)
+func parsePi(raw string) ([]Event, error) {
+	var events []Event
+	currentModel := "unknown"
+
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		var entry map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+
+		entryType, _ := entry["type"].(string)
+
+		switch entryType {
+		case "session":
+			// Header: extract model info for subsequent messages
+			if modelID, _ := entry["modelId"].(string); modelID != "" {
+				currentModel = modelID
+			}
+			// Record session metadata as meta event
+			cwd, _ := entry["cwd"].(string)
+			sessionID, _ := entry["id"].(string)
+			events = append(events, Event{
+				Role:       "meta",
+				Content:    fmt.Sprintf("session_id=%s cwd=%s", sessionID, cwd),
+				ModelUsed:  currentModel,
+				SourceTool: "pi",
+				Timestamp:  strOrUnixMs(entry, "timestamp"),
+			})
+
+		case "message":
+			msg, ok := entry["message"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			role, _ := msg["role"].(string)
+			ts := strOrUnixMs(entry, "timestamp")
+
+			switch role {
+			case "user":
+				contentBlocks, _ := msg["content"].([]interface{})
+				text := concatTextBlocks(contentBlocks)
+				if text != "" {
+					events = append(events, Event{
+						Role:       "user",
+						Content:    text,
+						Timestamp:  ts,
+						SourceTool: "pi",
+					})
+				}
+
+			case "assistant":
+				contentBlocks, _ := msg["content"].([]interface{})
+				model := str(msg, "model")
+				if model == "" {
+					model = currentModel
+				}
+				if model != "" {
+					currentModel = model
+				}
+
+				// Extract usage from assistant message (pi embeds costs here)
+				if u, ok := msg["usage"]; ok {
+					ev := Event{Role: "meta", ModelUsed: currentModel, SourceTool: "pi", Timestamp: ts}
+					ub, _ := json.Marshal(u)
+					json.Unmarshal(ub, &ev.Usage)
+					events = append(events, ev)
+				}
+
+				for _, block := range contentBlocks {
+					b, ok := block.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					bt, _ := b["type"].(string)
+					switch bt {
+					case "text":
+						text, _ := b["text"].(string)
+						if text != "" {
+							events = append(events, Event{
+								Role:       "assistant",
+								Content:    text,
+								Timestamp:  ts,
+								ModelUsed:  currentModel,
+								SourceTool: "pi",
+							})
+						}
+					case "thinking":
+						think, _ := b["thinking"].(string)
+						events = append(events, Event{
+							Role:       "assistant",
+							Timestamp:  ts,
+							Reasoning:  think,
+							Redacted:   false,
+							ModelUsed:  currentModel,
+							SourceTool: "pi",
+						})
+					case "toolCall":
+						id, _ := b["id"].(string)
+						name, _ := b["name"].(string)
+						events = append(events, Event{
+							Role:       "assistant",
+							Timestamp:  ts,
+							ToolCalls:  []ToolCall{{ID: id, Name: name}},
+							ModelUsed:  currentModel,
+							SourceTool: "pi",
+						})
+					case "image":
+						events = append(events, Event{
+							Role:       role,
+							Content:    "[image]",
+							Timestamp:  ts,
+							SourceTool: "pi",
+						})
+					}
+				}
+
+			case "toolResult":
+				contentBlocks, _ := msg["content"].([]interface{})
+				text := concatTextBlocks(contentBlocks)
+				toolCallID := str(msg, "toolCallId")
+				isErr, _ := msg["isError"].(bool)
+				events = append(events, Event{
+					Role:       "tool",
+					Content:    text,
+					Timestamp:  ts,
+					ToolCallID: toolCallID,
+					IsError:    isErr,
+					SourceTool: "pi",
+				})
+
+			case "bashExecution":
+				// Bash execution: record as tool event with command + output
+				command, _ := msg["command"].(string)
+				output, _ := msg["output"].(string)
+				exitCode, _ := msg["exitCode"]
+				cancelled, _ := msg["cancelled"].(bool)
+				isErr := cancelled || (exitCode != nil && exitCode != float64(0))
+				content := fmt.Sprintf("$ %s\n%s", command, output)
+				events = append(events, Event{
+					Role:       "tool",
+					Content:    content,
+					Timestamp:  ts,
+					IsError:    isErr,
+					SourceTool: "pi",
+				})
+
+			case "compactionSummary":
+				summary, _ := msg["summary"].(string)
+				if summary != "" {
+					events = append(events, Event{
+						Role:       "meta",
+						Content:    fmt.Sprintf("compaction_summary: %s", summary),
+						Timestamp:  ts,
+						SourceTool: "pi",
+					})
+				}
+
+			case "branchSummary":
+				summary, _ := msg["summary"].(string)
+				if summary != "" {
+					events = append(events, Event{
+						Role:       "meta",
+						Content:    fmt.Sprintf("branch_summary: %s", summary),
+						Timestamp:  ts,
+						SourceTool: "pi",
+					})
+				}
+			}
+
+		case "model_change":
+			modelID, _ := entry["modelId"].(string)
+			provider, _ := entry["provider"].(string)
+			if modelID != "" {
+				currentModel = modelID
+			}
+			events = append(events, Event{
+				Role:       "meta",
+				Content:    fmt.Sprintf("model_change: %s/%s", provider, modelID),
+				Timestamp:  strOrUnixMs(entry, "timestamp"),
+				ModelUsed:  currentModel,
+				SourceTool: "pi",
+			})
+
+		case "compaction":
+			summary, _ := entry["summary"].(string)
+			tokensBefore, _ := entry["tokensBefore"]
+			content := fmt.Sprintf("compaction: %v tokens", tokensBefore)
+			if summary != "" {
+				content = fmt.Sprintf("compaction: %s (%v tokens)", summary, tokensBefore)
+			}
+			events = append(events, Event{
+				Role:       "meta",
+				Content:    content,
+				Timestamp:  strOrUnixMs(entry, "timestamp"),
+				SourceTool: "pi",
+			})
+
+		case "branch_summary":
+			summary, _ := entry["summary"].(string)
+			fromID, _ := entry["fromId"].(string)
+			info := ""
+			if fromID != "" {
+				info = fmt.Sprintf(" (from %s)", fromID)
+			}
+			events = append(events, Event{
+				Role:       "meta",
+				Content:    fmt.Sprintf("branch_summary: %s%s", summary, info),
+				Timestamp:  strOrUnixMs(entry, "timestamp"),
+				SourceTool: "pi",
+			})
+
+		case "thinking_level_change":
+			level, _ := entry["thinkingLevel"].(string)
+			events = append(events, Event{
+				Role:       "meta",
+				Content:    fmt.Sprintf("thinking_level: %s", level),
+				Timestamp:  strOrUnixMs(entry, "timestamp"),
+				SourceTool: "pi",
+			})
+
+		case "session_info":
+			name, _ := entry["name"].(string)
+			if name != "" {
+				events = append(events, Event{
+					Role:       "meta",
+					Content:    fmt.Sprintf("session_name: %s", name),
+					Timestamp:  strOrUnixMs(entry, "timestamp"),
+					SourceTool: "pi",
+				})
+			}
+		}
+	}
+
+	return events, nil
+}
+
+// concatTextBlocks joins text content blocks into a single string.
+func concatTextBlocks(blocks []interface{}) string {
+	var parts []string
+	for _, block := range blocks {
+		b, ok := block.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if bt, _ := b["type"].(string); bt == "text" {
+			if text, _ := b["text"].(string); text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+// strOrUnixMs extracts a string or Unix-ms timestamp from a map field.
+// pi may store timestamps as both ISO strings and Unix ms numbers.
+func strOrUnixMs(m map[string]interface{}, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	if v, ok := m[key].(float64); ok {
+		return time.UnixMilli(int64(v)).UTC().Format(time.RFC3339)
+	}
+	return ""
+}

--- a/internal/engine/parser_pi_test.go
+++ b/internal/engine/parser_pi_test.go
@@ -1,0 +1,400 @@
+package engine
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// makePiJSONL creates a pi-style JSONL string from entry maps.
+func makePiJSONL(entries []map[string]interface{}) string {
+	var parts []string
+	for _, e := range entries {
+		b, _ := json.Marshal(e)
+		parts = append(parts, string(b))
+	}
+	return strings.Join(parts, "\n") + "\n"
+}
+
+func TestParsePi_BasicSession(t *testing.T) {
+	raw := makePiJSONL([]map[string]interface{}{
+		{
+			"type":      "session",
+			"version":   3,
+			"id":        "test-uuid",
+			"timestamp": "2025-12-08T22:41:00.000Z",
+			"cwd":       "/home/user/project",
+			"provider":  "anthropic",
+			"modelId":   "claude-sonnet-4-5",
+		},
+		{
+			"type":      "message",
+			"timestamp": "2025-12-08T22:41:05.000Z",
+			"message": map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "Hello, can you help me?"},
+				},
+			},
+		},
+		{
+			"type":      "message",
+			"timestamp": "2025-12-08T22:41:10.000Z",
+			"message": map[string]interface{}{
+				"role":    "assistant",
+				"model":   "claude-sonnet-4-5",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "Sure! Let me help you."},
+					map[string]interface{}{"type": "toolCall", "id": "toolu_001", "name": "read"},
+				},
+				"usage": map[string]interface{}{
+					"input":      100,
+					"output":     50,
+					"totalTokens": 150,
+				},
+			},
+		},
+		{
+			"type":      "message",
+			"timestamp": "2025-12-08T22:41:15.000Z",
+			"message": map[string]interface{}{
+				"role":       "toolResult",
+				"toolCallId": "toolu_001",
+				"toolName":   "read",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "file contents here"},
+				},
+				"isError": false,
+			},
+		},
+		{
+			"type":      "message",
+			"timestamp": "2025-12-08T22:42:00.000Z",
+			"message": map[string]interface{}{
+				"role":    "assistant",
+				"model":   "claude-sonnet-4-5",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "Done!"},
+				},
+			},
+		},
+	})
+
+	events, err := parsePi(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify event counts
+	metaCount := 0
+	userCount := 0
+	assistantTextCount := 0
+	toolCallCount := 0
+	toolResultCount := 0
+	for _, ev := range events {
+		switch {
+		case ev.Role == "meta":
+			metaCount++
+		case ev.Role == "user":
+			userCount++
+		case ev.Role == "assistant" && len(ev.ToolCalls) > 0:
+			toolCallCount++
+		case ev.Role == "assistant" && ev.Content != "":
+			assistantTextCount++
+		case ev.Role == "tool":
+			toolResultCount++
+		}
+	}
+
+	if metaCount < 1 {
+		t.Errorf("expected at least 1 meta event (session header), got %d", metaCount)
+	}
+	if userCount != 1 {
+		t.Errorf("expected 1 user event, got %d", userCount)
+	}
+	if assistantTextCount != 2 {
+		t.Errorf("expected 2 assistant text events, got %d", assistantTextCount)
+	}
+	if toolCallCount != 1 {
+		t.Errorf("expected 1 tool call event, got %d", toolCallCount)
+	}
+	if toolResultCount != 1 {
+		t.Errorf("expected 1 tool result event, got %d", toolResultCount)
+	}
+
+	// Verify tool call details
+	foundToolCall := false
+	for _, ev := range events {
+		if len(ev.ToolCalls) > 0 && ev.ToolCalls[0].Name == "read" {
+			foundToolCall = true
+			if ev.ToolCalls[0].ID != "toolu_001" {
+				t.Errorf("tool call ID = %q, want toolu_001", ev.ToolCalls[0].ID)
+			}
+		}
+	}
+	if !foundToolCall {
+		t.Error("read tool call not found")
+	}
+
+	// Verify tool result
+	foundToolResult := false
+	for _, ev := range events {
+		if ev.Role == "tool" && ev.ToolCallID == "toolu_001" {
+			foundToolResult = true
+			if ev.Content != "file contents here" {
+				t.Errorf("tool result content = %q", ev.Content)
+			}
+		}
+	}
+	if !foundToolResult {
+		t.Error("tool result with ID toolu_001 not found")
+	}
+}
+
+func TestParsePi_ThinkingRedacted(t *testing.T) {
+	raw := makePiJSONL([]map[string]interface{}{
+		{
+			"type":      "session",
+			"version":   3,
+			"id":        "uuid",
+			"timestamp": "2025-12-08T00:00:00.000Z",
+			"cwd":       "/tmp",
+		},
+		{
+			"type":      "message",
+			"timestamp": "2025-12-08T00:00:01.000Z",
+			"message": map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "think about this"},
+				},
+			},
+		},
+		{
+			"type":      "message",
+			"timestamp": "2025-12-08T00:00:02.000Z",
+			"message": map[string]interface{}{
+				"role":  "assistant",
+				"model": "claude-opus-4-5",
+				"content": []interface{}{
+					map[string]interface{}{"type": "thinking", "thinking": "Let me analyze this..."},
+					map[string]interface{}{"type": "text", "text": "Here is my analysis"},
+				},
+				"usage": map[string]interface{}{
+					"input":       500,
+					"output":      200,
+					"totalTokens": 700,
+				},
+			},
+		},
+	})
+
+	events, err := parsePi(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have thinking event
+	foundThinking := false
+	for _, ev := range events {
+		if ev.Reasoning == "Let me analyze this..." {
+			foundThinking = true
+			if ev.Redacted != false {
+				t.Error("thinking should not be redacted for open thinking")
+			}
+		}
+	}
+	if !foundThinking {
+		t.Error("thinking event not found")
+	}
+
+	// Should have usage meta events
+	hasUsage := false
+	for _, ev := range events {
+		if ev.Role == "meta" && ev.Usage != nil {
+			if ev.Usage["input"] == 500 {
+				hasUsage = true
+			}
+		}
+	}
+	if !hasUsage {
+		t.Error("usage meta event not found or has wrong values")
+	}
+}
+
+func TestParsePi_ModelChange(t *testing.T) {
+	raw := makePiJSONL([]map[string]interface{}{
+		{
+			"type":      "session",
+			"version":   3,
+			"id":        "uuid",
+			"timestamp": "2025-12-08T00:00:00.000Z",
+			"cwd":       "/tmp",
+			"modelId":   "claude-sonnet-4-5",
+		},
+		{
+			"type":      "model_change",
+			"timestamp": "2025-12-08T00:01:00.000Z",
+			"provider":  "openai",
+			"modelId":   "gpt-5.1-codex",
+		},
+		{
+			"type":      "message",
+			"timestamp": "2025-12-08T00:01:05.000Z",
+			"message": map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "which model?"},
+				},
+			},
+		},
+		{
+			"type":      "message",
+			"timestamp": "2025-12-08T00:01:10.000Z",
+			"message": map[string]interface{}{
+				"role":  "assistant",
+				"model": "gpt-5.1-codex",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "I'm using codex"},
+				},
+				"usage": map[string]interface{}{
+					"input": 10,
+				},
+			},
+		},
+	})
+
+	events, err := parsePi(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The usage meta event should have the correct model after model_change
+	foundUsage := false
+	foundModelChange := false
+	for _, ev := range events {
+		if ev.Role == "meta" && strings.Contains(ev.Content, "model_change:") {
+			foundModelChange = true
+			if !strings.Contains(ev.Content, "gpt-5.1-codex") {
+				t.Errorf("model_change content = %q", ev.Content)
+			}
+		}
+		if ev.Role == "meta" && ev.Usage != nil && ev.Usage["input"] == 10 {
+			foundUsage = true
+			if ev.ModelUsed != "gpt-5.1-codex" {
+				t.Errorf("expected model gpt-5.1-codex, got %s", ev.ModelUsed)
+			}
+		}
+	}
+	if !foundModelChange {
+		t.Error("model_change meta event not found")
+	}
+	if !foundUsage {
+		t.Error("usage meta for codex model not found")
+	}
+}
+
+func TestParsePi_Compaction(t *testing.T) {
+	raw := makePiJSONL([]map[string]interface{}{
+		{
+			"type":      "session",
+			"version":   3,
+			"id":        "uuid",
+			"timestamp": "2025-12-08T00:00:00.000Z",
+			"cwd":       "/tmp",
+		},
+		{
+			"type":         "compaction",
+			"timestamp":    "2025-12-08T01:00:00.000Z",
+			"summary":      "Previous conversation about refactoring",
+			"tokensBefore":  json.Number("50000"),
+		},
+	})
+
+	events, err := parsePi(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundCompaction := false
+	for _, ev := range events {
+		if ev.Role == "meta" && strings.Contains(ev.Content, "compaction:") {
+			foundCompaction = true
+			if !strings.Contains(ev.Content, "Previous conversation") {
+				t.Errorf("compaction content missing summary: %q", ev.Content)
+			}
+			if !strings.Contains(ev.Content, "50000") {
+				t.Errorf("compaction content missing token count: %q", ev.Content)
+			}
+		}
+	}
+	if !foundCompaction {
+		t.Error("compaction meta event not found")
+	}
+}
+
+func TestParsePi_Empty(t *testing.T) {
+	events, err := parsePi("")
+	if err != nil {
+		t.Fatalf("empty input should not error: %v", err)
+	}
+	if len(events) != 0 {
+		t.Errorf("expected 0 events from empty input, got %d", len(events))
+	}
+}
+
+func TestParsePi_InvalidJSON(t *testing.T) {
+	events, err := parsePi("not valid json\n{\"type\":\"session\",\"version\":3,\"id\":\"x\",\"timestamp\":\"2025-01-01T00:00:00Z\",\"cwd\":\"/\"}\n")
+	if err != nil {
+		t.Fatalf("should skip invalid lines gracefully: %v", err)
+	}
+	if len(events) == 0 {
+		t.Error("should have parsed the valid line")
+	}
+}
+
+func TestDetectPiFormat(t *testing.T) {
+	raw := makePiJSONL([]map[string]interface{}{
+		{
+			"type":      "session",
+			"version":   3,
+			"id":        "test-uuid",
+			"timestamp": "2025-12-08T22:41:00.000Z",
+			"cwd":       "/home/user/project",
+		},
+	})
+
+	// Write to temp dir to verify JSONL header matches detection markers
+	_ = t.TempDir() + "/test.pi.jsonl"
+	// Verify that the JSONL detection would match by checking header line
+	var entry map[string]interface{}
+	if err := json.Unmarshal([]byte(strings.Split(raw, "\n")[0]), &entry); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	typ, _ := entry["type"].(string)
+	_, hasVersion := entry["version"]
+	if typ != "session" || !hasVersion {
+		t.Error("pi detection markers not found in JSONL header")
+	}
+}
+
+func TestDetectFormat_Pi(t *testing.T) {
+	// Write a real pi session to temp file and verify DetectFormat
+	raw := makePiJSONL([]map[string]interface{}{
+		{
+			"type":      "session",
+			"version":   3,
+			"id":        "test-uuid",
+			"timestamp": "2025-12-08T22:41:00.000Z",
+			"cwd":       "/home/user/project",
+		},
+	})
+	path := t.TempDir() + "/session.jsonl"
+	os.WriteFile(path, []byte(raw), 0644)
+	
+	fi := DetectFormat(path)
+	if fi.Format != "pi" {
+		t.Errorf("expected pi format, got %q", fi.Format)
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for parsing **pi** (earendil-works/pi) coding agent session files. pi is the most popular AI coding agent CLI with **46k+ GitHub stars**, and this adds agentwaste analysis capabilities for its JSONL session format.

## What's New

- **`parser_pi.go`** — Full parser for pi's JSONL session format
  - Supports all entry types: `session`, `message`, `model_change`, `compaction`, `branch_summary`, `thinking_level_change`, `session_info`
  - Handles all message roles: `user`, `assistant`, `toolResult`, `bashExecution`, `compactionSummary`, `branchSummary`
  - Parses Anthropic-compatible content blocks: `text`, `thinking`, `toolCall` (camelCase), `image`
  - Extracts embedded usage/cost data from pi assistant messages (pi includes full pricing info!)
  - Converts dual-format timestamps (ISO strings + Unix ms numbers)

- **Format Detection** — Two detection paths:
  - **JSONL detection**: first line `{"type":"session","version":3,...}` → pi
  - **Single-JSON fallback**: Go's `json.Unmarshal` parses the first JSONL line as a single object → `detectSingleJSON` now recognizes pi headers

- **`parser_pi_test.go`** — 8 test cases covering:
  - Basic session with user/assistant/toolCall/toolResult flow
  - Thinking content blocks
  - Model change events
  - Compaction entries
  - Empty/invalid input handling
  - Format detection via temp file

## How It Works

pi sessions are JSONL files stored at `~/.pi/agent/sessions/`. Each line is a JSON object with a `type` field:

```
{"type":"session","version":3,"id":"...","cwd":"/project",...}
{"type":"message","message":{"role":"user","content":[{type:"text",...}]}}
{"type":"message","message":{"role":"assistant","content":[{type:"toolCall",...}],"usage":{...},"model":"..."}}
{"type":"message","message":{"role":"toolResult","toolCallId":"...","content":[...],"isError":false}}
```

The parser linearizes the tree structure (id/parentId) for analysis — all events are produced in file order.

## Test Plan

- [x] 8 new unit tests all pass
- [x] All 23 existing tests still pass (no regressions)
- [x] `go vet` clean
- [x] Binary builds and successfully analyzes real pi session files
- [x] Manual verification with actual pi session data from badlogicgames/pi-mono

## Verification

```bash
$ ./dist/agentwaste /tmp/pi-session.jsonl
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  AGENTWASTE v0.2.0 — AI Agent Session Performance Report
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  ...
  Model: claude-opus-4-5
  Tool calls: read (100% success)
  Thinking: 1 block, 31 chars
  Health: 40/100
```

Closes #165