### PR TITLE
fix: discover pi session directory

### DIFF
--- a/cmd/agenttrace/doctor_test.go
+++ b/cmd/agenttrace/doctor_test.go
@@ -79,6 +79,36 @@ func TestDoctorReportUsesReportableSQLiteBackedSources(t *testing.T) {
 	}
 }
 
+func TestDoctorReportIncludesPiSessionDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+
+	sessionDir := filepath.Join(home, ".pi", "agent", "sessions")
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"type":"session","version":3,"id":"pi-session","cwd":"/work/pi"}
+{"type":"message","message":{"role":"user","content":"hello from pi"}}
+`
+	if err := os.WriteFile(filepath.Join(sessionDir, "session.jsonl"), []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	report := buildDoctorReport("", false)
+	var piRow *doctorDirReport
+	for i := range report.Directories {
+		if report.Directories[i].Name == "Pi" {
+			piRow = &report.Directories[i]
+			break
+		}
+	}
+	if piRow == nil || !piRow.Exists || piRow.Files != 1 {
+		t.Fatalf("doctor should report PI sessions, got %+v", piRow)
+	}
+}
+
 func TestDoctorReportChineseText(t *testing.T) {
 	prev := i18n.Current
 	i18n.SetLang(i18n.ZH)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -2345,6 +2345,7 @@ func KnownSessionDirs() []KnownSessionDir {
 		{Name: "Gemini CLI tmp", Path: filepath.Join(home, ".gemini", "tmp")},
 		{Name: "Qwen Code", Path: filepath.Join(home, ".qwen", "projects")},
 		{Name: "Claude Code", Path: filepath.Join(home, ".claude", "projects")},
+		{Name: "Pi", Path: filepath.Join(home, ".pi", "agent", "sessions")},
 		{Name: "Oh My Pi", Path: filepath.Join(home, ".omp", "agent", "sessions")},
 	}
 	dirs = append(dirs, openCodeKnownSessionDirs(home)...)

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -485,6 +485,38 @@ func TestParseOhMyPiSessionJSONL_InvalidHeader(t *testing.T) {
 	}
 }
 
+func TestFindSessionFilesIncludesPiSessionDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	sessionDir := filepath.Join(home, ".pi", "agent", "sessions")
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessionDir, "session.jsonl")
+	raw := makeJSONL([]interface{}{
+		map[string]interface{}{"type": "session", "version": 3, "id": "pi-session", "cwd": "/work/pi"},
+		map[string]interface{}{
+			"type": "message",
+			"message": map[string]interface{}{
+				"role":    "user",
+				"content": "hello from pi",
+			},
+		},
+	})
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := DetectFormat(path).Format; got != "oh_my_pi" {
+		t.Fatalf("pi session format: %s", got)
+	}
+	files := FindSessionFiles("")
+	if !containsPath(files, path) {
+		t.Fatalf("expected PI session file, got %v", files)
+	}
+}
+
 func TestParseQwenCodeStreamJSONL(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "qwen-stream.jsonl")


### PR DESCRIPTION
## Summary

- Add Pi auto-discovery for `~/.pi/agent/sessions`.
- Keep the existing Oh My Pi path, `~/.omp/agent/sessions`, for compatibility.
- Add regression coverage for both session discovery and `agenttrace --doctor` output.

Related to #169. Leaving the issue open for reporter verification.

## Verification

```bash
go test ./internal/engine -run "TestFindSessionFilesIncludesPiSessionDir|TestParseOhMyPiSessionJSONL"
go test ./cmd/agenttrace -run "TestDoctorReportIncludesPiSessionDir|TestDoctorReportUsesReportableSQLiteBackedSources"
go test ./...
```

Also verified manually with a temporary `HOME` containing `~/.pi/agent/sessions/session.jsonl`; `agenttrace --doctor` reports `Pi found 1`.
