### PR TITLE
[codex] fix pi session display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-No unreleased changes yet.
+### Fixed
+
+- Show sessions from `~/.pi/agent/sessions` as Pi while keeping
+  legacy `~/.omp/agent/sessions` sessions labeled Oh My Pi.
 
 ## v0.4.5 - 2026-05-10
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ agenttrace --overview \
 
 agenttrace supports local sessions from:
 
-Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces.
+Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces.
 
 ## What you get
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,7 +97,7 @@ agenttrace --overview -f html -o agenttrace-overview.html
 
 agenttrace 支持这些本地会话来源：
 
-Claude Code、Codex CLI、Gemini CLI、Qwen Code、Cline、Aider、Cursor exports、Hermes Agent、OpenCode、OpenClaw、Oh My Pi、Kimi CLI、Copilot-style logs，以及通用 JSON/JSONL traces。
+Claude Code、Codex CLI、Gemini CLI、Qwen Code、Cline、Aider、Cursor exports、Hermes Agent、OpenCode、OpenClaw、Pi、Oh My Pi、Kimi CLI、Copilot-style logs，以及通用 JSON/JSONL traces。
 
 ## 你会得到什么
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,5 +1,5 @@
 // Package engine provides the core analysis engine for agenttrace.
-// Pure Go. Supports 13 agent formats: Hermes Agent, Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, OpenClaw, Copilot CLI, Kimi CLI, Oh My Pi, Aider, Cursor, Cline.
+// Pure Go. Supports 14 agent sources: Hermes Agent, Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, OpenClaw, Copilot CLI, Kimi CLI, Pi, Oh My Pi, Aider, Cursor, Cline.
 package engine
 
 import (
@@ -54,6 +54,7 @@ var ToolDisplayNames = map[string]string{
 	"openclaw":          "OpenClaw",
 	"copilot_cli":       "Copilot CLI",
 	"kimi_cli":          "Kimi CLI",
+	"pi":                "Pi",
 	"oh_my_pi":          "Oh My Pi",
 	"aider":             "Aider",
 	"cursor":            "Cursor",
@@ -789,7 +790,7 @@ func Parse(path string) ([]Event, error) {
 	case "kimi_cli":
 		return parseKimiCLI(fi.Doc)
 	case "oh_my_pi":
-		return parseOhMyPiSessionJSONL(string(fi.Raw))
+		return parseOhMyPiSessionJSONL(string(fi.Raw), piSourceForPath(path))
 	case "aider_chat_history":
 		return parseAiderChatHistory(string(fi.Raw))
 	case "cursor":

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -466,6 +466,36 @@ func TestParseOhMyPiSessionJSONL(t *testing.T) {
 	}
 }
 
+func TestParsePiSessionJSONLUsesPiSourceFromPath(t *testing.T) {
+	home := t.TempDir()
+	sessionDir := filepath.Join(home, ".pi", "agent", "sessions")
+	if err := os.MkdirAll(sessionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessionDir, "session.jsonl")
+	raw := makeJSONL([]interface{}{
+		map[string]interface{}{"type": "session", "version": 3, "id": "pi-session", "cwd": "/work/pi"},
+		map[string]interface{}{
+			"type": "message",
+			"message": map[string]interface{}{
+				"role":    "user",
+				"content": "hello from pi",
+			},
+		},
+	})
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m := Analyze(events, "mimo-v2.5-pro"); m.SourceTool != "pi" {
+		t.Fatalf("expected PI source for ~/.pi session, got %+v", m)
+	}
+}
+
 func TestParseOhMyPiSessionJSONL_InvalidHeader(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "broken.jsonl")
@@ -510,6 +540,13 @@ func TestFindSessionFilesIncludesPiSessionDir(t *testing.T) {
 
 	if got := DetectFormat(path).Format; got != "oh_my_pi" {
 		t.Fatalf("pi session format: %s", got)
+	}
+	events, err := Parse(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m := Analyze(events, "mimo-v2.5-pro"); m.SourceTool != "pi" {
+		t.Fatalf("expected PI source for auto-discovered PI session, got %+v", m)
 	}
 	files := FindSessionFiles("")
 	if !containsPath(files, path) {

--- a/internal/engine/parser_oh_my_pi.go
+++ b/internal/engine/parser_oh_my_pi.go
@@ -3,11 +3,23 @@ package engine
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 )
 
-const ohMyPiSource = "oh_my_pi"
+const (
+	piSource     = "pi"
+	ohMyPiSource = "oh_my_pi"
+)
+
+func piSourceForPath(path string) string {
+	normalized := strings.ToLower(filepath.ToSlash(path))
+	if strings.Contains(normalized, "/.pi/agent/sessions/") {
+		return piSource
+	}
+	return ohMyPiSource
+}
 
 func isOhMyPiSessionHeader(obj map[string]interface{}) bool {
 	if typ, _ := obj["type"].(string); typ != "session" {
@@ -20,11 +32,14 @@ func isOhMyPiSessionHeader(obj map[string]interface{}) bool {
 	return hasVersion || hasCWD || hasTitleSource || hasParent
 }
 
-func parseOhMyPiSessionJSONL(raw string) ([]Event, error) {
+func parseOhMyPiSessionJSONL(raw string, sourceTool string) ([]Event, error) {
 	var metaEvents []Event
 	var events []Event
 	model := "unknown"
 	seenHeader := false
+	if sourceTool == "" {
+		sourceTool = ohMyPiSource
+	}
 
 	for _, line := range strings.Split(raw, "\n") {
 		line = strings.TrimSpace(line)
@@ -56,7 +71,7 @@ func parseOhMyPiSessionJSONL(raw string) ([]Event, error) {
 			if !ok {
 				continue
 			}
-			for _, ev := range ohMyPiMessageEvents(msg, ts, &model) {
+			for _, ev := range ohMyPiMessageEvents(msg, ts, &model, sourceTool) {
 				if ev.Role == "meta" {
 					metaEvents = append(metaEvents, ev)
 				} else {
@@ -71,7 +86,7 @@ func parseOhMyPiSessionJSONL(raw string) ([]Event, error) {
 					Content:    content,
 					Timestamp:  ts,
 					ModelUsed:  model,
-					SourceTool: ohMyPiSource,
+					SourceTool: sourceTool,
 				})
 			}
 		case "model_change":
@@ -81,7 +96,7 @@ func parseOhMyPiSessionJSONL(raw string) ([]Event, error) {
 					Role:       "meta",
 					Timestamp:  ts,
 					ModelUsed:  model,
-					SourceTool: ohMyPiSource,
+					SourceTool: sourceTool,
 				})
 			}
 		case "branch_summary", "compaction":
@@ -92,7 +107,7 @@ func parseOhMyPiSessionJSONL(raw string) ([]Event, error) {
 					Content:    content,
 					Timestamp:  ts,
 					ModelUsed:  model,
-					SourceTool: ohMyPiSource,
+					SourceTool: sourceTool,
 				})
 			}
 		}
@@ -107,7 +122,7 @@ func parseOhMyPiSessionJSONL(raw string) ([]Event, error) {
 	return append(metaEvents, events...), nil
 }
 
-func ohMyPiMessageEvents(msg map[string]interface{}, entryTS string, model *string) []Event {
+func ohMyPiMessageEvents(msg map[string]interface{}, entryTS string, model *string, sourceTool string) []Event {
 	role := str(msg, "role")
 	ts := ohMyPiTimestamp(msg["timestamp"], entryTS)
 
@@ -122,7 +137,7 @@ func ohMyPiMessageEvents(msg map[string]interface{}, entryTS string, model *stri
 			Timestamp:  ts,
 			Usage:      usage,
 			ModelUsed:  *model,
-			SourceTool: ohMyPiSource,
+			SourceTool: sourceTool,
 		})
 	}
 
@@ -135,7 +150,7 @@ func ohMyPiMessageEvents(msg map[string]interface{}, entryTS string, model *stri
 				Content:    content,
 				Timestamp:  ts,
 				ModelUsed:  *model,
-				SourceTool: ohMyPiSource,
+				SourceTool: sourceTool,
 			})
 		}
 	case "developer":
@@ -145,7 +160,7 @@ func ohMyPiMessageEvents(msg map[string]interface{}, entryTS string, model *stri
 				Content:    content,
 				Timestamp:  ts,
 				ModelUsed:  *model,
-				SourceTool: ohMyPiSource,
+				SourceTool: sourceTool,
 			})
 		}
 	case "assistant":
@@ -158,7 +173,7 @@ func ohMyPiMessageEvents(msg map[string]interface{}, entryTS string, model *stri
 				ToolCalls:  toolCalls,
 				Timestamp:  ts,
 				ModelUsed:  *model,
-				SourceTool: ohMyPiSource,
+				SourceTool: sourceTool,
 			})
 		}
 	case "toolResult":
@@ -169,7 +184,7 @@ func ohMyPiMessageEvents(msg map[string]interface{}, entryTS string, model *stri
 			ToolCallID: str(msg, "toolCallId"),
 			IsError:    boolValue(msg["isError"]),
 			ModelUsed:  *model,
-			SourceTool: ohMyPiSource,
+			SourceTool: sourceTool,
 		})
 	}
 	return events

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -407,6 +407,8 @@ func loadingSourceFromPath(path string) string {
 		return "qwen_code"
 	case strings.Contains(p, "/opencode/") || strings.Contains(p, "application support/opencode"):
 		return "opencode"
+	case strings.Contains(p, "/.pi/agent/sessions/"):
+		return "pi"
 	case strings.Contains(p, "/.omp/"):
 		return "oh_my_pi"
 	case strings.Contains(p, "cline-dev"):

--- a/npm/README.md
+++ b/npm/README.md
@@ -58,7 +58,7 @@ agenttrace --overview --fail-under-health 80 --fail-on-critical --max-tool-fail-
 
 ## Supported Sources
 
-agenttrace auto-detects local sessions from Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, OpenClaw, Copilot CLI, Oh My Pi, Kimi CLI, Hermes Agent, and Aider chat history.
+agenttrace auto-detects local sessions from Claude Code, Codex CLI, Gemini CLI, Qwen Code, OpenCode, OpenClaw, Copilot CLI, Pi, Oh My Pi, Kimi CLI, Hermes Agent, and Aider chat history.
 
 For Aider repositories, run:
 

--- a/site/ai-agent-observability.html
+++ b/site/ai-agent-observability.html
@@ -139,7 +139,7 @@
           agenttrace is built for developers who want AI coding agent session history without sending
           prompts, code, or private logs to a hosted dashboard. It supports Claude Code, Codex CLI,
           Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw,
-          Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces.
+          Pi, Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces.
         </p>
       </section>
     </main>

--- a/site/index.html
+++ b/site/index.html
@@ -190,7 +190,7 @@
 
       <section class="sources" aria-label="Supported agent sources">
         <h2>Reads the logs developers already have.</h2>
-        <p>Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Oh My Pi, Kimi CLI, Copilot-style traces</p>
+        <p>Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style traces</p>
       </section>
 
       <section class="community">

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -11,7 +11,7 @@ License: MIT
 
 ## What it does
 
-- Parses local session logs from Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Kimi CLI, Oh My Pi, and Copilot-style traces.
+- Parses local session logs from Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Kimi CLI, Pi, Oh My Pi, and Copilot-style traces.
 - Shows historical cost, token usage, model usage, elapsed time, latency, hanging gaps, slow tool calls, and session health across multiple agents.
 - Provides a Bubble Tea terminal UI with overview, session list, detail, diagnostics, and diff views.
 - Exports JSON, Markdown, and self-contained HTML reports.


### PR DESCRIPTION
## Summary

- label sessions loaded from `~/.pi/agent/sessions` as `Pi`
- keep legacy `~/.omp/agent/sessions` sessions labeled `Oh My Pi`
- update supported-source docs to list Pi separately from Oh My Pi

## Root Cause

PI and legacy Oh My Pi share the same JSONL parser, but the parser always emitted `SourceTool: oh_my_pi`. That made real PI sessions render as Oh My Pi even when they were discovered from the PI session directory.

## Validation

- `go test ./internal/engine ./cmd/agenttrace ./internal/tui`
- `go test ./...`
- `go build -o /tmp/agenttrace-pi-display ./cmd/agenttrace`
- `/tmp/agenttrace-pi-display -d ~/.pi/agent/sessions --latest -f json` reports `source_tool: pi` for a real PI session
- `/tmp/agenttrace-pi-display --doctor` still reports `Pi found 1 ~/.pi/agent/sessions`

Fixes #169
