### PR TITLE
Add npm README release surface checks

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -2,11 +2,11 @@
 
 TUI observability for AI coding agent sessions. It helps you inspect local agent runs across cost, token usage, latency, tool failures, anomalies, health score, and CI quality gates.
 
-This directory contains the npm wrapper for agenttrace.
+This directory contains the npm wrapper for agenttrace. The public npm package has not been published yet, so `npm install -g agenttrace` will return a registry 404 until the first publish.
 
 ## Install
 
-Use one of the supported install methods:
+Use one of the supported install methods for now:
 
 ```bash
 brew install luoyuctl/tap/agenttrace
@@ -18,7 +18,7 @@ curl -fsSL https://raw.githubusercontent.com/luoyuctl/agenttrace/master/install.
 agenttrace --version
 ```
 
-npm install path:
+After the package is published, the npm install path will be:
 
 ```bash
 npm install -g agenttrace
@@ -33,7 +33,7 @@ From this directory:
 node --check install.js
 node --check run.js
 AGENTTRACE_BIN=/path/to/agenttrace node run.js --version
-AGENTTRACE_RELEASE_TAG=v0.4.2 node install.js
+AGENTTRACE_RELEASE_TAG=v0.4.6 node install.js
 npm pack --dry-run
 ```
 

--- a/scripts/ci/check-release-surfaces.sh
+++ b/scripts/ci/check-release-surfaces.sh
@@ -19,6 +19,14 @@ grep -q "agenttrace v$version" homebrew/Formula/agenttrace.rb \
   || fail "Homebrew formula test is not aligned with engine version $version"
 grep -q "\"softwareVersion\": \"$version\"" site/index.html \
   || fail "site structured metadata is not aligned with engine version $version"
+grep -q "AGENTTRACE_RELEASE_TAG=v$version node install.js" npm/README.md \
+  || fail "npm README maintainer release-tag check is not aligned with engine version $version"
+
+if grep -Eqi "not been published yet|registry 404|until the first publish" npm/README.md &&
+  grep -q "^npm install -g agenttrace$" npm/README.md &&
+  ! grep -qi "After the package is published" npm/README.md; then
+  fail "npm README must not present npm install as active while the package is unpublished"
+fi
 
 if ! grep -q "<div class=\"meta\">v$version" site/demo-report.html &&
   ! grep -qi "static sample data" site/demo-report.html; then
@@ -28,7 +36,7 @@ fi
 node -e '
 const fs = require("fs");
 const version = process.argv[1];
-const files = ["README.md", "homebrew/Formula/agenttrace.rb", "site/index.html", "site/demo-report.html"];
+const files = ["README.md", "homebrew/Formula/agenttrace.rb", "site/index.html", "site/demo-report.html", "npm/README.md"];
 const pattern = /\bv?(\d+\.\d+\.\d+)\b/g;
 for (const file of files) {
   const text = fs.readFileSync(file, "utf8");


### PR DESCRIPTION
## Summary

- extend `scripts/ci/check-release-surfaces.sh` to include `npm/README.md` version drift checks
- fail release-surface validation when npm wrapper docs still say the package is unpublished but present `npm install -g agenttrace` as an active install path
- update the npm README maintainer release-tag example to the current engine version

Closes #177

## Validation

- `scripts/ci/check-release-surfaces.sh`
- stale tag negative check: `AGENTTRACE_RELEASE_TAG=v0.4.2` fails release-surface validation
- unpublished active npm install negative check fails release-surface validation
- `go test ./...`
- `go build -o /tmp/agenttrace-quality-177 ./cmd/agenttrace`
- `scripts/ci/check-docs-commands.sh`
- `node --check npm/install.js && node --check npm/run.js && (cd npm && npm pack --dry-run)`
- `/tmp/agenttrace-quality-177 --doctor || true`
- `/tmp/agenttrace-quality-177 --demo --overview -f json`
- `npm view agenttrace version --json` returned registry E404, confirming npm remains unpublished at validation time
