### PR TITLE
Guard root README npm availability wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Windows:
 iwr -useb https://raw.githubusercontent.com/luoyuctl/agenttrace/master/install.ps1 | iex
 ```
 
-The npm wrapper is also available as `agenttrace` after each release is published.
+The npm wrapper package is not published yet; use the installer, Homebrew, or Go install paths above for now.
 
 ## Common workflows
 

--- a/scripts/ci/check-release-surfaces.sh
+++ b/scripts/ci/check-release-surfaces.sh
@@ -28,6 +28,12 @@ if grep -Eqi "not been published yet|registry 404|until the first publish" npm/R
   fail "npm README must not present npm install as active while the package is unpublished"
 fi
 
+if grep -Eqi "not been published yet|registry 404|until the first publish" npm/README.md &&
+  grep -Eqi "npm wrapper is also available|npm install -g agenttrace" README.md &&
+  ! grep -Eqi "npm wrapper package is not published yet|after the package is published" README.md; then
+  fail "README must not present npm as active while the package is unpublished"
+fi
+
 if ! grep -q "<div class=\"meta\">v$version" site/demo-report.html &&
   ! grep -qi "static sample data" site/demo-report.html; then
   fail "site demo report must use current version metadata or clearly identify static sample data"


### PR DESCRIPTION
Closes #181

## Scope
- Update root README npm wording to match the current unpublished package state.
- Extend release-surface validation so root README cannot imply npm is active while npm/README.md documents the package as unpublished.

## Validation
- scripts/ci/check-release-surfaces.sh
- scripts/ci/check-docs-commands.sh
- go test ./...
- go build -o /tmp/agenttrace-quality-181 ./cmd/agenttrace
- node --check npm/install.js && node --check npm/run.js && (cd npm && npm pack --dry-run)
- negative check: root README active npm wording fails scripts/ci/check-release-surfaces.sh
