### PR TITLE
[codex] Align guide parser coverage

### DIFF
--- a/docs/community-pain-points.md
+++ b/docs/community-pain-points.md
@@ -16,7 +16,7 @@ These are the product angles agenttrace should keep optimizing for.
 ## Product Implications
 
 - Keep startup fast and local-first.
-- Keep parser coverage broad: Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, Hermes, OpenCode, OpenClaw, Kimi, Copilot-style logs.
+- Keep parser coverage broad: Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces.
 - Make the first TUI screen answer: cost, health, errors, latency, and recent bad sessions.
 - Keep JSON output and CI gates first-class.
 - Prioritize diagnostics that produce an action, not just a chart.

--- a/docs/demo-playbook.md
+++ b/docs/demo-playbook.md
@@ -20,7 +20,7 @@ The script renders [docs/demo.tape](demo.tape) into `assets/agenttrace-demo.gif`
 
 ## Short Caption
 
-agenttrace is a local TUI for AI coding agent session history. It shows what Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, and similar tools spent across cost, tokens, and time, then helps diagnose why a task was slow.
+agenttrace is a local TUI for AI coding agent session history. It shows what Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Cursor exports, Aider, OpenCode, Kimi CLI, Pi, and generic JSON/JSONL traces spent across cost, tokens, and time, then helps diagnose why a task was slow.
 
 ## Verification Before Posting
 

--- a/site/ai-agent-observability.html
+++ b/site/ai-agent-observability.html
@@ -6,9 +6,9 @@
     <title>AI coding agent session history - cost, tokens, time, and slow-run diagnosis</title>
     <meta
       name="description"
-      content="A practical guide to local AI coding agent session history with agenttrace: compare cost, tokens, and time across Claude Code, Codex CLI, Gemini CLI, Cursor, Aider, and OpenCode logs, then diagnose slow tasks."
+      content="A practical guide to local AI coding agent session history with agenttrace: compare cost, tokens, and time across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Cursor, Aider, OpenCode, Kimi CLI, Pi, and generic JSON/JSONL traces, then diagnose slow tasks."
     />
-    <meta name="keywords" content="AI coding agent session history, Claude Code logs, Codex CLI session logs, Gemini CLI observability, Cursor agent traces, Aider chat history, token cost tracking, time tracking, slow agent task diagnosis, tool latency analysis" />
+    <meta name="keywords" content="AI coding agent session history, Claude Code logs, Codex CLI session logs, Gemini CLI observability, Qwen Code sessions, Cline task history, Cursor exports, Aider chat history, OpenCode logs, Kimi CLI logs, Pi agent logs, JSONL traces, token cost tracking, time tracking, slow agent task diagnosis, tool latency analysis" />
     <link rel="canonical" href="https://luoyuctl.github.io/agenttrace/ai-agent-observability.html" />
     <meta property="og:title" content="AI coding agent session history from local logs" />
     <meta property="og:description" content="Learn how agenttrace turns local coding-agent logs into historical cost, token, time, and slow-run evidence." />
@@ -17,7 +17,7 @@
     <meta property="og:image" content="https://luoyuctl.github.io/agenttrace/assets/hero-banner.png" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="AI coding agent session history from local logs" />
-    <meta name="twitter:description" content="Inspect Claude Code, Codex CLI, Gemini CLI, Cursor, Aider, and OpenCode logs for cost, tokens, time, and slow-run diagnosis." />
+    <meta name="twitter:description" content="Inspect local coding-agent logs across Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Cursor, Aider, OpenCode, Kimi CLI, Pi, and JSONL traces." />
     <meta name="twitter:image" content="https://luoyuctl.github.io/agenttrace/assets/hero-banner.png" />
     <link rel="icon" href="assets/logo-icon.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -40,6 +40,15 @@
           "AI coding agent session history",
           "Claude Code logs",
           "Codex CLI session logs",
+          "Gemini CLI sessions",
+          "Qwen Code sessions",
+          "Cline task history",
+          "Cursor exports",
+          "Aider chat history",
+          "OpenCode logs",
+          "Kimi CLI logs",
+          "Pi agent logs",
+          "generic JSON/JSONL traces",
           "token cost tracking",
           "time tracking",
           "slow agent task diagnosis"
@@ -103,8 +112,8 @@
           <span>Compare Gemini CLI sessions across tokens, models, cost, duration, and tool latency.</span>
         </article>
         <article>
-          <strong>Cursor + Aider</strong>
-          <span>Bring exported Cursor traces and Aider chat history into the same local TUI.</span>
+          <strong>More local logs</strong>
+          <span>Bring Qwen Code, Cline, Cursor exports, Aider, OpenCode, OpenClaw, Pi, Kimi CLI, and JSON/JSONL traces into the same local TUI.</span>
         </article>
       </section>
 


### PR DESCRIPTION
## Summary
- align AI observability guide metadata and proof-strip source wording with current README support
- align secondary docs/demo copy with current parser coverage
- avoid npm, package-channel, or release promises

## Validation
- git diff --check
- scripts/ci/check-pages-artifact.sh site
- scripts/ci/check-release-surfaces.sh
- scripts/ci/check-docs-commands.sh
- go test ./...
- go build -o /tmp/agenttrace-guide-docs-check ./cmd/agenttrace
- /tmp/agenttrace-guide-docs-check --version

## Notes
- Covers #191 and #192.
- No runtime code changes.
- The local untracked `agenttrace` binary is not part of this PR.
