### PR TITLE
docs: align skill parser coverage

### DIFF
--- a/skills/agenttrace-session-audit/SKILL.md
+++ b/skills/agenttrace-session-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agenttrace-session-audit
-description: Audit local AI coding-agent sessions with agenttrace. Use when the user asks to inspect Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor, OpenCode, Oh My Pi, Kimi, Copilot-style, or generic JSON/JSONL sessions for cost, tokens, tool failures, latency, anomalies, health, diffs, or CI gates.
+description: Audit local AI coding-agent sessions with agenttrace. Use when the user asks to inspect Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style logs, or generic JSON/JSONL traces for cost, tokens, tool failures, latency, anomalies, health, diffs, or CI gates.
 license: MIT
 metadata:
   short-description: Audit AI agent session health


### PR DESCRIPTION
## Summary
- align `skills/agenttrace-session-audit/SKILL.md` frontmatter with the current README supported-log list
- include Cline, Cursor exports, Hermes Agent, OpenClaw, Pi, Kimi CLI, Copilot-style logs, and JSON/JSONL trace wording
- keep the change scoped to skill metadata only

## Validation
- `git diff --check`
- `scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-release-surfaces.sh`
- `go build -o /tmp/agenttrace-skill-coverage-check ./cmd/agenttrace`