### PR TITLE
Add overview baseline comparison

### DIFF
--- a/cmd/agenttrace/main.go
+++ b/cmd/agenttrace/main.go
@@ -35,6 +35,10 @@ func main() {
 	failUnderHealth := flag.Int("fail-under-health", 0, "Exit non-zero when overview average health is below this score")
 	failOnCritical := flag.Bool("fail-on-critical", false, "Exit non-zero when overview contains critical sessions")
 	maxToolFailRate := flag.Float64("max-tool-fail-rate", -1, "Exit non-zero when overview tool failure rate exceeds this percent")
+	baseline := flag.String("baseline", "", "Compare --overview -f json against a local baseline JSON report")
+	baselineMaxDurationDeltaPct := flag.Float64("baseline-max-duration-delta-pct", 0, "Allowed overview duration increase percent versus --baseline")
+	baselineMaxCostDeltaPct := flag.Float64("baseline-max-cost-delta-pct", 0, "Allowed overview cost increase percent versus --baseline")
+	baselineMaxTokenDeltaPct := flag.Float64("baseline-max-token-delta-pct", 0, "Allowed overview token increase percent versus --baseline")
 	lang := flag.String("lang", "en", "Language for report output: en, zh")
 	flag.Parse()
 
@@ -127,7 +131,7 @@ func main() {
 		return
 	}
 
-	hasAction := path != "" || *latest || *compare || *overview || *wasteFlag
+	hasAction := path != "" || *latest || *compare || *overview || *wasteFlag || *baseline != ""
 
 	if !hasAction {
 		// Launch TUI
@@ -138,6 +142,10 @@ func main() {
 			os.Exit(1)
 		}
 		return
+	}
+	if *baseline != "" && !*overview {
+		fmt.Fprintln(os.Stderr, "--baseline requires --overview -f json")
+		os.Exit(1)
 	}
 
 	// Overview mode
@@ -161,9 +169,25 @@ func main() {
 		}
 		ov := engine.ComputeOverview(sessions)
 		out := engine.ReportOverview(ov, sessions)
+		if *baseline != "" && strings.ToLower(*format) != "json" {
+			fmt.Fprintln(os.Stderr, "--baseline requires --overview -f json")
+			os.Exit(1)
+		}
 		switch *format {
 		case "json":
 			out = engine.ReportOverviewJSON(ov, sessions)
+			if *baseline != "" {
+				var baselineErr error
+				out, baselineErr = engine.AddBaselineComparison(out, *baseline, engine.BaselineThresholds{
+					MaxDurationDeltaPct: *baselineMaxDurationDeltaPct,
+					MaxCostDeltaPct:     *baselineMaxCostDeltaPct,
+					MaxTokenDeltaPct:    *baselineMaxTokenDeltaPct,
+				})
+				if baselineErr != nil {
+					fmt.Fprintf(os.Stderr, i18n.T("cli_error"), baselineErr)
+					os.Exit(1)
+				}
+			}
 		case "markdown", "md":
 			out = engine.ReportOverviewMarkdown(ov, sessions)
 		case "html":

--- a/docs/ci-integration.md
+++ b/docs/ci-integration.md
@@ -43,6 +43,23 @@ agenttrace --overview -f json \
   -o agenttrace-overview.json
 ```
 
+To compare a current run with a local CI baseline artifact, keep a previous
+`--overview -f json` report and pass it back with explicit delta thresholds:
+
+```bash
+agenttrace --overview -f json \
+  --baseline agenttrace-baseline.json \
+  --baseline-max-duration-delta-pct 10 \
+  --baseline-max-cost-delta-pct 15 \
+  --baseline-max-token-delta-pct 20 \
+  -o agenttrace-overview.json
+```
+
+The JSON report includes `baseline_comparison` with deterministic fields for
+duration, cost, token deltas, new failure families, broader tool/file surfaces,
+and new high-authority tool use. Baseline reports must be local JSON artifacts
+from the same agenttrace version.
+
 ## GitHub Actions
 
 ```yaml
@@ -68,6 +85,15 @@ jobs:
             --fail-under-health 80 \
             --fail-on-critical \
             --max-tool-fail-rate 15 \
+            -o agenttrace-overview.json
+      - name: Compare against local baseline
+        if: hashFiles('agenttrace-baseline.json') != ''
+        run: |
+          agenttrace --overview -f json \
+            --baseline agenttrace-baseline.json \
+            --baseline-max-duration-delta-pct 10 \
+            --baseline-max-cost-delta-pct 15 \
+            --baseline-max-token-delta-pct 20 \
             -o agenttrace-overview.json
       - name: Write Markdown summary
         if: always()
@@ -104,6 +130,7 @@ scripts/ci/check-pages-artifact.sh site
 These checks cover:
 
 - demo JSON, Markdown, HTML, and doctor smoke output
+- local baseline comparison JSON contract and deterministic fields
 - `-o` stdout/stderr behavior and failing gate exit code `2`
 - repeated demo latest/overview JSON determinism
 - report cost-label and version metadata consistency

--- a/internal/engine/baseline.go
+++ b/internal/engine/baseline.go
@@ -1,0 +1,182 @@
+package engine
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+type BaselineThresholds struct {
+	MaxDurationDeltaPct float64 `json:"max_duration_delta_pct"`
+	MaxCostDeltaPct     float64 `json:"max_cost_delta_pct"`
+	MaxTokenDeltaPct    float64 `json:"max_token_delta_pct"`
+}
+
+type BaselineComparison struct {
+	BaselinePath            string             `json:"baseline_path"`
+	Thresholds              BaselineThresholds `json:"thresholds"`
+	Current                 baselineSnapshot   `json:"current"`
+	Baseline                baselineSnapshot   `json:"baseline"`
+	DurationDeltaPct        float64            `json:"duration_delta_pct"`
+	CostDeltaPct            float64            `json:"cost_delta_pct"`
+	TokenDeltaPct           float64            `json:"token_delta_pct"`
+	SlowerThanBaseline      bool               `json:"slower_than_baseline"`
+	CostAboveThreshold      bool               `json:"cost_above_threshold"`
+	TokensAboveThreshold    bool               `json:"tokens_above_threshold"`
+	NewFailureFamilies      []string           `json:"new_failure_families"`
+	BroaderToolSurface      bool               `json:"broader_tool_surface"`
+	NewTools                []string           `json:"new_tools"`
+	BroaderFileSurface      bool               `json:"broader_file_surface"`
+	NewFiles                []string           `json:"new_files"`
+	NewHighAuthorityToolUse []string           `json:"new_high_authority_tool_use"`
+}
+
+type baselineSnapshot struct {
+	DurationSeconds    float64  `json:"duration_seconds"`
+	Cost               float64  `json:"cost"`
+	Tokens             int      `json:"tokens"`
+	FailureFamilies    []string `json:"failure_families"`
+	Tools              []string `json:"tools"`
+	Files              []string `json:"files"`
+	HighAuthorityTools []string `json:"high_authority_tools"`
+}
+
+type overviewBaselineReport struct {
+	Version string `json:"version"`
+	Summary struct {
+		TotalDurationSeconds float64 `json:"total_duration_seconds"`
+		TotalCost            float64 `json:"total_cost"`
+		TotalTokens          int     `json:"total_tokens"`
+	} `json:"summary"`
+	FailureFamilies []string `json:"failure_families"`
+	Surfaces        struct {
+		Tools              []string `json:"tools"`
+		Files              []string `json:"files"`
+		HighAuthorityTools []string `json:"high_authority_tools"`
+	} `json:"surfaces"`
+}
+
+func AddBaselineComparison(currentReport string, baselinePath string, thresholds BaselineThresholds) (string, error) {
+	if baselinePath == "" {
+		return "", errors.New("missing baseline report path")
+	}
+	current, err := decodeOverviewBaselineReport([]byte(currentReport), "current report")
+	if err != nil {
+		return "", err
+	}
+	baselineData, err := os.ReadFile(baselinePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("missing baseline report: %s", baselinePath)
+		}
+		return "", fmt.Errorf("read baseline report %s: %w", baselinePath, err)
+	}
+	baseline, err := decodeOverviewBaselineReport(baselineData, "baseline report")
+	if err != nil {
+		return "", err
+	}
+	if baseline.Version != Version {
+		return "", fmt.Errorf("baseline report version %q is incompatible with current version %q", baseline.Version, Version)
+	}
+
+	comparison := compareOverviewBaseline(current, baseline, baselinePath, thresholds)
+	var payload map[string]interface{}
+	if err := json.Unmarshal([]byte(currentReport), &payload); err != nil {
+		return "", fmt.Errorf("decode current report payload: %w", err)
+	}
+	payload["baseline_comparison"] = comparison
+	out, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("encode baseline comparison report: %w", err)
+	}
+	return string(out), nil
+}
+
+func decodeOverviewBaselineReport(data []byte, label string) (overviewBaselineReport, error) {
+	var report overviewBaselineReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return report, fmt.Errorf("decode %s JSON: %w", label, err)
+	}
+	if report.Version == "" {
+		return report, fmt.Errorf("%s is missing version", label)
+	}
+	if report.Summary.TotalTokens == 0 && report.Summary.TotalCost == 0 && report.Summary.TotalDurationSeconds == 0 {
+		return report, fmt.Errorf("%s is missing overview summary totals", label)
+	}
+	return report, nil
+}
+
+func compareOverviewBaseline(current, baseline overviewBaselineReport, baselinePath string, thresholds BaselineThresholds) BaselineComparison {
+	currentSnapshot := baselineSnapshotFromReport(current)
+	baselineSnapshot := baselineSnapshotFromReport(baseline)
+	durationDelta := deltaPct(currentSnapshot.DurationSeconds, baselineSnapshot.DurationSeconds)
+	costDelta := deltaPct(currentSnapshot.Cost, baselineSnapshot.Cost)
+	tokenDelta := deltaPct(float64(currentSnapshot.Tokens), float64(baselineSnapshot.Tokens))
+	newTools := setDiff(currentSnapshot.Tools, baselineSnapshot.Tools)
+	newFiles := setDiff(currentSnapshot.Files, baselineSnapshot.Files)
+	return BaselineComparison{
+		BaselinePath:            baselinePath,
+		Thresholds:              thresholds,
+		Current:                 currentSnapshot,
+		Baseline:                baselineSnapshot,
+		DurationDeltaPct:        durationDelta,
+		CostDeltaPct:            costDelta,
+		TokenDeltaPct:           tokenDelta,
+		SlowerThanBaseline:      durationDelta > thresholds.MaxDurationDeltaPct,
+		CostAboveThreshold:      costDelta > thresholds.MaxCostDeltaPct,
+		TokensAboveThreshold:    tokenDelta > thresholds.MaxTokenDeltaPct,
+		NewFailureFamilies:      setDiff(currentSnapshot.FailureFamilies, baselineSnapshot.FailureFamilies),
+		BroaderToolSurface:      len(newTools) > 0,
+		NewTools:                newTools,
+		BroaderFileSurface:      len(newFiles) > 0,
+		NewFiles:                newFiles,
+		NewHighAuthorityToolUse: setDiff(currentSnapshot.HighAuthorityTools, baselineSnapshot.HighAuthorityTools),
+	}
+}
+
+func baselineSnapshotFromReport(report overviewBaselineReport) baselineSnapshot {
+	return baselineSnapshot{
+		DurationSeconds:    round4(report.Summary.TotalDurationSeconds),
+		Cost:               round4(report.Summary.TotalCost),
+		Tokens:             report.Summary.TotalTokens,
+		FailureFamilies:    sortedStringSet(report.FailureFamilies),
+		Tools:              sortedStringSet(report.Surfaces.Tools),
+		Files:              sortedStringSet(report.Surfaces.Files),
+		HighAuthorityTools: sortedStringSet(report.Surfaces.HighAuthorityTools),
+	}
+}
+
+func deltaPct(current, baseline float64) float64 {
+	if baseline == 0 {
+		if current > 0 {
+			return 100
+		}
+		return 0
+	}
+	return round4((current - baseline) / baseline * 100)
+}
+
+func setDiff(current, baseline []string) []string {
+	seen := make(map[string]struct{}, len(baseline))
+	for _, item := range baseline {
+		seen[item] = struct{}{}
+	}
+	var out []string
+	for _, item := range sortedStringSet(current) {
+		if _, ok := seen[item]; !ok {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+func sortedStringSet(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		if item != "" {
+			seen[item] = struct{}{}
+		}
+	}
+	return sortedReportKeys(seen)
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -95,6 +95,7 @@ type Metrics struct {
 	ToolCallsOK     int
 	ToolCallsFail   int
 	ToolUsage       map[string]int
+	FileUsage       map[string]int
 	ReasoningBlocks int
 	ReasoningChars  int
 	ReasoningLens   []int
@@ -1882,6 +1883,7 @@ func Analyze(events []Event, model string) Metrics {
 	m := Metrics{
 		ModelUsed: model,
 		ToolUsage: make(map[string]int),
+		FileUsage: make(map[string]int),
 	}
 
 	pricing := LookupPrice(model)
@@ -1945,6 +1947,9 @@ func Analyze(events []Event, model string) Metrics {
 					name = "unknown"
 				}
 				m.ToolUsage[name]++
+				for _, file := range extractToolCallFiles(tc.Args) {
+					m.FileUsage[file]++
+				}
 			}
 
 		case "tool":
@@ -2002,6 +2007,64 @@ func Analyze(events []Event, model string) Metrics {
 	)
 
 	return m
+}
+
+func extractToolCallFiles(args string) []string {
+	if strings.TrimSpace(args) == "" {
+		return nil
+	}
+	var raw interface{}
+	if err := json.Unmarshal([]byte(args), &raw); err != nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	collectToolCallFiles(raw, "", seen)
+	files := make([]string, 0, len(seen))
+	for file := range seen {
+		files = append(files, file)
+	}
+	sort.Strings(files)
+	return files
+}
+
+func collectToolCallFiles(raw interface{}, key string, seen map[string]struct{}) {
+	switch v := raw.(type) {
+	case map[string]interface{}:
+		for k, child := range v {
+			collectToolCallFiles(child, strings.ToLower(k), seen)
+		}
+	case []interface{}:
+		for _, child := range v {
+			collectToolCallFiles(child, key, seen)
+		}
+	case string:
+		if !isFileSurfaceKey(key) {
+			return
+		}
+		file := normalizeToolCallFile(v)
+		if file != "" {
+			seen[file] = struct{}{}
+		}
+	}
+}
+
+func isFileSurfaceKey(key string) bool {
+	key = strings.ReplaceAll(strings.ToLower(key), "-", "_")
+	switch key {
+	case "path", "file", "files", "filename", "file_name", "filepath", "file_path", "target", "target_file", "uri":
+		return true
+	default:
+		return strings.Contains(key, "file") || strings.Contains(key, "path")
+	}
+}
+
+func normalizeToolCallFile(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.Contains(value, "\n") || strings.HasPrefix(value, "http://") || strings.HasPrefix(value, "https://") {
+		return ""
+	}
+	value = strings.TrimPrefix(value, "file://")
+	return filepath.ToSlash(filepath.Clean(value))
 }
 
 // ═══════════════════════════════════════════════════════════════

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1328,7 +1328,7 @@ func TestAnalyze(t *testing.T) {
 	events := []Event{
 		{Role: "user", Content: "hello", SourceTool: "h", Timestamp: "2026-01-01T00:00:00Z"},
 		{Role: "assistant", Content: "hi", SourceTool: "h", Timestamp: "2026-01-01T00:00:01Z"},
-		{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file", ID: "t1"}}, SourceTool: "h", Timestamp: "2026-01-01T00:00:02Z"},
+		{Role: "assistant", ToolCalls: []ToolCall{{Name: "read_file", ID: "t1", Args: `{"path":"README.md"}`}}, SourceTool: "h", Timestamp: "2026-01-01T00:00:02Z"},
 		{Role: "tool", Content: "ok", ToolCallID: "t1", SourceTool: "h", Timestamp: "2026-01-01T00:00:03Z"},
 	}
 	m := Analyze(events, "default")
@@ -1347,6 +1347,9 @@ func TestAnalyze(t *testing.T) {
 	if m.CostEstimated < 0 {
 		t.Error("cost should be >=0")
 	}
+	if m.FileUsage["README.md"] != 1 {
+		t.Fatalf("expected file surface from tool args, got %+v", m.FileUsage)
+	}
 }
 
 func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
@@ -1363,7 +1366,10 @@ func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
 				TokensCacheR:  50,
 				ToolCallsOK:   9,
 				ToolCallsFail: 1,
+				ToolUsage:     map[string]int{"read_file": 1},
+				FileUsage:     map[string]int{"README.md": 1},
 				CostEstimated: 0.25,
+				DurationSec:   60,
 			},
 		},
 		{
@@ -1376,7 +1382,10 @@ func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
 				TokensInput:   200,
 				TokensOutput:  100,
 				ToolCallsFail: 2,
+				ToolUsage:     map[string]int{"bash": 1},
+				FileUsage:     map[string]int{"cmd/agenttrace/main.go": 1},
 				CostEstimated: 0.75,
+				DurationSec:   180,
 			},
 		},
 	}
@@ -1387,6 +1396,7 @@ func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
 			TotalSessions  int     `json:"total_sessions"`
 			Critical       int     `json:"critical"`
 			TotalCost      float64 `json:"total_cost"`
+			TotalDuration  float64 `json:"total_duration_seconds"`
 			TotalTokens    int     `json:"total_tokens"`
 			ToolFailRate   float64 `json:"tool_fail_rate"`
 			AnomaliesTotal int     `json:"anomalies_total"`
@@ -1400,6 +1410,12 @@ func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
 				} `json:"points"`
 			} `json:"health_trend"`
 		} `json:"summary"`
+		FailureFamilies []string `json:"failure_families"`
+		Surfaces        struct {
+			Tools              []string `json:"tools"`
+			Files              []string `json:"files"`
+			HighAuthorityTools []string `json:"high_authority_tools"`
+		} `json:"surfaces"`
 		ByAgent []struct {
 			Name     string  `json:"name"`
 			Sessions int     `json:"sessions"`
@@ -1418,7 +1434,7 @@ func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
 	if payload.Version != Version || payload.Summary.TotalSessions != 2 || payload.Summary.Critical != 1 {
 		t.Fatalf("bad summary: %+v", payload.Summary)
 	}
-	if payload.Summary.TotalCost != 1 || payload.Summary.TotalTokens != 525 || payload.Summary.ToolFailRate != 25 {
+	if payload.Summary.TotalCost != 1 || payload.Summary.TotalDuration != 240 || payload.Summary.TotalTokens != 525 || payload.Summary.ToolFailRate != 25 {
 		t.Fatalf("missing operational totals: %+v", payload.Summary)
 	}
 	if payload.Summary.AnomaliesTotal != 1 {
@@ -1427,9 +1443,94 @@ func TestReportOverviewJSONIncludesOperationalSummary(t *testing.T) {
 	if payload.Summary.HealthTrend.Direction == "" || payload.Summary.HealthTrend.Message == "" || len(payload.Summary.HealthTrend.Points) != 2 {
 		t.Fatalf("missing health trend: %+v", payload.Summary.HealthTrend)
 	}
+	if !containsString(payload.FailureFamilies, "hanging") ||
+		!containsString(payload.Surfaces.Tools, "bash") ||
+		!containsString(payload.Surfaces.Files, "README.md") ||
+		!containsString(payload.Surfaces.HighAuthorityTools, "bash") {
+		t.Fatalf("missing deterministic comparison surfaces: families=%v surfaces=%+v", payload.FailureFamilies, payload.Surfaces)
+	}
 	if len(payload.ByAgent) != 2 || len(payload.RecentSessions) != 2 || len(payload.Anomalies) != 1 {
 		t.Fatalf("missing overview sections: agents=%d recent=%d anomalies=%d",
 			len(payload.ByAgent), len(payload.RecentSessions), len(payload.Anomalies))
+	}
+}
+
+func TestAddBaselineComparisonFlagsDeterministicRegressions(t *testing.T) {
+	baselineSessions := []Session{{
+		Name:      "base",
+		Health:    90,
+		Anomalies: []Anomaly{{Type: "tool_failures"}},
+		Metrics: Metrics{
+			TokensInput:   100,
+			ToolCallsOK:   1,
+			ToolUsage:     map[string]int{"read_file": 1},
+			FileUsage:     map[string]int{"README.md": 1},
+			CostEstimated: 0.10,
+			DurationSec:   100,
+		},
+	}}
+	baselinePath := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(baselinePath, []byte(ReportOverviewJSON(ComputeOverview(baselineSessions), baselineSessions)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	currentSessions := []Session{{
+		Name:      "current",
+		Health:    40,
+		Anomalies: []Anomaly{{Type: "hanging"}, {Type: "tool_failures"}},
+		Metrics: Metrics{
+			TokensInput:   150,
+			ToolCallsOK:   1,
+			ToolUsage:     map[string]int{"bash": 1, "read_file": 1},
+			FileUsage:     map[string]int{"README.md": 1, "cmd/agenttrace/main.go": 1},
+			CostEstimated: 0.13,
+			DurationSec:   120,
+		},
+	}}
+	out, err := AddBaselineComparison(
+		ReportOverviewJSON(ComputeOverview(currentSessions), currentSessions),
+		baselinePath,
+		BaselineThresholds{MaxDurationDeltaPct: 10, MaxCostDeltaPct: 20, MaxTokenDeltaPct: 25},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var payload struct {
+		BaselineComparison BaselineComparison `json:"baseline_comparison"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("invalid comparison json: %v", err)
+	}
+	cmp := payload.BaselineComparison
+	if !cmp.SlowerThanBaseline || !cmp.CostAboveThreshold || !cmp.TokensAboveThreshold {
+		t.Fatalf("expected threshold regressions, got %+v", cmp)
+	}
+	if cmp.DurationDeltaPct != 20 || cmp.CostDeltaPct != 30 || cmp.TokenDeltaPct != 50 {
+		t.Fatalf("unexpected deltas: %+v", cmp)
+	}
+	if !containsString(cmp.NewFailureFamilies, "hanging") ||
+		!cmp.BroaderToolSurface ||
+		!containsString(cmp.NewTools, "bash") ||
+		!cmp.BroaderFileSurface ||
+		!containsString(cmp.NewFiles, "cmd/agenttrace/main.go") ||
+		!containsString(cmp.NewHighAuthorityToolUse, "bash") {
+		t.Fatalf("missing comparison surface regressions: %+v", cmp)
+	}
+}
+
+func TestAddBaselineComparisonRejectsMissingOrIncompatibleBaseline(t *testing.T) {
+	current := ReportOverviewJSON(ComputeOverview([]Session{{Metrics: Metrics{TokensInput: 1}}}), []Session{{Metrics: Metrics{TokensInput: 1}}})
+	if _, err := AddBaselineComparison(current, filepath.Join(t.TempDir(), "missing.json"), BaselineThresholds{}); err == nil || !strings.Contains(err.Error(), "missing baseline report") {
+		t.Fatalf("expected missing baseline diagnostic, got %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.WriteFile(path, []byte(`{"version":"v0.0.0","summary":{"total_tokens":1}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AddBaselineComparison(current, path, BaselineThresholds{}); err == nil || !strings.Contains(err.Error(), "incompatible") {
+		t.Fatalf("expected incompatible baseline diagnostic, got %v", err)
 	}
 }
 
@@ -2131,4 +2232,13 @@ func TestWasteReportClampsLoopWasteToTotal(t *testing.T) {
 	if report.TotalWasted > s.Metrics.CostEstimated {
 		t.Fatalf("total wasted should not exceed total cost for loop-only waste: got %.4f total %.4f", report.TotalWasted, s.Metrics.CostEstimated)
 	}
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -367,12 +367,28 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 	totalTokens := 0
 	totalTools := 0
 	failedTools := 0
+	totalDuration := 0.0
 	totalHealth := 0
+	toolSurface := make(map[string]struct{})
+	fileSurface := make(map[string]struct{})
+	failureFamilies := make(map[string]struct{})
 	for _, s := range orderedSessions {
 		totalTokens += s.Metrics.TokensInput + s.Metrics.TokensOutput + s.Metrics.TokensCacheW + s.Metrics.TokensCacheR
 		totalTools += s.Metrics.ToolCallsOK + s.Metrics.ToolCallsFail
 		failedTools += s.Metrics.ToolCallsFail
+		totalDuration += s.Metrics.DurationSec
 		totalHealth += s.Health
+		for tool := range s.Metrics.ToolUsage {
+			toolSurface[tool] = struct{}{}
+		}
+		for file := range s.Metrics.FileUsage {
+			fileSurface[file] = struct{}{}
+		}
+		for _, anomaly := range s.Anomalies {
+			if anomaly.Type != "" {
+				failureFamilies[anomaly.Type] = struct{}{}
+			}
+		}
 	}
 	avgHealth := 0.0
 	if len(orderedSessions) > 0 {
@@ -451,19 +467,20 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 	payload := map[string]interface{}{
 		"version": Version,
 		"summary": map[string]interface{}{
-			"total_sessions":      ov.TotalSessions,
-			"healthy":             ov.Healthy,
-			"warning":             ov.Warning,
-			"critical":            ov.Critical,
-			"avg_health":          avgHealth,
-			"total_cost":          round4(ov.TotalCost),
-			"total_tokens":        totalTokens,
-			"tool_calls":          totalTools,
-			"tool_failures":       failedTools,
-			"tool_fail_rate":      toolFailRate,
-			"anomalies_total":     len(anomalies),
-			"anomalies_returned":  len(anomaliesReturned),
-			"anomalies_truncated": len(anomaliesReturned) < len(anomalies),
+			"total_sessions":         ov.TotalSessions,
+			"healthy":                ov.Healthy,
+			"warning":                ov.Warning,
+			"critical":               ov.Critical,
+			"avg_health":             avgHealth,
+			"total_cost":             round4(ov.TotalCost),
+			"total_duration_seconds": round4(totalDuration),
+			"total_tokens":           totalTokens,
+			"tool_calls":             totalTools,
+			"tool_failures":          failedTools,
+			"tool_fail_rate":         toolFailRate,
+			"anomalies_total":        len(anomalies),
+			"anomalies_returned":     len(anomaliesReturned),
+			"anomalies_truncated":    len(anomaliesReturned) < len(anomalies),
 			"health_trend": map[string]interface{}{
 				"direction":  trend.Direction,
 				"regressing": trend.Regressing,
@@ -471,6 +488,12 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 				"message":    trend.Message,
 				"points":     points,
 			},
+		},
+		"failure_families": sortedReportKeys(failureFamilies),
+		"surfaces": map[string]interface{}{
+			"tools":                sortedReportKeys(toolSurface),
+			"files":                sortedReportKeys(fileSurface),
+			"high_authority_tools": highAuthorityTools(sortedReportKeys(toolSurface)),
 		},
 		"by_agent":        agents,
 		"by_model":        models,
@@ -814,6 +837,49 @@ func minReportInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func sortedReportKeys(items map[string]struct{}) []string {
+	out := make([]string, 0, len(items))
+	for item := range items {
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func highAuthorityTools(tools []string) []string {
+	var out []string
+	for _, tool := range tools {
+		if isHighAuthorityTool(tool) {
+			out = append(out, tool)
+		}
+	}
+	return out
+}
+
+func isHighAuthorityTool(tool string) bool {
+	name := strings.ToLower(tool)
+	for _, marker := range []string{
+		"apply_patch",
+		"bash",
+		"delete",
+		"edit",
+		"exec",
+		"remove",
+		"rm",
+		"run_command",
+		"shell",
+		"terminal",
+		"write",
+	} {
+		if strings.Contains(name, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func markdownCell(value string) string {

--- a/scripts/ci/check-deterministic-output.sh
+++ b/scripts/ci/check-deterministic-output.sh
@@ -17,6 +17,11 @@ for i in 1 2 3; do
   "$bin" --demo --overview -f json >"$out_dir/determinism/overview-$i.json"
 done
 
+for i in 1 2 3; do
+  "$bin" --demo --overview -f json --baseline "$out_dir/determinism/overview-1.json" \
+    >"$out_dir/determinism/baseline-$i.json"
+done
+
 for path in "$out_dir"/determinism/*.json; do
   node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' "$path" \
     || fail "invalid JSON: $path"
@@ -30,3 +35,7 @@ cmp -s "$out_dir/determinism/overview-1.json" "$out_dir/determinism/overview-2.j
   || fail "--demo --overview -f json changed between run 1 and 2"
 cmp -s "$out_dir/determinism/overview-1.json" "$out_dir/determinism/overview-3.json" \
   || fail "--demo --overview -f json changed between run 1 and 3"
+cmp -s "$out_dir/determinism/baseline-1.json" "$out_dir/determinism/baseline-2.json" \
+  || fail "--demo --overview -f json --baseline changed between run 1 and 2"
+cmp -s "$out_dir/determinism/baseline-1.json" "$out_dir/determinism/baseline-3.json" \
+  || fail "--demo --overview -f json --baseline changed between run 1 and 3"

--- a/scripts/ci/check-output-contract.sh
+++ b/scripts/ci/check-output-contract.sh
@@ -34,8 +34,32 @@ node -e '
 const report = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
 if (!report.version) throw new Error("missing version");
 if (!report.summary || report.summary.total_sessions < 1) throw new Error("missing demo summary");
+if (typeof report.summary.total_duration_seconds !== "number") throw new Error("missing duration summary");
 if (!Array.isArray(report.recent_sessions) || report.recent_sessions.length < 1) throw new Error("missing recent sessions");
+if (!report.surfaces || !Array.isArray(report.surfaces.tools) || !Array.isArray(report.surfaces.files)) {
+  throw new Error("missing comparison surfaces");
+}
 ' "$out_dir/agenttrace-demo.json"
+
+"$bin" --demo --overview -f json \
+  --baseline "$out_dir/agenttrace-demo.json" \
+  --baseline-max-duration-delta-pct 0 \
+  --baseline-max-cost-delta-pct 0 \
+  --baseline-max-token-delta-pct 0 \
+  >"$out_dir/agenttrace-baseline-compare.json"
+require_file "$out_dir/agenttrace-baseline-compare.json"
+require_json "$out_dir/agenttrace-baseline-compare.json"
+node -e '
+const report = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+const cmp = report.baseline_comparison;
+if (!cmp) throw new Error("missing baseline_comparison");
+for (const key of ["slower_than_baseline", "cost_delta_pct", "token_delta_pct", "new_failure_families", "broader_tool_surface", "broader_file_surface", "new_high_authority_tool_use"]) {
+  if (!(key in cmp)) throw new Error(`missing baseline comparison field ${key}`);
+}
+if (cmp.slower_than_baseline || cmp.cost_delta_pct !== 0 || cmp.token_delta_pct !== 0) {
+  throw new Error("identical demo baseline should not regress");
+}
+' "$out_dir/agenttrace-baseline-compare.json"
 
 "$bin" --demo --overview -f markdown \
   -o "$out_dir/agenttrace-demo.md" \

--- a/scripts/ci/check-report-semantics.sh
+++ b/scripts/ci/check-report-semantics.sh
@@ -40,6 +40,26 @@ const version = process.argv[2];
 const report = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
 if (report.version !== version) throw new Error(`json version ${report.version} != ${version}`);
 if (!report.summary || typeof report.summary.total_cost !== "number") throw new Error("missing total_cost");
+if (typeof report.summary.total_duration_seconds !== "number") throw new Error("missing total_duration_seconds");
 if (report.summary.total_sessions !== 3) throw new Error("demo summary should contain 3 sessions");
 if (!Array.isArray(report.recent_sessions) || report.recent_sessions.length !== 3) throw new Error("demo should contain 3 recent sessions");
+if (!Array.isArray(report.failure_families)) throw new Error("missing failure_families");
+if (!report.surfaces || !Array.isArray(report.surfaces.tools) || !Array.isArray(report.surfaces.high_authority_tools)) {
+  throw new Error("missing deterministic comparison surfaces");
+}
 ' "$out_dir/semantics/overview.json" "$version"
+
+"$bin" --demo --overview -f json --baseline "$out_dir/semantics/overview.json" \
+  >"$out_dir/semantics/baseline-compare.json"
+node -e '
+const fs = require("fs");
+const report = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const cmp = report.baseline_comparison;
+if (!cmp) throw new Error("missing baseline comparison");
+if (cmp.duration_delta_pct !== 0 || cmp.cost_delta_pct !== 0 || cmp.token_delta_pct !== 0) {
+  throw new Error("identical baseline should have zero deltas");
+}
+if (!("slower_than_baseline" in cmp) || !("broader_tool_surface" in cmp) || !("new_high_authority_tool_use" in cmp)) {
+  throw new Error("baseline comparison missing regression fields");
+}
+' "$out_dir/semantics/baseline-compare.json"


### PR DESCRIPTION
## Summary
- add `--baseline` support for `--overview -f json` with explicit duration, cost, and token delta thresholds
- expose deterministic overview comparison fields for failure families, tool/file surface, and high-authority tool use
- extend CI output-contract, deterministic-output, and report-semantics checks for baseline comparison

Closes #200

## Test plan
- `go test ./...`
- `go build -o /tmp/agenttrace-quality-200 ./cmd/agenttrace`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-200 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-200-ci scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-200 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-200-ci scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-200 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-200-ci scripts/ci/check-report-semantics.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-200 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-200-ci scripts/ci/check-docs-commands.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-200 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-200-ci scripts/ci/check-release-surfaces.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-200 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-200-ci scripts/ci/check-pages-artifact.sh site`
- `/tmp/agenttrace-quality-200 --doctor || true`
- `/tmp/agenttrace-quality-200 --demo --overview -f json --baseline /tmp/agenttrace-quality-200-ci/agenttrace-demo.json | node -e 'const fs=require("fs"); const r=JSON.parse(fs.readFileSync(0,"utf8")); if(!r.baseline_comparison) throw new Error("missing baseline_comparison"); console.log(JSON.stringify({duration_delta_pct:r.baseline_comparison.duration_delta_pct,cost_delta_pct:r.baseline_comparison.cost_delta_pct,token_delta_pct:r.baseline_comparison.token_delta_pct,broader_tool_surface:r.baseline_comparison.broader_tool_surface}))'`