### PR TITLE
[Impl] Add incident timeline evidence to TUI and reports

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1587,15 +1587,18 @@ func TestReportOverviewMarkdownIncludesCISummary(t *testing.T) {
 			Name:   "good|session",
 			Health: 92,
 			Metrics: Metrics{
-				SourceTool:    "aider",
-				ModelUsed:     "gpt-4.1",
-				TokensInput:   1000,
-				TokensOutput:  500,
-				TokensCacheW:  25,
-				TokensCacheR:  50,
-				ToolCallsOK:   4,
-				ToolCallsFail: 1,
-				CostEstimated: 0.12,
+				SourceTool:     "aider",
+				ModelUsed:      "gpt-4.1",
+				TokensInput:    1000,
+				TokensOutput:   500,
+				TokensCacheW:   25,
+				TokensCacheR:   50,
+				ToolCallsOK:    4,
+				ToolCallsFail:  1,
+				ToolUsage:      map[string]int{"read_file": 5},
+				AssistantTurns: 2,
+				DurationSec:    45,
+				CostEstimated:  0.12,
 			},
 		},
 		{
@@ -1603,12 +1606,14 @@ func TestReportOverviewMarkdownIncludesCISummary(t *testing.T) {
 			Health:    30,
 			Anomalies: []Anomaly{{Type: "hanging", Severity: SeverityHigh}},
 			Metrics: Metrics{
-				SourceTool:    "cursor",
-				ModelUsed:     "default",
-				TokensInput:   300,
-				TokensOutput:  200,
-				ToolCallsFail: 5,
-				CostEstimated: 0.34,
+				SourceTool:     "cursor",
+				ModelUsed:      "default",
+				TokensInput:    300,
+				TokensOutput:   200,
+				ToolCallsFail:  5,
+				AssistantTurns: 1,
+				DurationSec:    90,
+				CostEstimated:  0.34,
 			},
 		},
 	}
@@ -1619,6 +1624,9 @@ func TestReportOverviewMarkdownIncludesCISummary(t *testing.T) {
 		"| Total tokens | 2075 |",
 		"| Health Trend |",
 		"| Tool failures | 6 / 10 (60.0%) |",
+		"## Incident timeline",
+		"Last milestone",
+		"Touched surface",
 		"| Aider | 1 |",
 		"| Cursor | 1 |",
 		"good\\|session",
@@ -1627,6 +1635,67 @@ func TestReportOverviewMarkdownIncludesCISummary(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("markdown report missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestBuildIncidentTimelineKeepsEvidenceCompact(t *testing.T) {
+	got := BuildIncidentTimeline(Session{
+		Name: "incident",
+		Metrics: Metrics{
+			AssistantTurns: 4,
+			DurationSec:    125,
+			GapsSec:        []float64{2, 75},
+			ToolCallsOK:    3,
+			ToolCallsFail:  2,
+			ToolUsage:      map[string]int{"read_file": 2, "shell\nsecret args": 3},
+			TokensInput:    42000,
+			TokensOutput:   9000,
+			CostEstimated:  0.80,
+		},
+		LoopFingerprints: []LoopFingerprint{{ToolName: "shell\nsecret args", Count: 3, Severity: "critical"}},
+		LoopCost:         LoopCost{TotalLoopCost: 0.30},
+	})
+	if len(got.Items) < 5 {
+		t.Fatalf("expected compact incident evidence, got %+v", got.Items)
+	}
+	kinds := map[string]bool{}
+	for _, item := range got.Items {
+		kinds[item.Kind] = true
+		if strings.Contains(item.Detail, "\n") {
+			t.Fatalf("timeline detail should stay one-line and redacted enough for reports: %+v", item)
+		}
+		if strings.Contains(item.Detail, "secret") {
+			t.Fatalf("timeline detail should not expose whitespace-suffixed tool text: %+v", item)
+		}
+	}
+	for _, want := range []string{"milestone", "idle_gap", "failure_loop", "touched_surface", "burn_divergence"} {
+		if !kinds[want] {
+			t.Fatalf("missing incident timeline kind %q in %+v", want, got.Items)
+		}
+	}
+}
+
+func TestReportOverviewJSONIncludesIncidentTimelines(t *testing.T) {
+	sessions := []Session{{
+		Name:   "slow",
+		Health: 45,
+		Metrics: Metrics{
+			AssistantTurns: 3,
+			DurationSec:    180,
+			GapsSec:        []float64{90},
+			ToolCallsOK:    1,
+			ToolCallsFail:  2,
+			ToolUsage:      map[string]int{"shell": 3},
+		},
+	}}
+	var payload struct {
+		IncidentTimelines []IncidentTimelineSummary `json:"incident_timelines"`
+	}
+	if err := json.Unmarshal([]byte(ReportOverviewJSON(ComputeOverview(sessions), sessions)), &payload); err != nil {
+		t.Fatalf("parse overview json: %v", err)
+	}
+	if len(payload.IncidentTimelines) != 1 || len(payload.IncidentTimelines[0].Items) == 0 {
+		t.Fatalf("expected incident timeline JSON evidence, got %+v", payload.IncidentTimelines)
 	}
 }
 

--- a/internal/engine/incident_timeline.go
+++ b/internal/engine/incident_timeline.go
@@ -1,0 +1,162 @@
+package engine
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/luoyuctl/agenttrace/internal/i18n"
+)
+
+type IncidentTimelineItem struct {
+	Kind     string `json:"kind"`
+	Label    string `json:"label"`
+	Detail   string `json:"detail"`
+	Severity string `json:"severity"`
+}
+
+type IncidentTimelineSummary struct {
+	Session string                 `json:"session"`
+	Items   []IncidentTimelineItem `json:"items"`
+}
+
+func BuildIncidentTimeline(s Session) IncidentTimelineSummary {
+	m := s.Metrics
+	summary := IncidentTimelineSummary{Session: s.Name}
+	add := func(kind, label, detail, severity string) {
+		detail = strings.TrimSpace(detail)
+		if detail == "" {
+			return
+		}
+		summary.Items = append(summary.Items, IncidentTimelineItem{
+			Kind: kind, Label: label, Detail: detail, Severity: severity,
+		})
+	}
+
+	if m.AssistantTurns > 0 {
+		detail := fmt.Sprintf(i18n.T("incident_milestone_detail"), m.AssistantTurns, FmtDuration(m.DurationSec))
+		add("milestone", i18n.T("incident_milestone"), detail, SeverityLow)
+	}
+
+	if gap := maxIncidentGap(m.GapsSec); gap >= 30 {
+		severity := SeverityLow
+		if gap >= 300 {
+			severity = SeverityHigh
+		} else if gap >= 60 {
+			severity = SeverityMedium
+		}
+		add("idle_gap", i18n.T("incident_idle_gap"), fmt.Sprintf(i18n.T("incident_idle_gap_detail"), gap), severity)
+	}
+
+	if fp, ok := topIncidentLoop(s.LoopFingerprints); ok {
+		tool := incidentSafeName(fp.ToolName)
+		if tool == "" {
+			tool = i18n.T("unknown_tool")
+		}
+		add("failure_loop", i18n.T("incident_failure_loop"), fmt.Sprintf(i18n.T("incident_failure_loop_detail"), tool, fp.Count), incidentLoopSeverity(fp.Severity))
+	} else if totalTools := m.ToolCallsOK + m.ToolCallsFail; totalTools > 0 && m.ToolCallsFail > 1 {
+		failRate := float64(m.ToolCallsFail) / float64(totalTools) * 100
+		severity := SeverityMedium
+		if failRate >= 30 {
+			severity = SeverityHigh
+		}
+		add("failure_loop", i18n.T("incident_failure_loop"), fmt.Sprintf(i18n.T("incident_failure_rate_detail"), m.ToolCallsFail, totalTools, failRate), severity)
+	}
+
+	if totalTools := m.ToolCallsOK + m.ToolCallsFail; totalTools > 0 && len(m.ToolUsage) > 0 {
+		name, count := topIncidentTool(m.ToolUsage)
+		if count > 0 {
+			add("touched_surface", i18n.T("incident_touched_surface"), fmt.Sprintf(i18n.T("incident_touched_surface_detail"), len(m.ToolUsage), totalTools, incidentSafeName(name), count), SeverityLow)
+		}
+	}
+
+	totalTokens := m.TokensInput + m.TokensOutput + m.TokensCacheW + m.TokensCacheR
+	if s.LoopCost.TotalLoopCost > 0 && m.CostEstimated > 0 {
+		loopCost := ClampLoopWaste(s.LoopCost.TotalLoopCost, m.CostEstimated)
+		add("burn_divergence", i18n.T("incident_burn_divergence"), fmt.Sprintf(i18n.T("incident_burn_loop_detail"), loopCost, m.CostEstimated), SeverityHigh)
+	} else if totalTokens > 0 && m.AssistantTurns > 0 {
+		tokensPerTurn := totalTokens / m.AssistantTurns
+		if tokensPerTurn >= 10000 {
+			add("burn_divergence", i18n.T("incident_burn_divergence"), fmt.Sprintf(i18n.T("incident_burn_tokens_detail"), tokensPerTurn, m.AssistantTurns), SeverityMedium)
+		}
+	}
+
+	return summary
+}
+
+func maxIncidentGap(gaps []float64) float64 {
+	maxGap := 0.0
+	for _, gap := range gaps {
+		if math.IsNaN(gap) || math.IsInf(gap, 0) || gap < 0 {
+			continue
+		}
+		if gap > maxGap {
+			maxGap = gap
+		}
+	}
+	return maxGap
+}
+
+func topIncidentLoop(items []LoopFingerprint) (LoopFingerprint, bool) {
+	if len(items) == 0 {
+		return LoopFingerprint{}, false
+	}
+	ordered := append([]LoopFingerprint(nil), items...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].Count == ordered[j].Count {
+			if ordered[i].ToolName == ordered[j].ToolName {
+				return ordered[i].ResultHash < ordered[j].ResultHash
+			}
+			return ordered[i].ToolName < ordered[j].ToolName
+		}
+		return ordered[i].Count > ordered[j].Count
+	})
+	return ordered[0], true
+}
+
+func topIncidentTool(items map[string]int) (string, int) {
+	type kv struct {
+		name  string
+		count int
+	}
+	ordered := make([]kv, 0, len(items))
+	for name, count := range items {
+		if count <= 0 {
+			continue
+		}
+		ordered = append(ordered, kv{name: name, count: count})
+	}
+	if len(ordered) == 0 {
+		return "", 0
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		if ordered[i].count == ordered[j].count {
+			return ordered[i].name < ordered[j].name
+		}
+		return ordered[i].count > ordered[j].count
+	})
+	return ordered[0].name, ordered[0].count
+}
+
+func incidentLoopSeverity(severity string) string {
+	switch strings.ToLower(severity) {
+	case SeverityHigh, "critical":
+		return SeverityHigh
+	case SeverityMedium, "warning":
+		return SeverityMedium
+	default:
+		return SeverityLow
+	}
+}
+
+func incidentSafeName(value string) string {
+	value = strings.TrimSpace(value)
+	if fields := strings.Fields(value); len(fields) > 0 {
+		value = fields[0]
+	}
+	if len(value) > 48 {
+		value = value[:48]
+	}
+	return value
+}

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -447,6 +447,7 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 	for _, p := range trend.Points {
 		points = append(points, trendPoint{Name: p.Name, Health: p.Health, Cost: round4(p.Cost)})
 	}
+	incidentTimelines := overviewIncidentTimelines(orderedSessions, 10)
 
 	payload := map[string]interface{}{
 		"version": Version,
@@ -472,10 +473,11 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 				"points":     points,
 			},
 		},
-		"by_agent":        agents,
-		"by_model":        models,
-		"recent_sessions": recent,
-		"anomalies":       anomaliesReturned,
+		"by_agent":           agents,
+		"by_model":           models,
+		"recent_sessions":    recent,
+		"incident_timelines": incidentTimelines,
+		"anomalies":          anomaliesReturned,
 	}
 	out, _ := json.MarshalIndent(payload, "", "  ")
 	return string(out)
@@ -497,6 +499,25 @@ func ReportOverviewMarkdown(ov Overview, sessions []Session) string {
 	fmt.Fprintf(&b, "| %s | $%.2f |\n", i18n.T("total_cost"), ov.TotalCost)
 	fmt.Fprintf(&b, "| %s | %d |\n", i18n.T("report_total_tokens"), summary.TotalTokens)
 	fmt.Fprintf(&b, "| %s | %d / %d (%.1f%%) |\n\n", i18n.T("report_tool_failures"), summary.FailedTools, summary.TotalTools, summary.ToolFailRate)
+
+	fmt.Fprintf(&b, "## %s\n\n", i18n.T("incident_timeline_title"))
+	timelines := overviewIncidentTimelines(orderedSessions, 6)
+	if len(timelines) == 0 {
+		fmt.Fprintf(&b, "%s\n\n", i18n.T("incident_timeline_no_evidence"))
+	} else {
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n|---|---|---|---|\n",
+			i18n.T("report_session"), i18n.T("incident_timeline_signal"), i18n.T("incident_timeline_evidence"), i18n.T("incident_timeline_severity"))
+		for _, timeline := range timelines {
+			for _, item := range timeline.Items {
+				fmt.Fprintf(&b, "| %s | %s | %s | %s |\n",
+					markdownCell(timeline.Session),
+					markdownCell(item.Label),
+					markdownCell(item.Detail),
+					markdownCell(reportSeverityLabel(item.Severity)))
+			}
+		}
+		fmt.Fprintln(&b)
+	}
 
 	fmt.Fprintf(&b, "## %s\n\n", i18n.T("report_by_agent"))
 	fmt.Fprintf(&b, "| %s | %s | %s |\n|---|---:|---:|\n", i18n.T("report_agent"), i18n.T("report_sessions"), i18n.T("report_cost"))
@@ -606,6 +627,26 @@ func ReportOverviewHTML(ov Overview, sessions []Session) string {
 	if len(orderedSessions) > 1 {
 		w(fmt.Sprintf(`<section><h2>%s</h2><p>%s</p></section>`, html.EscapeString(i18n.T("trend_title")), html.EscapeString(trend.Message)))
 	}
+
+	w(fmt.Sprintf(`<section><h2>%s</h2>`, html.EscapeString(i18n.T("incident_timeline_title"))))
+	timelines := overviewIncidentTimelines(orderedSessions, 8)
+	if len(timelines) == 0 {
+		w(fmt.Sprintf(`<p>%s</p>`, html.EscapeString(i18n.T("incident_timeline_no_evidence"))))
+	} else {
+		w(fmt.Sprintf(`<table><thead><tr><th>%s</th><th>%s</th><th>%s</th><th>%s</th></tr></thead><tbody>`,
+			html.EscapeString(i18n.T("report_session")), html.EscapeString(i18n.T("incident_timeline_signal")), html.EscapeString(i18n.T("incident_timeline_evidence")), html.EscapeString(i18n.T("incident_timeline_severity"))))
+		for _, timeline := range timelines {
+			for _, item := range timeline.Items {
+				w(fmt.Sprintf(`<tr><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>`,
+					html.EscapeString(timeline.Session),
+					html.EscapeString(item.Label),
+					html.EscapeString(item.Detail),
+					html.EscapeString(reportSeverityLabel(item.Severity))))
+			}
+		}
+		w(`</tbody></table>`)
+	}
+	w(`</section>`)
 
 	w(fmt.Sprintf(`<section><h2>%s</h2><table><thead><tr><th>%s</th><th>%s</th><th>%s</th><th class="num">%s</th><th class="num">%s</th><th class="num">%s</th><th class="num">%s</th></tr></thead><tbody>`,
 		html.EscapeString(i18n.T("report_recent_sessions")), html.EscapeString(i18n.T("report_session")), html.EscapeString(i18n.T("report_source")), html.EscapeString(i18n.T("report_model")), html.EscapeString(i18n.T("report_total_tokens")), html.EscapeString(i18n.T("report_cost")), html.EscapeString(i18n.T("report_health")), html.EscapeString(i18n.T("report_anomalies"))))
@@ -820,6 +861,27 @@ func markdownCell(value string) string {
 	value = strings.ReplaceAll(value, "|", "\\|")
 	value = strings.ReplaceAll(value, "\n", "<br>")
 	return value
+}
+
+func overviewIncidentTimelines(sessions []Session, limit int) []IncidentTimelineSummary {
+	if limit <= 0 {
+		return []IncidentTimelineSummary{}
+	}
+	items := make([]IncidentTimelineSummary, 0, minReportInt(len(sessions), limit))
+	for _, s := range sessions {
+		timeline := BuildIncidentTimeline(s)
+		if len(timeline.Items) == 0 {
+			continue
+		}
+		items = append(items, timeline)
+		if len(items) >= limit {
+			break
+		}
+	}
+	if items == nil {
+		return []IncidentTimelineSummary{}
+	}
+	return items
 }
 
 // LoopCostSection generates the loop cost breakdown section for text reports.

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -471,6 +471,26 @@ var translations = map[string]map[Lang]string{
 		EN: "Recent anomalies",
 		ZH: "近期异常",
 	},
+	"incident_timeline_title": {
+		EN: "Incident timeline",
+		ZH: "事件时间线",
+	},
+	"incident_timeline_no_evidence": {
+		EN: "No incident timeline evidence yet.",
+		ZH: "暂无事件时间线证据。",
+	},
+	"incident_timeline_signal": {
+		EN: "Signal",
+		ZH: "信号",
+	},
+	"incident_timeline_evidence": {
+		EN: "Evidence",
+		ZH: "证据",
+	},
+	"incident_timeline_severity": {
+		EN: "Severity",
+		ZH: "严重度",
+	},
 	"report_agent": {
 		EN: "Agent",
 		ZH: "Agent",
@@ -963,6 +983,40 @@ var translations = map[string]map[Lang]string{
 	"detail_metric_title":     {EN: "Key metrics", ZH: "关键指标"},
 	"detail_raw_report_title": {EN: "Raw performance report", ZH: "原始性能报告"},
 	"detail_tools_metric":     {EN: "%d/%d ok / %d fail", ZH: "%d/%d 成功 / %d 失败"},
+	"unknown_tool":            {EN: "unknown tool", ZH: "未知工具"},
+	"incident_milestone":      {EN: "Last milestone", ZH: "最后里程碑"},
+	"incident_milestone_detail": {
+		EN: "%d assistant turn(s) completed over %s",
+		ZH: "%d 轮助手输出，持续 %s",
+	},
+	"incident_idle_gap": {EN: "Longest idle gap", ZH: "最长空闲间隔"},
+	"incident_idle_gap_detail": {
+		EN: "%.1fs gap between recorded events",
+		ZH: "记录事件之间间隔 %.1fs",
+	},
+	"incident_failure_loop": {EN: "Failure loop", ZH: "失败循环"},
+	"incident_failure_loop_detail": {
+		EN: "%s repeated the same result %d time(s)",
+		ZH: "%s 重复相同结果 %d 次",
+	},
+	"incident_failure_rate_detail": {
+		EN: "%d failed tool result(s) out of %d (%.1f%%)",
+		ZH: "%d/%d 次工具结果失败 (%.1f%%)",
+	},
+	"incident_touched_surface": {EN: "Touched surface", ZH: "触达面"},
+	"incident_touched_surface_detail": {
+		EN: "%d unique tool(s), %d total calls; top tool %s x%d",
+		ZH: "%d 个不同工具，%d 次调用；最高频 %s x%d",
+	},
+	"incident_burn_divergence": {EN: "Burn divergence", ZH: "消耗偏离"},
+	"incident_burn_loop_detail": {
+		EN: "$%.4f loop cost inside $%.4f total",
+		ZH: "循环成本 $%.4f，总成本 $%.4f",
+	},
+	"incident_burn_tokens_detail": {
+		EN: "%d tokens per assistant turn across %d turn(s)",
+		ZH: "%d tokens/助手轮，共 %d 轮",
+	},
 	"diag_for":                {EN: "Diagnostics for: %s", ZH: "诊断对象: %s"},
 	"diag_simple_loop":        {EN: "⚠ Simple loop detected (cost $%.4f) — see Detail view", ZH: "⚠ 检测到简单循环 (成本 $%.4f) — 查看详情视图"},
 	"diag_score":              {EN: "Diagnostic score %d/100", ZH: "诊断评分 %d/100"},

--- a/internal/tui/insights.go
+++ b/internal/tui/insights.go
@@ -88,6 +88,40 @@ func (m Model) renderDiagnosticSummary() string {
 	return styleForOuterWidth(style, cardW).Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
 }
 
+func (m Model) renderIncidentTimeline(s engine.Session) string {
+	timeline := engine.BuildIncidentTimeline(s)
+	if len(timeline.Items) == 0 {
+		return ""
+	}
+	cardW := minInt(maxInt(20, m.detailViewportWidth()), 140)
+	bodyW := maxInt(8, cardW-4)
+	lines := []string{boldStyle.Render(i18n.T("incident_timeline_title"))}
+	for _, item := range timeline.Items {
+		color := incidentTimelineColor(item.Severity)
+		line := fmt.Sprintf("%s %s — %s",
+			lipgloss.NewStyle().Foreground(color).Render("•"),
+			lipgloss.NewStyle().Foreground(color).Render(item.Label),
+			item.Detail)
+		lines = append(lines, truncate(line, bodyW))
+	}
+	style := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("39")).
+		Padding(0, 1)
+	return styleForOuterWidth(style, cardW).Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+}
+
+func incidentTimelineColor(severity string) lipgloss.Color {
+	switch severity {
+	case engine.SeverityHigh:
+		return lipgloss.Color("196")
+	case engine.SeverityMedium:
+		return lipgloss.Color("220")
+	default:
+		return lipgloss.Color("42")
+	}
+}
+
 func buildDiffInsight(dr engine.SessionDiff) (winner string, explanation string) {
 	scoreA, scoreB := 0, 0
 	var drivers []string

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -892,6 +892,9 @@ func (m Model) renderDetailViewportContent(s engine.Session) string {
 		"",
 		m.renderDetailMetricChips(s),
 	}
+	if timelineSection := m.renderIncidentTimeline(s); timelineSection != "" {
+		sections = append(sections, "", timelineSection)
+	}
 	if loopSection := m.renderLoopAnalysis(); loopSection != "" {
 		sections = append(sections, "", loopSection)
 	}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -2025,6 +2025,8 @@ func TestDetailViewportPrioritizesDiagnosisBeforeRawReport(t *testing.T) {
 		i18n.T("duration_col"),
 		i18n.T("tools"),
 		i18n.T("diff_field_anomalies"),
+		i18n.T("incident_timeline_title"),
+		i18n.T("incident_failure_loop"),
 		i18n.T("detail_raw_report_title"),
 	} {
 		if !strings.Contains(content, want) {
@@ -2033,9 +2035,10 @@ func TestDetailViewportPrioritizesDiagnosisBeforeRawReport(t *testing.T) {
 	}
 
 	metricsIdx := strings.Index(content, i18n.T("detail_metric_title"))
+	timelineIdx := strings.Index(content, i18n.T("incident_timeline_title"))
 	rawIdx := strings.Index(content, i18n.T("detail_raw_report_title"))
-	if metricsIdx < 0 || rawIdx < 0 || rawIdx <= metricsIdx {
-		t.Fatalf("raw report should sit below diagnosis-first metrics, metrics=%d raw=%d:\n%s", metricsIdx, rawIdx, content)
+	if metricsIdx < 0 || timelineIdx < 0 || rawIdx < 0 || timelineIdx <= metricsIdx || rawIdx <= timelineIdx {
+		t.Fatalf("raw report should sit below metrics and incident timeline, metrics=%d timeline=%d raw=%d:\n%s", metricsIdx, timelineIdx, rawIdx, content)
 	}
 }
 


### PR DESCRIPTION
Closes #199

## Summary
- Adds a compact incident timeline builder for parser sessions.
- Surfaces timeline evidence in overview JSON, Markdown, HTML, and the TUI detail view.
- Covers milestone, idle gap, failure loop, touched surface, and burn divergence signals.

## User value
- Makes incident review faster by showing the key evidence near the existing diagnosis and report summaries.
- Keeps evidence compact and avoids raw prompts, tool arguments, or file paths in timeline rows.

## Scope
- Engine timeline summary generation.
- Overview report output for JSON, Markdown, and HTML.
- TUI detail panel rendering.
- English and Chinese labels.
- Focused unit coverage for compact evidence and report/TUI placement.

## Changed files
- internal/engine/incident_timeline.go
- internal/engine/report.go
- internal/engine/engine_test.go
- internal/i18n/i18n.go
- internal/tui/insights.go
- internal/tui/tui.go
- internal/tui/tui_test.go

## Test plan
- go test ./...
- go build -o /tmp/agenttrace-parser-check ./cmd/agenttrace
- AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-contract scripts/ci/check-output-contract.sh
- AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-deterministic scripts/ci/check-deterministic-output.sh
- AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-semantics scripts/ci/check-report-semantics.sh
- AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-docs scripts/ci/check-docs-commands.sh
- AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-release scripts/ci/check-release-surfaces.sh
- AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-pages scripts/ci/check-pages-artifact.sh site

## Fixture/privacy note
- Timeline evidence is derived from aggregate metrics, loop fingerprints, tool names, counts, token totals, and cost totals.
- It does not include raw prompts, tool arguments, or session paths.
- Tests assert one-line compact details and prevent whitespace-suffixed tool text from leaking into timeline evidence.

## Risk
- Adds a top-level overview JSON field, incident_timelines, which is additive but user-visible.
- Report layouts gain an additional Incident timeline section.

## Non-goals
- No raw event timeline reconstruction.
- No prompt, path, or argument disclosure.
- No new storage or database behavior.

## Blackboard events
- Took #199 as Parser & Implementation Agent.
- Implemented compact incident timeline evidence for TUI and reports.
- Verified parser tests, build, output contract, deterministic output, report semantics, docs commands, release surfaces, and Pages artifact checks.

## Release impact
- minor: additive user-visible TUI/report evidence and additive JSON report field.

## Handoff suggestion
- Documentation or release notes can mention incident timeline evidence as a local-first debugging aid.