### PR TITLE
Guard static demo report semantics

### DIFF
--- a/scripts/ci/check-pages-artifact.sh
+++ b/scripts/ci/check-pages-artifact.sh
@@ -13,12 +13,33 @@ fail() {
 [[ -f "$page_dir/index.html" ]] || fail "missing index.html in $page_dir"
 [[ -f "$page_dir/demo-report.html" ]] || fail "missing demo-report.html in $page_dir"
 
+demo_report="$page_dir/demo-report.html"
 version="$(sed -nE 's/^const Version = "([^"]+)"/\1/p' "$repo_root/internal/engine/engine.go")"
 [[ -n "$version" ]] || fail "could not read internal/engine Version"
 
-if ! grep -q "<div class=\"meta\">v$version" "$page_dir/demo-report.html" &&
-  ! grep -qi "static sample data" "$page_dir/demo-report.html"; then
+if ! grep -q "<div class=\"meta\">v$version" "$demo_report" &&
+  ! grep -qi "static sample data" "$demo_report"; then
   fail "demo-report.html must use current version metadata or clearly identify static sample data"
+fi
+
+has_static_sample=false
+if grep -qi "static sample data" "$demo_report"; then
+  has_static_sample=true
+fi
+
+has_current_evidence=false
+if grep -qi "Incident timeline" "$demo_report" &&
+  grep -Eqi "tool authority|authority categories" "$demo_report"; then
+  has_current_evidence=true
+fi
+
+if [[ "$has_static_sample" == false && "$has_current_evidence" == false ]]; then
+  fail "demo-report.html must include current report evidence markers or clearly identify static sample data"
+fi
+
+if [[ "$has_static_sample" == true ]] &&
+  ! grep -Eqi "local-first|local coding-agent traces|No hosted tracing|No prompt upload|uploaded logs" "$demo_report"; then
+  fail "static demo-report.html sample must keep local-first/no-upload wording"
 fi
 
 for asset in \

--- a/site/demo-report.html
+++ b/site/demo-report.html
@@ -17,7 +17,7 @@ section{border:1px solid var(--line);background:rgba(16,20,25,.78);padding:20px;
 <body>
 <main>
 <header>
-<div><div class="brand">agenttrace</div><h1>AI agent session overview</h1><p>Static report generated from local coding-agent traces.</p></div>
+<div><div class="brand">agenttrace</div><h1>AI agent session overview</h1><p>Static report generated from local coding-agent traces.</p><p>Static sample data: this local-first snapshot is a representative public artifact, not a full current generated report; current demo output may include incident timelines, baseline comparison fields, and tool authority summaries. No hosted tracing or uploaded logs.</p></div>
 <div class="meta">v0.4.6<br>1761 Sessions<br><code>agenttrace --overview -f html</code></div>
 </header>
 <div class="grid" aria-label="summary metrics">
@@ -98,4 +98,3 @@ section{border:1px solid var(--line);background:rgba(16,20,25,.78);padding:20px;
 </main>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- tighten `check-pages-artifact.sh` so `site/demo-report.html` must expose current report evidence markers or explicitly identify static sample data
- require local-first/no-upload wording when the static sample path is used
- mark the committed static demo report as static sample data without changing generated report behavior

Fixes #207

## Test plan
- `go test ./...`
- `go build -o /tmp/agenttrace-quality-207 ./cmd/agenttrace`
- `/tmp/agenttrace-quality-207 --doctor || true`
- `/tmp/agenttrace-quality-207 --demo --overview -f json >/tmp/agenttrace-quality-207-demo.json`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-207 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-207-ci-output scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-207 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-207-ci-deterministic scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-207 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-207-ci-semantics scripts/ci/check-report-semantics.sh`
- `scripts/ci/check-release-surfaces.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-quality-207 AGENTTRACE_CI_OUT=/tmp/agenttrace-quality-207-ci-docs scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-pages-artifact.sh site`
- negative smoke: remove static sample paragraph from a temp copy of `site/demo-report.html`; `scripts/ci/check-pages-artifact.sh` fails with the expected semantic guard message
- `git diff --check`