### PR TITLE
[Impl] Show tool authority summary in Markdown overview reports

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1955,6 +1955,53 @@ func TestReportTextChineseLabelsAnomalySeverityAndLoopCost(t *testing.T) {
 	}
 }
 
+func TestReportOverviewMarkdownShowsAuthority(t *testing.T) {
+	sessions := []Session{
+		{
+			Name:   "build",
+			Health: 92,
+			Metrics: Metrics{
+				SourceTool:       "aider",
+				ModelUsed:        "gpt-4.1",
+				ToolCallsOK:      1,
+				ToolUsage:        map[string]int{"go test": 1},
+				ToolAuthority:    map[string]int{ToolAuthorityTestOrBuild: 1},
+				HighestAuthority: ToolAuthorityTestOrBuild,
+			},
+		},
+		{
+			Name:   "shell",
+			Health: 70,
+			Metrics: Metrics{
+				SourceTool:       "cursor",
+				ModelUsed:        "default",
+				ToolCallsOK:      1,
+				ToolUsage:        map[string]int{"bash|prod\nsecret args": 1},
+				ToolAuthority:    map[string]int{ToolAuthorityShellExec: 1},
+				HighestAuthority: ToolAuthorityShellExec,
+			},
+		},
+	}
+	out := ReportOverviewMarkdown(ComputeOverview(sessions), sessions)
+	for _, want := range []string{
+		"## Tool authority",
+		"| Highest category | `shell_exec` |",
+		"| High-authority tools | `bash\\|prod<br>secret args` |",
+		"### Authority category counts",
+		"| `test_or_build` | 1 |",
+		"| `shell_exec` | 1 |",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("markdown report missing %q:\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{"`bash|prod", "secret args` |\n|"} {
+		if strings.Contains(out, unwanted) {
+			t.Fatalf("markdown report did not escape high-authority tool name %q:\n%s", unwanted, out)
+		}
+	}
+}
+
 func TestReportOverviewHTMLIsShareableAndEscaped(t *testing.T) {
 	sessions := []Session{
 		{

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -530,6 +530,7 @@ func ReportOverviewJSON(ov Overview, sessions []Session) string {
 func ReportOverviewMarkdown(ov Overview, sessions []Session) string {
 	orderedSessions := canonicalOverviewSessions(sessions)
 	summary := overviewReportSummary(orderedSessions)
+	authority := overviewAuthoritySummary(orderedSessions)
 	trend := AnalyzeHealthTrend(orderedSessions)
 
 	var b strings.Builder
@@ -542,6 +543,25 @@ func ReportOverviewMarkdown(ov Overview, sessions []Session) string {
 	fmt.Fprintf(&b, "| %s | $%.2f |\n", i18n.T("total_cost"), ov.TotalCost)
 	fmt.Fprintf(&b, "| %s | %d |\n", i18n.T("report_total_tokens"), summary.TotalTokens)
 	fmt.Fprintf(&b, "| %s | %d / %d (%.1f%%) |\n\n", i18n.T("report_tool_failures"), summary.FailedTools, summary.TotalTools, summary.ToolFailRate)
+
+	if authority.HasData {
+		fmt.Fprintf(&b, "## %s\n\n", i18n.T("report_tool_authority"))
+		fmt.Fprintf(&b, "| %s | %s |\n|---|---:|\n", i18n.T("report_metric"), i18n.T("report_value"))
+		if authority.Highest != "" {
+			fmt.Fprintf(&b, "| %s | `%s` |\n", i18n.T("report_highest_authority"), markdownInlineCode(authority.Highest))
+		}
+		if len(authority.HighTools) > 0 {
+			fmt.Fprintf(&b, "| %s | %s |\n", i18n.T("report_high_authority_tools"), reportMarkdownCodeList(authority.HighTools))
+		}
+		if len(authority.Counts) > 0 {
+			fmt.Fprintf(&b, "\n### %s\n\n", i18n.T("report_authority_category_counts"))
+			fmt.Fprintf(&b, "| %s | %s |\n|---|---:|\n", i18n.T("report_authority_category"), i18n.T("report_count"))
+			for _, item := range authority.Counts {
+				fmt.Fprintf(&b, "| `%s` | %d |\n", markdownInlineCode(item.Category), item.Count)
+			}
+			fmt.Fprintln(&b)
+		}
+	}
 
 	fmt.Fprintf(&b, "## %s\n\n", i18n.T("incident_timeline_title"))
 	timelines := overviewIncidentTimelines(orderedSessions, 6)
@@ -1021,6 +1041,23 @@ func reportHTMLCodeList(values []string) string {
 		}
 	}
 	return strings.Join(parts, ", ")
+}
+
+func reportMarkdownCodeList(values []string) string {
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		if value != "" {
+			parts = append(parts, "`"+markdownInlineCode(value)+"`")
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func markdownInlineCode(value string) string {
+	value = strings.ReplaceAll(value, "`", "'")
+	value = strings.ReplaceAll(value, "|", "\\|")
+	value = strings.ReplaceAll(value, "\n", "<br>")
+	return value
 }
 
 func markdownCell(value string) string {

--- a/scripts/ci/check-report-semantics.sh
+++ b/scripts/ci/check-report-semantics.sh
@@ -27,6 +27,12 @@ grep -q "$expected_cost_label" "$out_dir/semantics/overview.txt" \
   || fail "text overview missing expected cost label"
 grep -q "| $expected_cost_label |" "$out_dir/semantics/overview.md" \
   || fail "markdown overview missing expected cost label"
+grep -q "## Tool authority" "$out_dir/semantics/overview.md" \
+  || fail "markdown overview missing tool authority summary"
+grep -q "### Authority category counts" "$out_dir/semantics/overview.md" \
+  || fail "markdown overview missing authority category counts"
+grep -q '`test_or_build`' "$out_dir/semantics/overview.md" \
+  || fail "markdown overview missing highest demo authority category"
 grep -q "<span>$expected_cost_label</span>" "$out_dir/semantics/overview.html" \
   || fail "html overview missing expected cost label"
 grep -q "<div class=\"meta\">v$version" "$out_dir/semantics/overview.html" \


### PR DESCRIPTION
Closes #211

## Summary

- Render a Tool authority section in Markdown overview reports using the existing overview authority summary data.
- Show the highest authority category, high-authority tools, and authority category counts when authority data exists.
- Add regression coverage so demo Markdown cannot silently drop the authority summary.

## User value

Users can share Markdown reports in CI comments, issue handoffs, and text-first docs while still seeing whether local sessions touched higher-authority tool surfaces.

## Scope

- Markdown overview rendering only.
- Existing HTML authority output from #210 remains intact.
- Existing authority classification and JSON overview fields are unchanged.

## Changed files

- `internal/engine/report.go`
- `internal/engine/engine_test.go`
- `scripts/ci/check-report-semantics.sh`

## Test plan

- `go test ./internal/engine`
- `go test ./...`
- `go build -o /tmp/agenttrace-parser-check ./cmd/agenttrace`
- `/tmp/agenttrace-parser-check --doctor || true`
- `/tmp/agenttrace-parser-check --demo --overview -f json >/tmp/agenttrace-parser-overview-211.json`
- `/tmp/agenttrace-parser-check --demo --overview -f markdown -o /tmp/agenttrace-parser-overview-211.md >/tmp/agenttrace-parser-overview-211.md.stdout`
- `/tmp/agenttrace-parser-check --demo --overview -f html -o /tmp/agenttrace-parser-overview-211.html >/tmp/agenttrace-parser-overview-211.html.stdout`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-output-211 scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-deterministic-211 scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-semantics-211 scripts/ci/check-report-semantics.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-docs-211 scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`

## Fixture/privacy note

Uses demo and synthetic unit-test sessions only. No real user prompts, logs, tokens, or secrets were added.

## Risk

Low. This changes only Markdown report presentation and the matching regression check; authority classification, JSON contract, and HTML report output remain compatible.

## Non-goals

- Do not change authority classification rules.
- Do not change JSON field names or existing JSON contracts.
- Do not add hosted telemetry, upload, or external sharing behavior.
- Do not change release, package, npm, Homebrew, or public site surfaces.

## Blackboard events

- Claimed Issue #211 as Parser & Implementation Agent.
- Created branch `impl/211-tool-authority-markdown` from `origin/master` after confirming stale branch `impl/209-tool-authority-html` was merged in PR #210.
- Added local validation evidence for Markdown, HTML, and JSON authority outputs.

## Release impact

patch: Markdown report contract and visible report content change. No parser/source compatibility change, no CLI flag change, no JSON/HTML contract change, no install/package docs change.

## Handoff suggestion

Handoff to: Growth after merge if release notes are being collected.
Suggested release note: Markdown overview reports now show tool authority evidence alongside existing local session health and incident summaries.
