### PR TITLE
[Impl] Surface incident and tool authority cues in text overview

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1859,6 +1859,39 @@ func TestReportOverviewJSONIncludesIncidentTimelines(t *testing.T) {
 	}
 }
 
+func TestReportOverviewTextShowsIncidentAndAuthorityCues(t *testing.T) {
+	sessions := []Session{{
+		Name:   "risky",
+		Health: 45,
+		Metrics: Metrics{
+			SourceTool:       "codex_cli",
+			ModelUsed:        "gpt-5.1",
+			AssistantTurns:   3,
+			DurationSec:      180,
+			GapsSec:          []float64{90},
+			ToolCallsOK:      1,
+			ToolCallsFail:    2,
+			ToolUsage:        map[string]int{"terminal": 3},
+			ToolAuthority:    map[string]int{ToolAuthorityTestOrBuild: 1},
+			HighestAuthority: ToolAuthorityTestOrBuild,
+		},
+	}}
+	out := ReportOverview(ComputeOverview(sessions), sessions)
+	for _, want := range []string{
+		"Incident timeline",
+		"Last milestone",
+		"Touched surface",
+		"Tool authority",
+		"Highest category: test_or_build",
+		"Authority category counts: test_or_build=1",
+		"High-authority tools: terminal",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text overview missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestReportOverviewCostLabelUsesEstimatedTotalCost(t *testing.T) {
 	sessions := []Session{{
 		Name:   "demo",

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -1107,6 +1107,8 @@ func LoopCostSection(lc LoopCost) string {
 
 // ReportOverview generates the CLI overview dashboard text.
 func ReportOverview(ov Overview, sessions []Session) string {
+	orderedSessions := canonicalOverviewSessions(sessions)
+	authority := overviewAuthoritySummary(orderedSessions)
 	sep := strings.Repeat(i18n.T("separator_double"), 70)
 	var b strings.Builder
 	w := func(s string) { b.WriteString(s + "\n") }
@@ -1130,6 +1132,39 @@ func ReportOverview(ov Overview, sessions []Session) string {
 	wf("  🔴 "+i18n.T("overview_critical")+":   %d (%d%%)", ov.Critical, critPct)
 	wf("  💰 "+i18n.T("total_cost")+":      $%.2f", ov.TotalCost)
 	w("")
+
+	timelines := overviewIncidentTimelines(orderedSessions, 3)
+	if len(timelines) > 0 {
+		w("  ── " + i18n.T("incident_timeline_title") + " ──")
+		rendered := 0
+		for _, timeline := range timelines {
+			for _, item := range timeline.Items {
+				wf("    %-30s %s: %s", textCell(timeline.Session, 30), item.Label, textCell(item.Detail, 68))
+				rendered++
+				if rendered >= 5 {
+					break
+				}
+			}
+			if rendered >= 5 {
+				break
+			}
+		}
+		w("")
+	}
+
+	if authority.HasData {
+		w("  ── " + i18n.T("report_tool_authority") + " ──")
+		if authority.Highest != "" {
+			wf("    %s: %s", i18n.T("report_highest_authority"), authority.Highest)
+		}
+		if len(authority.Counts) > 0 {
+			wf("    %s: %s", i18n.T("report_authority_category_counts"), textAuthorityCounts(authority.Counts))
+		}
+		if len(authority.HighTools) > 0 {
+			wf("    %s: %s", i18n.T("report_high_authority_tools"), textCell(strings.Join(authority.HighTools, ", "), 68))
+		}
+		w("")
+	}
 
 	// By agent
 	w("  ── " + i18n.T("overview_agents") + " ──")
@@ -1191,4 +1226,20 @@ func ReportOverview(ov Overview, sessions []Session) string {
 	w("")
 	w(sep)
 	return b.String()
+}
+
+func textAuthorityCounts(items []authorityCount) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		parts = append(parts, fmt.Sprintf("%s=%d", item.Category, item.Count))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func textCell(value string, limit int) string {
+	value = strings.Join(strings.Fields(value), " ")
+	if limit > 3 && len(value) > limit {
+		return value[:limit-3] + "..."
+	}
+	return value
 }

--- a/scripts/ci/check-report-semantics.sh
+++ b/scripts/ci/check-report-semantics.sh
@@ -25,6 +25,12 @@ grep -q "AGENTTRACE v$version" "$out_dir/semantics/overview.txt" \
   || fail "text overview missing current version"
 grep -q "$expected_cost_label" "$out_dir/semantics/overview.txt" \
   || fail "text overview missing expected cost label"
+grep -q "Incident timeline" "$out_dir/semantics/overview.txt" \
+  || fail "text overview missing incident timeline evidence"
+grep -q "Tool authority" "$out_dir/semantics/overview.txt" \
+  || fail "text overview missing tool authority summary"
+grep -q "test_or_build" "$out_dir/semantics/overview.txt" \
+  || fail "text overview missing highest demo authority category"
 grep -q "| $expected_cost_label |" "$out_dir/semantics/overview.md" \
   || fail "markdown overview missing expected cost label"
 grep -q "## Tool authority" "$out_dir/semantics/overview.md" \


### PR DESCRIPTION
Closes #213

## Summary

- Add compact Incident timeline cues to text overview output when timeline evidence exists.
- Add compact Tool authority cues to text overview output when authority data exists.
- Add regression coverage so demo text output cannot silently drop these cues.

## User value

Terminal-first users can see the same local debugging signals from the fastest readable overview path without switching to JSON, Markdown, or HTML.

## Scope

- Text overview rendering only.
- Existing JSON, Markdown, and HTML report contracts remain compatible.
- Existing authority classification and incident timeline generation are unchanged.

## Changed files

- `internal/engine/report.go`
- `internal/engine/engine_test.go`
- `scripts/ci/check-report-semantics.sh`

## Test plan

- `go test ./internal/engine`
- `go test ./...`
- `go build -o /tmp/agenttrace-parser-check ./cmd/agenttrace`
- `/tmp/agenttrace-parser-check --doctor || true`
- `/tmp/agenttrace-parser-check --demo --overview -f text >/tmp/agenttrace-parser-overview-213.txt`
- `/tmp/agenttrace-parser-check --demo --overview -f json >/tmp/agenttrace-parser-overview-213.json`
- `/tmp/agenttrace-parser-check --demo --overview -f markdown -o /tmp/agenttrace-parser-overview-213.md >/tmp/agenttrace-parser-overview-213.md.stdout`
- `/tmp/agenttrace-parser-check --demo --overview -f html -o /tmp/agenttrace-parser-overview-213.html >/tmp/agenttrace-parser-overview-213.html.stdout`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-output-213 scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-deterministic-213 scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-semantics-213 scripts/ci/check-report-semantics.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-docs-213 scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`

## Fixture/privacy note

Uses demo and synthetic unit-test sessions only. No real user prompts, logs, tokens, or secrets were added.

## Risk

Medium-low. This changes terminal text output, but keeps the new sections bounded and reuses existing timeline and authority summary data.

## Non-goals

- Do not make text output as dense as Markdown or HTML tables.
- Do not change JSON field names or authority classification rules.
- Do not add hosted telemetry, upload, or external sharing behavior.
- Do not change release, package, npm, Homebrew, or public site surfaces.

## Blackboard events

- Claimed Issue #213 as Parser & Implementation Agent.
- Created branch `impl/213-text-overview-evidence` from `origin/master` after confirming stale branch `impl/211-tool-authority-markdown` was merged in PR #212.
- Added local validation evidence for text, JSON, Markdown, and HTML overview outputs.

## Release impact

patch: text overview visible output changes. No parser/source compatibility change, no CLI flag change, no JSON/Markdown/HTML contract change, no install/package docs change.

## Handoff suggestion

Handoff to: Growth after merge if release notes are being collected.
Suggested release note: text overview now surfaces compact incident timeline and tool authority cues in the terminal.
