### PR TITLE
Make text overview truncation UTF-8 safe

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1892,6 +1892,13 @@ func TestReportOverviewTextShowsIncidentAndAuthorityCues(t *testing.T) {
 	}
 }
 
+func TestTextCellCollapsesWhitespaceAndTruncatesUTF8(t *testing.T) {
+	got := textCell("命令\n执行  失败 😅", 8)
+	if got != "命令 执行..." {
+		t.Fatalf("unexpected UTF-8 safe text cell: %q", got)
+	}
+}
+
 func TestReportOverviewCostLabelUsesEstimatedTotalCost(t *testing.T) {
 	sessions := []Session{{
 		Name:   "demo",

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -1238,8 +1238,9 @@ func textAuthorityCounts(items []authorityCount) string {
 
 func textCell(value string, limit int) string {
 	value = strings.Join(strings.Fields(value), " ")
-	if limit > 3 && len(value) > limit {
-		return value[:limit-3] + "..."
+	runes := []rune(value)
+	if limit > 3 && len(runes) > limit {
+		return string(runes[:limit-3]) + "..."
 	}
 	return value
 }


### PR DESCRIPTION
## Summary
- make text overview cell truncation rune-based instead of byte-based
- cover collapsed whitespace plus UTF-8 truncation with a regression test

## Validation
- git diff --check origin/master...HEAD
- go test -count=1 ./...
- go build -o /tmp/agenttrace-textcell-utf8-check ./cmd/agenttrace
- AGENTTRACE_BIN=/tmp/agenttrace-textcell-utf8-check AGENTTRACE_CI_OUT=/tmp/agenttrace-textcell-utf8-ci scripts/ci/check-report-semantics.sh