### PR TITLE
[Impl] Make text overview truncation Unicode-safe

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/luoyuctl/agenttrace/internal/i18n"
 )
@@ -1889,6 +1890,47 @@ func TestReportOverviewTextShowsIncidentAndAuthorityCues(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("text overview missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestReportOverviewTextTruncatesUnicodeSafely(t *testing.T) {
+	longName := "x" + strings.Repeat("项目", 24) + "-异常会话"
+	longTool := "x" + strings.Repeat("工具", 32)
+	sessions := []Session{{
+		Name:      longName,
+		Health:    45,
+		Anomalies: []Anomaly{{Type: "hanging", Severity: SeverityHigh}},
+		Metrics: Metrics{
+			SourceTool:       "codex_cli",
+			ModelUsed:        "gpt-5.1",
+			AssistantTurns:   3,
+			DurationSec:      180,
+			GapsSec:          []float64{90},
+			ToolCallsOK:      1,
+			ToolCallsFail:    2,
+			ToolUsage:        map[string]int{longTool: 3},
+			ToolAuthority:    map[string]int{ToolAuthorityTestOrBuild: 1},
+			HighestAuthority: ToolAuthorityTestOrBuild,
+		},
+	}}
+
+	out := ReportOverview(ComputeOverview(sessions), sessions)
+	if !utf8.ValidString(out) {
+		t.Fatalf("text overview should stay valid UTF-8 after truncation:\n%x", out)
+	}
+	for _, want := range []string{
+		"Incident timeline",
+		"Touched surface",
+		"Tool authority",
+		"Recent Anomalies",
+		"...",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text overview missing %q:\n%s", want, out)
+		}
+	}
+	if strings.ContainsRune(out, '\uFFFD') {
+		t.Fatalf("text overview contains replacement characters after truncation:\n%s", out)
 	}
 }
 

--- a/internal/engine/incident_timeline.go
+++ b/internal/engine/incident_timeline.go
@@ -155,8 +155,5 @@ func incidentSafeName(value string) string {
 	if fields := strings.Fields(value); len(fields) > 0 {
 		value = fields[0]
 	}
-	if len(value) > 48 {
-		value = value[:48]
-	}
-	return value
+	return truncateTextRunes(value, 48, "")
 }

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -6,6 +6,7 @@ import (
 	"html"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/luoyuctl/agenttrace/internal/i18n"
 )
@@ -1216,11 +1217,7 @@ func ReportOverview(ov Overview, sessions []Session) string {
 		}
 		for i := 0; i < limit; i++ {
 			a := ov.AnomaliesTop[i]
-			name := a.Session
-			if len(name) > 30 {
-				name = name[:30]
-			}
-			wf("    ⚠️  %-30s %s", name, reportAnomalyTypeLabel(a.Type))
+			wf("    ⚠️  %-30s %s", textCell(a.Session, 30), reportAnomalyTypeLabel(a.Type))
 		}
 	}
 	w("")
@@ -1238,8 +1235,25 @@ func textAuthorityCounts(items []authorityCount) string {
 
 func textCell(value string, limit int) string {
 	value = strings.Join(strings.Fields(value), " ")
-	if limit > 3 && len(value) > limit {
-		return value[:limit-3] + "..."
+	if limit > 3 {
+		return truncateTextRunes(value, limit, "...")
 	}
 	return value
+}
+
+func truncateTextRunes(value string, limit int, suffix string) string {
+	if limit <= 0 {
+		return ""
+	}
+	if utf8.RuneCountInString(value) <= limit {
+		return value
+	}
+	cut := limit
+	if suffixRunes := utf8.RuneCountInString(suffix); suffix != "" && suffixRunes < limit {
+		cut = limit - suffixRunes
+	} else {
+		suffix = ""
+	}
+	runes := []rune(value)
+	return string(runes[:cut]) + suffix
 }


### PR DESCRIPTION
Closes #215

## Summary

- Add rune-safe truncation for compact text overview cells.
- Route recent anomaly session names through the same safe text overview truncation path used by incident timeline rows.
- Keep incident timeline tool names valid UTF-8 before they are embedded in text evidence details.
- Add focused regression coverage for long non-ASCII session and tool names.

## User value

Terminal-first users with non-English project, path, session, or tool names get readable overview output without broken UTF-8 replacement characters.

## Scope

- Text overview truncation behavior only.
- Incident timeline safe-name truncation is made rune-safe so text overview detail rows cannot inherit invalid UTF-8.
- Existing JSON, Markdown, and HTML report contracts remain unchanged.

## Changed files

- `internal/engine/report.go`
- `internal/engine/incident_timeline.go`
- `internal/engine/engine_test.go`

## Test plan

- `go test ./internal/engine -run 'TestReportOverviewText(ShowsIncidentAndAuthorityCues|TruncatesUnicodeSafely)'`
- `go test ./internal/engine`
- `go test ./...`
- `go build -o /tmp/agenttrace-parser-check ./cmd/agenttrace`
- `/tmp/agenttrace-parser-check --doctor || true`
- `/tmp/agenttrace-parser-check --demo --overview -f text >/tmp/agenttrace-parser-overview-215.txt`
- `/tmp/agenttrace-parser-check --demo --overview -f json >/tmp/agenttrace-parser-overview-215.json`
- `/tmp/agenttrace-parser-check --demo --overview -f markdown -o /tmp/agenttrace-parser-overview-215.md >/tmp/agenttrace-parser-overview-215.md.stdout`
- `/tmp/agenttrace-parser-check --demo --overview -f html -o /tmp/agenttrace-parser-overview-215.html >/tmp/agenttrace-parser-overview-215.html.stdout`
- `rg -n "Incident timeline|Tool authority|test_or_build|Last milestone|Touched surface|Recent Anomalies" /tmp/agenttrace-parser-overview-215.txt /tmp/agenttrace-parser-overview-215.md /tmp/agenttrace-parser-overview-215.html`
- `node -e "const fs=require('fs'); const txt=fs.readFileSync('/tmp/agenttrace-parser-overview-215.txt','utf8'); if(txt.includes('\\uFFFD')) throw new Error('replacement character in text overview'); const json=JSON.parse(fs.readFileSync('/tmp/agenttrace-parser-overview-215.json','utf8')); if(!json.summary || !json.summary.tool_authority) throw new Error('missing authority summary'); if(!Array.isArray(json.incident_timelines)) throw new Error('missing incident timelines'); console.log('overview artifacts ok');"`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-output-215 scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-deterministic-215 scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-semantics-215 scripts/ci/check-report-semantics.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-docs-215 scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`
- `git diff --check`

## Fixture/privacy note

Uses synthetic unit-test strings and demo output only. No real user prompts, logs, tokens, paths, or secrets were added.

## Risk

Low. The change is limited to display truncation in terminal text formatting and preserves compact output limits.

## Non-goals

- Do not redesign text overview layout.
- Do not change parser behavior or session discovery.
- Do not change JSON, Markdown, or HTML report contracts.
- Do not add CLI flags.
- Do not touch release, package, npm, Homebrew, or public site surfaces.

## Blackboard events

- Claimed Issue #215 as Parser & Implementation Agent.
- Created branch `impl/215-unicode-text-truncation` from `origin/master` after confirming stale branch `impl/213-text-overview-evidence` was merged in PR #214.
- Added local validation evidence for Unicode-safe text overview truncation and existing #214 text cues.

## Release impact

patch: text overview visible output truncation becomes Unicode-safe. No parser/source compatibility change, no CLI behavior change, no JSON/Markdown/HTML contract change, no install/package docs change.

## Handoff suggestion

Handoff to: Growth after merge if release notes are being collected.
Suggested release note: text overview truncation now preserves valid UTF-8 for non-English session and tool names.