### PR TITLE
[Impl] Keep text overview authority summary readable

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1893,6 +1893,67 @@ func TestReportOverviewTextShowsIncidentAndAuthorityCues(t *testing.T) {
 	}
 }
 
+func TestReportOverviewTextWrapsAuthoritySummary(t *testing.T) {
+	tools := map[string]int{}
+	for i := 0; i < 10; i++ {
+		tools[fmt.Sprintf("terminal-very-long-authority-tool-%02d", i)] = 1
+	}
+	sessions := []Session{{
+		Name:   "wide-authority",
+		Health: 90,
+		Metrics: Metrics{
+			SourceTool: "codex_cli",
+			ModelUsed:  "gpt-5.1",
+			ToolUsage:  tools,
+			ToolAuthority: map[string]int{
+				ToolAuthorityReadOnlyFiles:   11,
+				ToolAuthorityTestOrBuild:     12,
+				ToolAuthorityWriteFiles:      13,
+				ToolAuthorityPackageInstall:  14,
+				ToolAuthorityNetworkAccess:   15,
+				ToolAuthorityShellExec:       16,
+				ToolAuthorityGitWrite:        17,
+				ToolAuthorityExternalPublish: 18,
+				ToolAuthorityUnknown:         19,
+			},
+			HighestAuthority: ToolAuthorityUnknown,
+		},
+	}}
+
+	out := ReportOverview(ComputeOverview(sessions), sessions)
+	for _, want := range []string{
+		"Tool authority",
+		"Highest category",
+		"Authority category counts",
+		"High-authority tools",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text overview missing %q:\n%s", want, out)
+		}
+	}
+
+	var authorityLines []string
+	inAuthority := false
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "── Tool authority ──") {
+			inAuthority = true
+			continue
+		}
+		if inAuthority && strings.TrimSpace(line) == "" {
+			break
+		}
+		if inAuthority {
+			authorityLines = append(authorityLines, line)
+			if got := utf8.RuneCountInString(line); got > 100 {
+				t.Fatalf("authority line too wide (%d): %q\n%s", got, line, out)
+			}
+		}
+	}
+	if len(authorityLines) < 5 {
+		t.Fatalf("expected wrapped authority evidence lines, got %d:\n%s", len(authorityLines), out)
+	}
+}
+
 func TestReportOverviewTextTruncatesUnicodeSafely(t *testing.T) {
 	longName := "x" + strings.Repeat("项目", 24) + "-异常会话"
 	longTool := "x" + strings.Repeat("工具", 32)

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -1159,10 +1159,14 @@ func ReportOverview(ov Overview, sessions []Session) string {
 			wf("    %s: %s", i18n.T("report_highest_authority"), authority.Highest)
 		}
 		if len(authority.Counts) > 0 {
-			wf("    %s: %s", i18n.T("report_authority_category_counts"), textAuthorityCounts(authority.Counts))
+			for _, line := range textWrappedKeyValues(i18n.T("report_authority_category_counts"), textAuthorityCountValues(authority.Counts), 96) {
+				wf("    %s", line)
+			}
 		}
 		if len(authority.HighTools) > 0 {
-			wf("    %s: %s", i18n.T("report_high_authority_tools"), textCell(strings.Join(authority.HighTools, ", "), 68))
+			for _, line := range textWrappedKeyValues(i18n.T("report_high_authority_tools"), textToolValues(authority.HighTools), 96) {
+				wf("    %s", line)
+			}
 		}
 		w("")
 	}
@@ -1225,12 +1229,52 @@ func ReportOverview(ov Overview, sessions []Session) string {
 	return b.String()
 }
 
-func textAuthorityCounts(items []authorityCount) string {
+func textAuthorityCountValues(items []authorityCount) []string {
 	parts := make([]string, 0, len(items))
 	for _, item := range items {
 		parts = append(parts, fmt.Sprintf("%s=%d", item.Category, item.Count))
 	}
-	return strings.Join(parts, ", ")
+	return parts
+}
+
+func textToolValues(items []string) []string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		parts = append(parts, textCell(item, 40))
+	}
+	return parts
+}
+
+func textWrappedKeyValues(label string, values []string, limit int) []string {
+	if len(values) == 0 {
+		return []string{label + ":"}
+	}
+	prefix := label + ": "
+	continuation := strings.Repeat(" ", utf8.RuneCountInString(label)+2)
+	lines := make([]string, 0, 1)
+	current := prefix
+	for _, value := range values {
+		separator := ""
+		if current != prefix && current != continuation {
+			separator = ", "
+		}
+		next := separator + value
+		if utf8.RuneCountInString(current)+utf8.RuneCountInString(next) > limit && current != prefix && current != continuation {
+			lines = append(lines, current)
+			current = continuation + value
+			continue
+		}
+		if utf8.RuneCountInString(current)+utf8.RuneCountInString(next) > limit {
+			valueLimit := limit - utf8.RuneCountInString(current)
+			if valueLimit < 4 {
+				valueLimit = 4
+			}
+			next = textCell(value, valueLimit)
+		}
+		current += next
+	}
+	lines = append(lines, current)
+	return lines
 }
 
 func textCell(value string, limit int) string {


### PR DESCRIPTION
Closes #218

## Summary

- Wrap text overview authority category counts across bounded continuation lines.
- Wrap high-authority tool summaries across bounded continuation lines while truncating very long tool labels.
- Add a synthetic regression test that prevents very wide authority summary lines from returning.

## User value

Terminal-first users can scan tool authority evidence without horizontal scrolling or wrapped labels burying the signal.

## Scope

- Text overview authority summary formatting only.
- Existing evidence labels are preserved: Highest category, Authority category counts, and High-authority tools.
- JSON, Markdown, and HTML report contracts remain unchanged.

## Changed files

- `internal/engine/report.go`
- `internal/engine/engine_test.go`

## Test plan

- `go test ./internal/engine -run 'TestReportOverviewText(WrapsAuthoritySummary|ShowsIncidentAndAuthorityCues|TruncatesUnicodeSafely)'`
- `go test ./internal/engine`
- `go test ./...`
- `go build -o /tmp/agenttrace-parser-check ./cmd/agenttrace`
- `/tmp/agenttrace-parser-check --doctor || true`
- `/tmp/agenttrace-parser-check --demo --overview -f text >/tmp/agenttrace-parser-overview-218.txt`
- `/tmp/agenttrace-parser-check --demo --overview -f json >/tmp/agenttrace-parser-overview-218.json`
- `/tmp/agenttrace-parser-check --demo --overview -f markdown -o /tmp/agenttrace-parser-overview-218.md >/tmp/agenttrace-parser-overview-218.md.stdout`
- `/tmp/agenttrace-parser-check --demo --overview -f html -o /tmp/agenttrace-parser-overview-218.html >/tmp/agenttrace-parser-overview-218.html.stdout`
- `rg -n "Tool authority|Highest category|Authority category counts|High-authority tools|Incident timeline|Recent Anomalies" /tmp/agenttrace-parser-overview-218.txt /tmp/agenttrace-parser-overview-218.md /tmp/agenttrace-parser-overview-218.html`
- `node -e "const fs=require('fs'); const txt=fs.readFileSync('/tmp/agenttrace-parser-overview-218.txt','utf8'); if(txt.includes('\\uFFFD')) throw new Error('replacement character in text overview'); const max=Math.max(...txt.split(/\\n/).map(l=>[...l].length)); if(max>120) throw new Error('demo text line too wide: '+max); const json=JSON.parse(fs.readFileSync('/tmp/agenttrace-parser-overview-218.json','utf8')); if(!json.summary || !json.summary.tool_authority) throw new Error('missing authority summary'); console.log('overview artifacts ok, max text line '+max);"`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-output-218 scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-deterministic-218 scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-semantics-218 scripts/ci/check-report-semantics.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-docs-218 scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`
- `git diff --check`

## Fixture/privacy note

Uses synthetic authority categories and tool names in unit tests plus demo output only. No real user prompts, logs, paths, tokens, or secrets were added.

## Risk

Low to medium. The summary is bounded for readability while preserving all authority categories and high-authority tool evidence across continuation lines.

## Non-goals

- Do not change authority classification rules.
- Do not remove authority evidence from text overview.
- Do not change JSON, Markdown, or HTML report contracts.
- Do not touch release, package, npm, Homebrew, or public site surfaces.

## Blackboard events

- Claimed Issue #218 as Parser & Implementation Agent.
- Created branch `impl/218-readable-authority-text` from `origin/master` after confirming stale branch `impl/215-unicode-text-truncation` was merged in PR #217.
- Added local validation evidence for bounded text overview authority summary lines and existing authority labels.

## Release impact

patch: text overview visible formatting changes for authority summary readability. No parser/source compatibility change, no CLI behavior change, no JSON/Markdown/HTML contract change, no install/package docs change.

## Handoff suggestion

Handoff to: Growth after merge if release notes are being collected.
Suggested release note: text overview now wraps tool authority summary evidence into readable terminal-width lines.