### PR TITLE
[Impl] Keep text overview incident timeline rows readable

### DIFF
--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1954,6 +1954,50 @@ func TestReportOverviewTextWrapsAuthoritySummary(t *testing.T) {
 	}
 }
 
+func TestReportOverviewTextBoundsIncidentTimelineRows(t *testing.T) {
+	longTool := "terminal-" + strings.Repeat("very-long-tool-name-", 5)
+	sessions := []Session{{
+		Name:   "wide-incident",
+		Health: 90,
+		Metrics: Metrics{
+			SourceTool:     "codex_cli",
+			ModelUsed:      "gpt-5.1",
+			AssistantTurns: 3,
+			DurationSec:    180,
+			ToolCallsOK:    12,
+			ToolUsage:      map[string]int{longTool: 12},
+		},
+	}}
+
+	out := ReportOverview(ComputeOverview(sessions), sessions)
+	for _, want := range []string{"Incident timeline", "Touched surface", "..."} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("text overview missing %q:\n%s", want, out)
+		}
+	}
+
+	inTimeline := false
+	checked := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "── Incident timeline ──") {
+			inTimeline = true
+			continue
+		}
+		if inTimeline && strings.TrimSpace(line) == "" {
+			break
+		}
+		if inTimeline {
+			checked++
+			if got := utf8.RuneCountInString(line); got > 100 {
+				t.Fatalf("incident line too wide (%d): %q\n%s", got, line, out)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatalf("expected incident timeline rows:\n%s", out)
+	}
+}
+
 func TestReportOverviewTextTruncatesUnicodeSafely(t *testing.T) {
 	longName := "x" + strings.Repeat("项目", 24) + "-异常会话"
 	longTool := "x" + strings.Repeat("工具", 32)

--- a/internal/engine/report.go
+++ b/internal/engine/report.go
@@ -1140,7 +1140,7 @@ func ReportOverview(ov Overview, sessions []Session) string {
 		rendered := 0
 		for _, timeline := range timelines {
 			for _, item := range timeline.Items {
-				wf("    %-30s %s: %s", textCell(timeline.Session, 30), item.Label, textCell(item.Detail, 68))
+				wf("    %-30s %s: %s", textCell(timeline.Session, 30), item.Label, textCell(item.Detail, textIncidentDetailLimit(item.Label)))
 				rendered++
 				if rendered >= 5 {
 					break
@@ -1243,6 +1243,19 @@ func textToolValues(items []string) []string {
 		parts = append(parts, textCell(item, 40))
 	}
 	return parts
+}
+
+func textIncidentDetailLimit(label string) int {
+	const lineLimit = 96
+	const indentWidth = 4
+	const sessionWidth = 30
+	const separatorsWidth = 3
+
+	limit := lineLimit - indentWidth - sessionWidth - separatorsWidth - utf8.RuneCountInString(label)
+	if limit < 24 {
+		return 24
+	}
+	return limit
 }
 
 func textWrappedKeyValues(label string, values []string, limit int) []string {


### PR DESCRIPTION
Closes #220

## Summary

- Bound text overview Incident timeline detail width based on the row label.
- Keep long `Touched surface` details readable by truncating detail text before it pushes rows past normal terminal width.
- Add a synthetic regression test for a long top tool name in incident timeline output.

## User value

Terminal-first users can scan incident evidence without one long row stretching the default overview past ordinary terminal widths.

## Scope

- Text overview Incident timeline row formatting only.
- Existing Incident timeline, Tool authority, and Recent Anomalies labels remain visible.
- JSON, Markdown, and HTML report contracts remain unchanged.

## Changed files

- `internal/engine/report.go`
- `internal/engine/engine_test.go`

## Test plan

- `go test ./internal/engine -run 'TestReportOverviewText(BoundsIncidentTimelineRows|WrapsAuthoritySummary|ShowsIncidentAndAuthorityCues|TruncatesUnicodeSafely)'`
- `go test ./internal/engine`
- `go test ./...`
- `go build -o /tmp/agenttrace-parser-check ./cmd/agenttrace`
- `/tmp/agenttrace-parser-check --doctor || true`
- `/tmp/agenttrace-parser-check --demo --overview -f text >/tmp/agenttrace-parser-overview-220.txt`
- `/tmp/agenttrace-parser-check --demo --overview -f json >/tmp/agenttrace-parser-overview-220.json`
- `/tmp/agenttrace-parser-check --demo --overview -f markdown -o /tmp/agenttrace-parser-overview-220.md >/tmp/agenttrace-parser-overview-220.md.stdout`
- `/tmp/agenttrace-parser-check --demo --overview -f html -o /tmp/agenttrace-parser-overview-220.html >/tmp/agenttrace-parser-overview-220.html.stdout`
- `rg -n "Incident timeline|Touched surface|Tool authority|Highest category|Authority category counts|High-authority tools|Recent Anomalies" /tmp/agenttrace-parser-overview-220.txt /tmp/agenttrace-parser-overview-220.md /tmp/agenttrace-parser-overview-220.html`
- `node -e "const fs=require('fs'); const txt=fs.readFileSync('/tmp/agenttrace-parser-overview-220.txt','utf8'); if(txt.includes('\\uFFFD')) throw new Error('replacement character in text overview'); const lines=txt.split(/\\n/); const max=Math.max(...lines.map(l=>[...l].length)); const incident=[]; let on=false; for (const l of lines){ if(l.includes('── Incident timeline ──')){on=true; continue} if(on && !l.trim()) break; if(on) incident.push(l)} const incidentMax=Math.max(...incident.map(l=>[...l].length)); if(incidentMax>100) throw new Error('incident line too wide: '+incidentMax); const json=JSON.parse(fs.readFileSync('/tmp/agenttrace-parser-overview-220.json','utf8')); if(!Array.isArray(json.incident_timelines)) throw new Error('missing incident timelines'); console.log('overview artifacts ok, max text '+max+', incident '+incidentMax);"`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-output-220 scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-deterministic-220 scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-semantics-220 scripts/ci/check-report-semantics.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-parser-check AGENTTRACE_CI_OUT=/tmp/agenttrace-parser-ci-docs-220 scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`
- `git diff --check`

## Fixture/privacy note

Uses synthetic unit-test data and demo output only. No real user prompts, logs, paths, tokens, or secrets were added.

## Risk

Low to medium. Long incident details are shortened in text overview only; the signal label and compact evidence remain visible, and structured report contracts are unchanged.

## Non-goals

- Do not change incident timeline data generation semantics.
- Do not remove incident evidence from text overview.
- Do not change JSON, Markdown, or HTML report contracts.
- Do not touch release, package, npm, Homebrew, or public site surfaces.

## Blackboard events

- Claimed Issue #220 as Parser & Implementation Agent.
- Created branch `impl/220-readable-incident-text` from `origin/master` after confirming stale branch `impl/218-readable-authority-text` was merged in PR #219.
- Added local validation evidence for bounded Incident timeline text rows and existing overview labels.

## Release impact

patch: text overview visible formatting changes for Incident timeline row readability. No parser/source compatibility change, no CLI behavior change, no JSON/Markdown/HTML contract change, no install/package docs change.

## Handoff suggestion

Handoff to: Growth after merge if release notes are being collected.
Suggested release note: text overview now keeps Incident timeline rows within readable terminal-width lines.