### PR TITLE
[Growth] Remove launch-kit npm checklist references

### DIFF
--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -380,7 +380,7 @@ scripts/ci/check-pages-artifact.sh site
 Before sharing a release publicly, compare these surfaces against `gh release list --repo luoyuctl/agenttrace --limit 1`:
 
 - README release and Homebrew badges point at the latest version.
-- `homebrew/Formula/agenttrace.rb`, `homebrew/README.md`, `npm/package.json`, and `npm/README.md` match the current install story.
+- `homebrew/Formula/agenttrace.rb` and `homebrew/README.md` match the current install story.
 - `site/index.html` JSON-LD `softwareVersion`, `site/demo-report.html`, `site/llms.txt`, `site/robots.txt`, and `site/sitemap.xml` remain present and version-consistent where they mention a release.
 - GitHub Discussions, release notes, and launch copy do not point readers at stale release links.
 - Public CTAs use neutral product actions such as `Get agenttrace`, `Install`, or `Latest release`.

--- a/scripts/ci/check-release-surfaces.sh
+++ b/scripts/ci/check-release-surfaces.sh
@@ -25,7 +25,7 @@ while IFS= read -r file; do
 done < <(git ls-files 'npm/*')
 
 if grep -R -Eqi "npm (wrapper|package)|npm install -g agenttrace|AGENTTRACE_RELEASE_TAG|npm/" \
-  README.md CONTRIBUTING.md CHANGELOG.md site homebrew; then
+  README.md CONTRIBUTING.md CHANGELOG.md docs/launch-kit.md site homebrew; then
   fail "public release surfaces must not advertise npm package support"
 fi
 


### PR DESCRIPTION
Closes #223

## Summary
- Remove stale npm package file references from the launch-kit release checklist.
- Extend the release-surface guard to scan `docs/launch-kit.md` for npm package/wrapper regressions.

## User-facing value
Release checklist readers no longer see deleted npm package surfaces as part of the current install story.

## Adoption rationale
Keeping launch and release docs aligned with the supported install paths avoids sending new users or maintainers toward unavailable package surfaces.

## Scope
- Docs checklist cleanup only for the stale launch-kit npm references.
- CI guard coverage for the same launch-kit surface.
- No tag, GitHub Release, package publish, npm publish, Homebrew publish, external posting, or unrelated workflow changes.

## Test plan
- `git diff --check`
- `go test ./...`
- `go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace`
- `/tmp/agenttrace-growth-check --doctor`
- `scripts/ci/check-release-surfaces.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-pages-artifact.sh site`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-report-semantics.sh`
- `markdownlint README.md docs/**/*.md || true` attempted; unavailable locally (`markdownlint: command not found`)

## Safety checklist
- [x] Focused follow-up to reopened #223.
- [x] No npm wrapper files restored.
- [x] No package publish, tag, release, or external posting.
- [x] No Go source changes.
