### PR TITLE
[Growth] Surface report regression evidence in public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ It helps you answer:
 
 - **What did my agents spend?** Compare historical sessions by agent source, model, input/output/cache tokens, estimated cost, and wall-clock time.
 - **Why was this task slow?** Catch long gaps, hanging sessions, retry loops, slow tool calls, large parameters, and context pressure.
+- **Did a run regress?** Compare against a local baseline when supplied, then inspect incident timelines and conservative tool authority categories in reports.
 - **What should I inspect first?** Rank sessions by cost, duration, turns, health, failures, anomalies, model, source, or text search.
 - **Can I inspect this privately?** Everything runs locally; prompts, code, and logs do not need to leave your machine.
 
@@ -109,6 +110,12 @@ agenttrace --overview -f json
 # Create a self-contained report for CI artifacts or issue links
 agenttrace --overview -f html -o agenttrace-overview.html
 
+# Save a local baseline, then compare a later run
+agenttrace --overview -f json -o agenttrace-baseline.json
+agenttrace --overview -f json \
+  --baseline agenttrace-baseline.json \
+  -o agenttrace-overview.json
+
 # Fail CI on unhealthy agent runs
 agenttrace --overview \
   --fail-under-health 80 \
@@ -128,6 +135,7 @@ Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Her
 |---|---|
 | Historical spend review | Sessions grouped across agents with token totals, model pricing, estimated cost, and elapsed time |
 | Slow-task diagnosis | Latency stats, long gaps, hanging sessions, retry loops, slow tools, large params, and context pressure |
+| Regression evidence | Local baseline comparison when supplied, incident timelines, and conservative tool authority categories in reports |
 | First-session triage | Sort and filter by cost, duration, health, failures, anomalies, model, source, or text search |
 | Shareable evidence | JSON, Markdown, and self-contained HTML reports |
 | Local-first inspection | No hosted backend required |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,6 +41,7 @@ AI 编程 Agent 越来越像一套小型构建系统：会调用工具、重试�
 
 - **Agent 花了多少？** 按来源、模型、input/output/cache token、估算成本和真实耗时对比历史会话。
 - **任务为什么慢？** 发现长时间空档、挂起会话、重试循环、慢工具调用、大参数和上下文压力。
+- **这次有没有退化？** 在提供本地 baseline 时对比回归，再从报告里查看 incident timeline 和保守的 tool authority 分类。
 - **先看哪一次？** 按成本、耗时、轮次、健康分、失败、异常、模型、来源或文本搜索排序。
 - **能不能本地看？** 所有分析都在本机完成，不需要上传 prompt、代码和日志。
 
@@ -91,6 +92,12 @@ agenttrace --overview -f json
 
 # 生成可放到 CI artifact 或 issue 里的独立 HTML 报告
 agenttrace --overview -f html -o agenttrace-overview.html
+
+# 保存本地 baseline，再对比后续运行
+agenttrace --overview -f json -o agenttrace-baseline.json
+agenttrace --overview -f json \
+  --baseline agenttrace-baseline.json \
+  -o agenttrace-overview.json
 ```
 
 ## 支持哪些Agent
@@ -105,6 +112,7 @@ Claude Code、Codex CLI、Gemini CLI、Qwen Code、Cline、Aider、Cursor export
 |---|---|
 | 历史消耗总览 | 跨 Agent 会话聚合，展示 token 总量、模型价格、估算成本和真实耗时 |
 | 慢任务诊断 | 延迟统计、长间隔、挂起会话、重试循环、慢工具、大参数和上下文压力 |
+| 回归证据 | 在提供本地 baseline 时进行对比，并在报告中展示 incident timeline 和保守的 tool authority 分类 |
 | 优先级排序 | 按成本、耗时、轮次、健康分、失败、异常、模型、来源或文本搜索筛选 |
 | 可分享证据 | JSON、Markdown 和独立 HTML 报告 |
 

--- a/site/index.html
+++ b/site/index.html
@@ -6,19 +6,19 @@
     <title>agenttrace - local AI coding agent observability</title>
     <meta
       name="description"
-      content="Local-first observability for AI coding agent sessions. Compare agent spend, tokens, latency, health, and slow-run evidence from Claude Code, Codex CLI, Gemini CLI, Cursor, Aider, and more."
+      content="Local-first observability for AI coding agent sessions. Compare spend, tokens, latency, health, baseline deltas, incident timelines, and tool authority evidence from local logs."
     />
     <meta name="keywords" content="AI coding agent observability, AI agent session history, AI agent cost tracking, Claude Code logs, Codex CLI logs, Gemini CLI sessions, Cursor agent traces, Aider chat history, token cost tracking, slow agent task diagnosis, local-first developer tools" />
     <link rel="canonical" href="https://luoyuctl.github.io/agenttrace/" />
     <meta property="og:title" content="agenttrace - local AI coding agent observability" />
-    <meta property="og:description" content="Know what your agents spent, rank slow runs, and diagnose failures from local session logs." />
+    <meta property="og:description" content="Know what your agents spent, rank slow runs, and explain regressions with local baseline, incident, and tool authority evidence." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://luoyuctl.github.io/agenttrace/" />
     <meta property="og:image" content="https://luoyuctl.github.io/agenttrace/assets/readme-real-overview.png" />
     <meta property="og:image:alt" content="agenttrace terminal dashboard showing real AI coding agent session metrics" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="agenttrace - local AI coding agent observability" />
-    <meta name="twitter:description" content="Compare AI coding agent cost, tokens, time, and health, then diagnose slow runs locally." />
+    <meta name="twitter:description" content="Compare AI coding agent cost, tokens, time, health, baseline deltas, and incident evidence locally." />
     <meta name="twitter:image" content="https://luoyuctl.github.io/agenttrace/assets/readme-real-overview.png" />
     <link rel="icon" href="assets/logo-icon.png" />
     <link rel="stylesheet" href="styles.css" />
@@ -31,11 +31,12 @@
         "applicationSubCategory": "AI agent session observability",
         "operatingSystem": "macOS, Linux, Windows",
         "softwareVersion": "0.4.6",
-        "description": "Local-first TUI and report generator for reviewing AI coding agent cost, tokens, health, latency, failures, and slow-run evidence across historical sessions.",
+        "description": "Local-first TUI and report generator for reviewing AI coding agent cost, tokens, health, latency, failures, baseline deltas, incident timelines, and tool authority evidence across historical sessions.",
         "keywords": "AI coding agent observability, Claude Code logs, Codex CLI logs, Gemini CLI sessions, Cursor agent traces, Aider chat history, token cost tracking, local-first TUI",
         "featureList": [
           "Cost, token, model, health, and elapsed-time tracking across AI coding agent sessions",
-          "Slow-run diagnosis with long gaps, hanging sessions, retry loops, slow tools, large params, and context pressure",
+          "Slow-run diagnosis with long gaps, hanging sessions, retry loops, slow tools, large params, context pressure, and incident timelines",
+          "Local baseline comparison and conservative tool authority categories for report evidence",
           "Local-first TUI for Claude Code, Codex CLI, Gemini CLI, Cursor, Aider, and other session logs",
           "JSON, Markdown, and HTML reports for reviews, issues, and CI evidence"
         ],
@@ -113,7 +114,7 @@
         <article>
           <span>01 / Observe</span>
           <h2>One local timeline for messy agent history.</h2>
-          <p>Bring together multi-agent runs, source tools, models, turns, tokens, cost, latency, and health without sending prompts to another service.</p>
+          <p>Bring together multi-agent runs, source tools, models, turns, tokens, cost, latency, health, and local baseline deltas without sending prompts to another service.</p>
         </article>
         <article>
           <span>02 / Rank</span>
@@ -123,7 +124,7 @@
         <article>
           <span>03 / Diagnose</span>
           <h2>Move from slow to a specific reason.</h2>
-          <p>Surface hanging gaps, slow tools, retry chains, repeated loops, large params, rare tools, context pressure, and concrete next actions.</p>
+          <p>Surface hanging gaps, slow tools, retry chains, repeated loops, large params, incident timelines, conservative tool authority categories, and concrete next actions.</p>
         </article>
       </section>
 
@@ -131,7 +132,7 @@
         <div class="section-head">
           <p class="terminal-label">real local screenshots</p>
           <h2>Built around the debugging path, not a vanity dashboard.</h2>
-          <p>Overview points you at the trouble. Session List ranks the blast radius. Detail and Diagnostics explain the slowdown. Diff compares adjacent runs when a regression appears.</p>
+          <p>Overview points you at the trouble. Session List ranks the blast radius. Detail and Diagnostics explain the slowdown. Diff compares adjacent runs when a regression appears, and reports preserve incident and authority evidence.</p>
         </div>
         <div class="screen-stack">
           <figure class="screen-shot large">
@@ -167,6 +168,7 @@
         <div>
           <p class="terminal-label">reports and gates</p>
           <h2>Same evidence, outside the TUI.</h2>
+          <p>Reports can carry local baseline comparison, incident timelines, and conservative tool authority categories for PR review or CI artifacts.</p>
         </div>
         <div class="command-list">
           <article>


### PR DESCRIPTION
Closes #206

## Summary
- add README and README.zh-CN wording for local baseline comparison, incident timelines, and conservative tool authority report evidence
- add a copyable baseline-then-compare workflow to the common commands
- update site metadata and report/gate copy so the public page explains the report evidence model without hosted-service or enforcement claims

## User-facing value
First-time evaluators can now see that reports explain regressions with local baseline deltas, incident timeline evidence, and tool authority categories instead of only generic health or slow-run summaries.

## Adoption rationale
This makes the post-v0.4.6 report model legible on the main public docs while keeping the positioning local-first and evidence-oriented.

## Scope
- README.md
- README.zh-CN.md
- site/index.html

No Go source, release, tag, package publish, npm, Homebrew, or external posting work.

## Test plan
- [x] git diff --check
- [x] go test ./...
- [x] go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace
- [x] /tmp/agenttrace-growth-check --doctor
- [x] scripts/ci/check-release-surfaces.sh
- [x] AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-docs-commands.sh
- [x] scripts/ci/check-pages-artifact.sh site
- [x] AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-output-contract.sh
- [x] AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-deterministic-output.sh
- [x] AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-report-semantics.sh
- [ ] markdownlint README.md docs/**/*.md (not available in this environment: command not found)

## Safety checklist
- [x] Public copy avoids internal growth targets and attention-seeking language
- [x] No hosted tracing, uploaded-log, security-enforcement, release, or package-publish claim added
- [x] No npm package/prepared-wrapper surface restored
- [x] README/site proof-point lists unchanged
