### PR TITLE
[Growth] Align site llms.txt parser coverage

### DIFF
--- a/site/llms.txt
+++ b/site/llms.txt
@@ -11,7 +11,7 @@ License: MIT
 
 ## What it does
 
-- Parses local session logs from Claude Code, Codex CLI, Gemini CLI, Qwen Code, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Kimi CLI, Pi, Oh My Pi, and Copilot-style traces.
+- Parses local sessions from Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces.
 - Shows historical cost, token usage, model usage, elapsed time, latency, hanging gaps, slow tool calls, and session health across multiple agents.
 - Provides a Bubble Tea terminal UI with overview, session list, detail, diagnostics, and diff views.
 - Exports JSON, Markdown, and self-contained HTML reports.
@@ -50,4 +50,4 @@ agenttrace is useful when developers want to understand what multiple AI coding 
 
 ## Search and discovery terms
 
-agenttrace is relevant for AI coding agent session history, Claude Code log analysis, Codex CLI session logs, Gemini CLI session triage, Cursor agent traces, Aider chat history, local-first LLM observability, token cost tracking, time tracking, slow agent task diagnosis, tool latency analysis, agent health scoring, and CI gates for AI coding agents.
+agenttrace is relevant for AI coding agent session history, Claude Code log analysis, Codex CLI session logs, Gemini CLI session triage, Qwen Code sessions, Cline task history, Cursor agent traces, Aider chat history, OpenCode storage, OpenClaw sessions, Kimi CLI traces, Pi and Oh My Pi sessions, Copilot-style logs, generic JSON/JSONL traces, local-first LLM observability, token cost tracking, time tracking, slow agent task diagnosis, tool latency analysis, agent health scoring, and CI gates for AI coding agents.


### PR DESCRIPTION
Closes #190

## Summary
- align `site/llms.txt` supported-source wording with the README support list
- add Cline and generic JSON/JSONL traces to the compact discovery surface
- use README-consistent `Copilot-style logs` terminology

## User-facing value
Users and AI assistants reading `llms.txt` get the same parser-coverage signal as README before deciding whether agenttrace supports their local session history.

## Adoption rationale
`llms.txt` is a compact public discovery entry point. Keeping it aligned with README improves onboarding clarity without expanding package, release, or hosted-service claims.

## Scope
- `site/llms.txt` only

No Go source, release, tag, package publish, npm, Homebrew, or external posting work.

## Test plan
- [x] git diff --check
- [x] go test ./...
- [x] go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace
- [x] /tmp/agenttrace-growth-check --doctor
- [x] scripts/ci/check-pages-artifact.sh site
- [x] scripts/ci/check-release-surfaces.sh
- [x] AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-docs-commands.sh
- [x] AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-output-contract.sh
- [x] AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-deterministic-output.sh
- [x] AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-report-semantics.sh
- [ ] markdownlint README.md docs/**/*.md (not available in this environment: command not found)

## Safety checklist
- [x] No unsupported source added beyond README-level parser coverage
- [x] No internal growth target or attention-seeking wording
- [x] No npm package/prepared-wrapper surface restored
- [x] No release, package, Homebrew, hosted tracing, uploaded-log, or security-enforcement claim added
