### PR TITLE
[Growth] Align site metadata parser coverage

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -6,9 +6,9 @@
     <title>agenttrace - local AI coding agent observability</title>
     <meta
       name="description"
-      content="Local-first observability for AI coding agent sessions. Compare spend, tokens, latency, health, baseline deltas, incident timelines, and tool authority evidence from local logs."
+      content="Local-first observability for Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style logs, and JSON/JSONL agent sessions."
     />
-    <meta name="keywords" content="AI coding agent observability, AI agent session history, AI agent cost tracking, Claude Code logs, Codex CLI logs, Gemini CLI sessions, Cursor agent traces, Aider chat history, token cost tracking, slow agent task diagnosis, local-first developer tools" />
+    <meta name="keywords" content="AI coding agent observability, AI agent session history, Claude Code logs, Codex CLI logs, Gemini CLI sessions, Qwen Code sessions, Cline task history, Aider chat history, Cursor exports, Hermes Agent sessions, OpenCode storage, OpenClaw sessions, Pi sessions, Oh My Pi sessions, Kimi CLI traces, Copilot-style logs, generic JSON/JSONL traces, token cost tracking, slow agent task diagnosis, local-first developer tools" />
     <link rel="canonical" href="https://luoyuctl.github.io/agenttrace/" />
     <meta property="og:title" content="agenttrace - local AI coding agent observability" />
     <meta property="og:description" content="Know what your agents spent, rank slow runs, and explain regressions with local baseline, incident, and tool authority evidence." />
@@ -32,12 +32,12 @@
         "operatingSystem": "macOS, Linux, Windows",
         "softwareVersion": "0.4.6",
         "description": "Local-first TUI and report generator for reviewing AI coding agent cost, tokens, health, latency, failures, baseline deltas, incident timelines, and tool authority evidence across historical sessions.",
-        "keywords": "AI coding agent observability, Claude Code logs, Codex CLI logs, Gemini CLI sessions, Cursor agent traces, Aider chat history, token cost tracking, local-first TUI",
+        "keywords": "AI coding agent observability, Claude Code logs, Codex CLI logs, Gemini CLI sessions, Qwen Code sessions, Cline task history, Aider chat history, Cursor exports, Hermes Agent sessions, OpenCode storage, OpenClaw sessions, Pi sessions, Oh My Pi sessions, Kimi CLI traces, Copilot-style logs, generic JSON/JSONL traces, token cost tracking, local-first TUI",
         "featureList": [
           "Cost, token, model, health, and elapsed-time tracking across AI coding agent sessions",
           "Slow-run diagnosis with long gaps, hanging sessions, retry loops, slow tools, large params, context pressure, and incident timelines",
           "Local baseline comparison and conservative tool authority categories for report evidence",
-          "Local-first TUI for Claude Code, Codex CLI, Gemini CLI, Cursor, Aider, and other session logs",
+          "Local-first TUI for Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces",
           "JSON, Markdown, and HTML reports for reviews, issues, and CI evidence"
         ],
         "url": "https://luoyuctl.github.io/agenttrace/",
@@ -78,8 +78,9 @@
           <p class="terminal-label">local-first AI coding agent observability</p>
           <h1>Know what your agents spent. Find why they slowed down.</h1>
           <p class="hero-lede">
-            agenttrace turns Claude Code, Codex CLI, Gemini CLI, Cursor, Aider, OpenCode,
-            and other local session logs into a fast terminal cockpit for cost, token, health,
+            agenttrace turns Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider,
+            Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI,
+            Copilot-style logs, and JSON/JSONL traces into a fast terminal cockpit for cost, token, health,
             latency, failure, and slow-run diagnosis. No hosted backend. No prompt upload.
           </p>
           <div class="install-row" aria-label="Install command">
@@ -192,7 +193,7 @@
 
       <section class="sources" aria-label="Supported agent sources">
         <h2>Reads the logs developers already have.</h2>
-        <p>Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style traces</p>
+        <p>Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces</p>
       </section>
 
       <section class="proof" aria-label="Community listings">


### PR DESCRIPTION
Closes #185

## Summary
- Align `site/index.html` metadata keywords and JSON-LD parser coverage with the current README-supported source list.
- Update the site hero/source copy so the HTML page names the same major local log families as the public docs.

## User-facing value
Search snippets, social previews, and structured metadata now give accurate signals for users looking for support for Qwen Code, Cline, Cursor exports, Hermes Agent, OpenCode/OpenClaw, Pi/Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces.

## Adoption rationale
Metadata is often the first surface users see before opening the site. Keeping it aligned with the visible support list improves discoverability without changing product scope.

## Scope
- Changed only `site/index.html`.
- No Go source, package publishing, release, Homebrew, npm, prepared-wrapper, repository-topic, or external-posting work.

## Test plan
- `git diff --check`
- `go test ./...`
- `go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace`
- `/tmp/agenttrace-growth-check --doctor`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-docs-commands.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-report-semantics.sh`
- `markdownlint README.md docs/**/*.md` unavailable locally: command not found

## Safety checklist
- [x] No unsupported source claim added beyond README/site llms coverage.
- [x] No npm package or prepared-wrapper copy restored.
- [x] No package/release/Homebrew promise introduced.
- [x] No hosted tracing, uploaded-log, or security-enforcement claim introduced.
- [x] No tag, release, package publish, or external posting performed.
