### PR TITLE
[Growth] Sharpen local session positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">AgentTrace</h1>
 
 <p align="center">
-  Review AI coding agent history across cost, tokens, and time, then find why a run was slow.
+  Local-first TUI and reports for AI coding-agent session history, cost, tokens, time, and slow-run diagnosis.
 </p>
 
 <p align="center">
@@ -29,7 +29,7 @@
 
 ---
 
-**agenttrace** is a local TUI and report generator for AI coding agent session history. It reads Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces, then helps with two daily jobs: see what multiple agents spent across cost, tokens, and time; and diagnose why a task ran slowly.
+**agenttrace** is a local-first terminal TUI and report generator for AI coding-agent session history. It reads Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI, Copilot-style logs, and generic JSON/JSONL traces, then helps with two daily jobs: see what multiple agents spent across cost, tokens, and time; and diagnose why a task ran slowly.
 
 ## Why agenttrace?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 <h1 align="center">AgentTrace</h1>
 
 <p align="center">
-  汇总多个 AI 编程 Agent 的历史成本、Token 和耗时，并定位任务为什么跑得慢。
+  本地优先的 TUI 和报告工具，用来分析 AI 编程 Agent 会话历史、成本、Token、耗时和慢任务原因。
 </p>
 
 <p align="center">
@@ -29,7 +29,7 @@
 
 ---
 
-**agenttrace** 是一个本地 TUI 和报告生成工具，用来分析 AI 编程 Agent 的历史会话。它会读取 Claude Code、Codex CLI、Gemini CLI、Qwen Code、Cline、Aider、Cursor exports、Hermes Agent、OpenCode、OpenClaw、Pi、Oh My Pi、Kimi CLI、Copilot-style logs 和通用 JSON/JSONL traces，主要帮你做两件事：汇总多个 Agent 历史会话的成本、Token 和耗时；定位某次任务为什么跑得慢。
+**agenttrace** 是一个本地优先的终端 TUI 和报告生成工具，用来分析 AI 编程 Agent 的会话历史。它会读取 Claude Code、Codex CLI、Gemini CLI、Qwen Code、Cline、Aider、Cursor exports、Hermes Agent、OpenCode、OpenClaw、Pi、Oh My Pi、Kimi CLI、Copilot-style logs 和通用 JSON/JSONL traces，主要帮你做两件事：汇总多个 Agent 历史会话的成本、Token 和耗时；定位某次任务为什么跑得慢。
 
 ## 为什么需要 agenttrace？
 

--- a/site/index.html
+++ b/site/index.html
@@ -75,8 +75,8 @@
     <main>
       <section class="hero" id="install">
         <div class="hero-copy">
-          <p class="terminal-label">local-first AI coding agent observability</p>
-          <h1>Know what your agents spent. Find why they slowed down.</h1>
+          <p class="terminal-label">local-first coding-agent session history</p>
+          <h1>Inspect local agent logs from a terminal TUI.</h1>
           <p class="hero-lede">
             agenttrace turns Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider,
             Cursor exports, Hermes Agent, OpenCode, OpenClaw, Pi, Oh My Pi, Kimi CLI,


### PR DESCRIPTION
Closes #173

## Summary
- Move `local-first`, terminal TUI, reports, and coding-agent session history into the first README viewport.
- Mirror the same focused positioning in the Chinese README opening copy.
- Update the site hero eyebrow/headline so the first viewport distinguishes agenttrace as local log/session-history tooling rather than a generic tracing SDK or hosted dashboard.

## User-facing value
First-time readers coming from same-name search results can identify agenttrace as a local coding-agent session-history TUI/report tool before they get to install or feature details.

## Adoption rationale
The live repository metadata already passes the search-card cutoff check. This PR aligns the next landing surfaces, README and site first viewport, with that same local-first session-history positioning.

## Scope
- Changed only `README.md`, `README.zh-CN.md`, and `site/index.html` first-viewport copy.
- No repo/package rename, npm/PyPI/package publishing, release action, Homebrew work, external posting, repository topic edit, or negative comparison against same-name projects.

## Test plan
- `git diff --check`
- `go test ./...`
- `go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace`
- `/tmp/agenttrace-growth-check --doctor`
- `scripts/ci/check-release-surfaces.sh`
- `scripts/ci/check-pages-artifact.sh site`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-docs-commands.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-report-semantics.sh`
- `markdownlint README.md docs/**/*.md` unavailable locally: command not found

## Safety checklist
- [x] No unsupported source claim added.
- [x] No npm package or prepared-wrapper copy restored.
- [x] No package/release/Homebrew promise introduced.
- [x] No hosted tracing, uploaded-log, or security-enforcement claim introduced.
- [x] No tag, release, package publish, or external posting performed.
