### PR TITLE
[Growth] Prepare v0.5.0 release surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,31 @@
 
 ## Unreleased
 
-No unreleased changes yet.
+v0.5.0 release candidate notes:
+
+### Added
+
+- Added local baseline comparison for overview reports so a later run can be
+  checked against a saved local JSON baseline. (#203)
+- Added incident timeline evidence to the TUI and report surfaces. (#204)
+- Added tool authority summaries to HTML, Markdown, and text overview reports.
+  (#210, #212, #214, #219, #221)
+
+### Changed
+
+- Improved overview report readability for Unicode text, incident rows, and
+  terminal-readable authority summaries. (#216, #217, #219, #221)
+- Aligned public README, docs, site metadata, and discovery surfaces with the
+  current local coding-agent session coverage. (#197, #202, #228, #229, #230,
+  #231, #232)
+- Removed stale package-channel and launch-kit surfaces so release-facing
+  install guidance stays limited to available channels. (#225, #226)
+
+### Validation
+
+- Added and refreshed release-surface, report-semantics, Pages artifact, and
+  parser-coverage checks for the v0.5.0 release train. (#178, #182, #184, #205,
+  #208)
 
 ## v0.4.6 - 2026-05-10
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://goreportcard.com/report/github.com/luoyuctl/agenttrace"><img src="https://goreportcard.com/badge/github.com/luoyuctl/agenttrace" alt="Go Report Card"></a>
   <img src="https://img.shields.io/badge/go-1.25+-00ADD8.svg" alt="Go">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
-  <img src="https://img.shields.io/badge/Homebrew-v0.4.6-2bbc8a.svg" alt="Homebrew">
+  <img src="https://img.shields.io/badge/Homebrew-v0.5.0-2bbc8a.svg" alt="Homebrew">
 </p>
 
 <p align="center">
@@ -64,7 +64,7 @@ agenttrace
 That local run found:
 
 ```text
-AGENTTRACE v0.4.6
+AGENTTRACE v0.5.0
 ```
 
 | Signal | What agenttrace found |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@
   <a href="https://goreportcard.com/report/github.com/luoyuctl/agenttrace"><img src="https://goreportcard.com/badge/github.com/luoyuctl/agenttrace" alt="Go Report Card"></a>
   <img src="https://img.shields.io/badge/go-1.25+-00ADD8.svg" alt="Go">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
-  <img src="https://img.shields.io/badge/Homebrew-v0.4.6-2bbc8a.svg" alt="Homebrew">
+  <img src="https://img.shields.io/badge/Homebrew-v0.5.0-2bbc8a.svg" alt="Homebrew">
 </p>
 
 <p align="center">

--- a/homebrew/Formula/agenttrace.rb
+++ b/homebrew/Formula/agenttrace.rb
@@ -2,7 +2,7 @@ class Agenttrace < Formula
   desc "TUI observability for AI coding agent sessions, cost, latency, and anomalies"
   homepage "https://github.com/luoyuctl/agenttrace"
   url "https://github.com/luoyuctl/agenttrace.git", branch: "master"
-  version "0.4.6"
+  version "0.5.0"
   license "MIT"
 
   depends_on "go" => :build
@@ -12,6 +12,6 @@ class Agenttrace < Formula
   end
 
   test do
-    assert_match "agenttrace v0.4.6", shell_output("#{bin}/agenttrace --version")
+    assert_match "agenttrace v0.5.0", shell_output("#{bin}/agenttrace --version")
   end
 end

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,7 +15,7 @@ import (
 	"github.com/luoyuctl/agenttrace/internal/i18n"
 )
 
-const Version = "0.4.6"
+const Version = "0.5.0"
 
 // Severity constants for anomaly severity (internal, not i18n).
 const (

--- a/site/demo-report.html
+++ b/site/demo-report.html
@@ -18,7 +18,7 @@ section{border:1px solid var(--line);background:rgba(16,20,25,.78);padding:20px;
 <main>
 <header>
 <div><div class="brand">agenttrace</div><h1>AI agent session overview</h1><p>Static report generated from local coding-agent traces.</p><p>Static sample data: this local-first snapshot is a representative public artifact, not a full current generated report; current demo output may include incident timelines, baseline comparison fields, and tool authority summaries. No hosted tracing or uploaded logs.</p></div>
-<div class="meta">v0.4.6<br>1761 Sessions<br><code>agenttrace --overview -f html</code></div>
+<div class="meta">v0.5.0<br>1761 Sessions<br><code>agenttrace --overview -f html</code></div>
 </header>
 <div class="grid" aria-label="summary metrics">
 <div class="metric"><span>Sessions</span><strong>1761</strong><p>1411 Healthy / 334 Warning / 16 Critical</p></div>

--- a/site/index.html
+++ b/site/index.html
@@ -30,7 +30,7 @@
         "applicationCategory": "DeveloperApplication",
         "applicationSubCategory": "AI agent session observability",
         "operatingSystem": "macOS, Linux, Windows",
-        "softwareVersion": "0.4.6",
+        "softwareVersion": "0.5.0",
         "description": "Local-first TUI and report generator for reviewing AI coding agent cost, tokens, health, latency, failures, baseline deltas, incident timelines, and tool authority evidence across historical sessions.",
         "keywords": "AI coding agent observability, Claude Code logs, Codex CLI logs, Gemini CLI sessions, Qwen Code sessions, Cline task history, Aider chat history, Cursor exports, Hermes Agent sessions, OpenCode storage, OpenClaw sessions, Pi sessions, Oh My Pi sessions, Kimi CLI traces, Copilot-style logs, generic JSON/JSONL traces, token cost tracking, local-first TUI",
         "featureList": [
@@ -97,7 +97,7 @@
         <div class="hero-visual" aria-label="agenttrace real local run dashboard preview">
           <div class="window-bar">
             <span></span><span></span><span></span>
-            <strong>agenttrace v0.4.6</strong>
+            <strong>agenttrace v0.5.0</strong>
           </div>
           <img src="assets/readme-real-overview.png" alt="agenttrace overview from a real local run with sessions, token cost, latency, and health" />
         </div>


### PR DESCRIPTION
Refs #179

## Summary
- Bump the engine release candidate version to `0.5.0`.
- Align repository release surfaces for README badges/sample output, site metadata/preview, static demo report metadata, and the in-repo Homebrew formula/test.
- Add concise `v0.5.0` release candidate notes based on merged post-v0.4.6 PRs.

## User-facing value
Keeps the candidate binary and public release-facing surfaces consistent before Quality reruns the `v0.5.0` Release Gate.

## Adoption rationale
Version drift at install and release surfaces makes first-run trust weaker. This focused prep keeps Go install/GitHub Release surfaces auditable without changing package-channel policy.

## Scope
- Version/release surfaces only.
- No tag, GitHub Release, package publish, Homebrew publish, npm publish, external posting, secrets, permission expansion, or Roadmap direction change.
- No npm wrapper/package files were restored.

## Test plan
- [x] `git diff --check`
- [x] `go test ./...`
- [x] `go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace`
- [x] `/tmp/agenttrace-growth-check --version` -> `agenttrace v0.5.0`
- [x] `/tmp/agenttrace-growth-check --doctor`
- [x] `/tmp/agenttrace-growth-check --demo --overview -f json`
- [x] `/tmp/agenttrace-growth-check --demo --overview -f html -o /tmp/agenttrace-growth-demo.html`
- [x] `scripts/ci/check-release-surfaces.sh`
- [x] `scripts/ci/check-pages-artifact.sh site`
- [x] `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-docs-commands.sh`
- [x] `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-output-contract.sh`
- [x] `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-deterministic-output.sh`
- [x] `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-report-semantics.sh`
- [x] `git ls-files 'npm/*'` returned no tracked files
- [ ] `markdownlint README.md docs/**/*.md` unavailable in this environment (`command not found`)

## Safety checklist
- [x] No tag/release/package/Homebrew/npm/external posting performed.
- [x] No npm wrapper/package files restored.
- [x] Public notes avoid internal growth targets and unsupported hosted/package claims.
