### PR TITLE
[Growth] Add concise strategic Roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,36 @@
+# agenttrace roadmap
+
+agenttrace is focused on two jobs:
+
+1. Review AI coding agent history across cost, tokens, elapsed time, and tool authority.
+2. Diagnose why an agent task ran slowly or regressed.
+
+This roadmap keeps the project pointed at local post-run evidence instead of
+becoming a generic observability dashboard.
+
+## Strategic directions
+
+- Broaden reliable local parser coverage for active coding-agent session formats.
+- Keep local-first privacy and public asset hygiene explicit in screenshots,
+  reports, and launch materials.
+- Make first-screen TUI triage faster for cost, tokens, tool failures, latency,
+  anomalies, health, and incident evidence.
+- Strengthen shareable evidence through terminal text, JSON, Markdown, and HTML
+  reports, local baseline comparison, and repeatable CI gates.
+- Keep tool authority categories conservative, deterministic, and clearly framed
+  as report evidence rather than policy enforcement.
+- Keep doctor, install paths, release artifacts, Homebrew, and site surfaces
+  consistent with the current project state.
+- Improve discoverability around local coding-agent session observability,
+  distinct from generic tracing SDKs.
+- Route ecosystem feedback into parser, quality, growth, product, or radar lanes
+  with clear ownership.
+- Track adjacent surfaces such as local session search, multi-agent dashboards,
+  token attribution, persistent memory, and upstream log fidelity before
+  committing implementation.
+
+## Non-goals
+
+Non-goals: hosted prompt storage, billing-grade invoice reconciliation, replacing
+agent chat UIs, live tracing while a model is streaming, security enforcement,
+release promises, package-publish promises, and internal platform targets.


### PR DESCRIPTION
Closes #176

## Summary
- Add a concise public `ROADMAP.md` with 9 strategic directions.
- Keep the Roadmap focused on local post-run evidence, parser coverage, TUI triage, report/CI evidence, release-surface consistency, discoverability, routing, and adjacent surfaces under observation.
- Include explicit non-goals to avoid hosted storage, live tracing, security enforcement, release promises, package-publish promises, and internal targets.

## User-facing value
Contributors get a stable public routing surface that explains what belongs in agenttrace without reading the full issue board.

## Adoption rationale
A short Roadmap makes the project easier to evaluate and contribute to while keeping public expectations directional instead of promise-based.

## Scope
- Public docs only: `ROADMAP.md`.
- No completed issue clusters listed as current work.
- No package/release promise, npm package/prepared-wrapper copy, internal platform target, external posting, tag/release/package publish, or Homebrew publish.

## Test plan
- [x] `git diff --check`
- [x] Roadmap direction count is 9
- [x] Roadmap grep found no completed issue clusters or public platform target wording
- [x] `go test ./...`
- [x] `go build -o /tmp/agenttrace-growth-check ./cmd/agenttrace`
- [x] `scripts/ci/check-release-surfaces.sh`
- [x] `scripts/ci/check-pages-artifact.sh site`
- [x] `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-docs-commands.sh`
- [x] `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-output-contract.sh`
- [x] `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-deterministic-output.sh`
- [x] `AGENTTRACE_BIN=/tmp/agenttrace-growth-check AGENTTRACE_CI_OUT=/tmp/agenttrace-growth-ci scripts/ci/check-report-semantics.sh`
- [ ] `markdownlint README.md docs/**/*.md ROADMAP.md` unavailable in this environment (`command not found`)

## Safety checklist
- [x] No internal growth target language.
- [x] No release/package publish commitment.
- [x] No npm wrapper/package restoration.
- [x] No tag/release/package publish or external posting.
