### PR TITLE
Fix Claude JSONL parallel tool turn metrics

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1536,6 +1536,9 @@ func parseClaudeCodeJSONL(raw string) ([]Event, error) {
 					}
 				}
 				if content, ok := msg["content"].([]interface{}); ok {
+					var assistantParts []string
+					var reasoningParts []string
+					var toolCalls []ToolCall
 					for _, blk := range content {
 						b, ok := blk.(map[string]interface{})
 						if !ok {
@@ -1545,16 +1548,14 @@ func parseClaudeCodeJSONL(raw string) ([]Event, error) {
 						switch bt {
 						case "text":
 							text, _ := b["text"].(string)
-							events = append(events, Event{
-								Role: "assistant", Content: text, Timestamp: ts,
-								ModelUsed: modelName, SourceTool: "claude_code",
-							})
+							if text != "" {
+								assistantParts = append(assistantParts, text)
+							}
 						case "thinking":
 							think, _ := b["thinking"].(string)
-							events = append(events, Event{
-								Role: "assistant", Reasoning: think, Timestamp: ts,
-								ModelUsed: modelName, SourceTool: "claude_code",
-							})
+							if think != "" {
+								reasoningParts = append(reasoningParts, think)
+							}
 						case "tool_use":
 							id, _ := b["id"].(string)
 							name, _ := b["name"].(string)
@@ -1562,11 +1563,7 @@ func parseClaudeCodeJSONL(raw string) ([]Event, error) {
 							if args == "" {
 								args = jsonish(b["arguments"])
 							}
-							events = append(events, Event{
-								Role: "assistant", Timestamp: ts,
-								ToolCalls: []ToolCall{{ID: id, Name: name, Args: args}},
-								ModelUsed: modelName, SourceTool: "claude_code",
-							})
+							toolCalls = append(toolCalls, ToolCall{ID: id, Name: name, Args: args})
 						case "tool_result":
 							tid, _ := b["tool_use_id"].(string)
 							isErr, _ := b["is_error"].(bool)
@@ -1577,6 +1574,17 @@ func parseClaudeCodeJSONL(raw string) ([]Event, error) {
 								SourceTool: "claude_code",
 							})
 						}
+					}
+					if len(assistantParts) > 0 || len(reasoningParts) > 0 || len(toolCalls) > 0 {
+						events = append(events, Event{
+							Role:       "assistant",
+							Content:    strings.Join(assistantParts, "\n"),
+							Reasoning:  strings.Join(reasoningParts, "\n"),
+							Timestamp:  ts,
+							ToolCalls:  toolCalls,
+							ModelUsed:  modelName,
+							SourceTool: "claude_code",
+						})
 					}
 				}
 			}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -290,6 +290,28 @@ func TestParseClaudeCodeJSONLDeduplicatesAssistantUsage(t *testing.T) {
 	}
 }
 
+func TestParseClaudeCodeJSONLParallelToolBatchIsSingleTurn(t *testing.T) {
+	raw := strings.Join([]string{
+		`{"type":"assistant","timestamp":"2026-05-03T10:00:00Z","message":{"id":"msg_parallel","role":"assistant","model":"claude-sonnet-4-6","usage":{"input_tokens":200,"output_tokens":30,"cache_read_input_tokens":70,"cache_creation_input_tokens":8},"content":[{"type":"thinking","thinking":"Need to inspect and test in parallel."},{"type":"text","text":"I'll inspect both files."},{"type":"tool_use","id":"tool_read","name":"Read","input":{"file_path":"README.md"}},{"type":"tool_use","id":"tool_test","name":"Bash","input":{"command":"go test ./..."}}]}}`,
+		`{"type":"user","timestamp":"2026-05-03T10:00:01Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool_read","content":"readme text","is_error":false}]}}`,
+		`{"type":"user","timestamp":"2026-05-03T10:00:02Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool_test","content":"test failed","is_error":true}]}}`,
+	}, "\n")
+	events, err := parseClaudeCodeJSONL(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := Analyze(events, "claude-sonnet-4-6")
+	if m.AssistantTurns != 1 || m.ToolCallsTotal != 2 || m.ToolCallsOK != 1 || m.ToolCallsFail != 1 {
+		t.Fatalf("expected one assistant turn with two tool calls and one failure: %+v", m)
+	}
+	if m.TokensInput != 200 || m.TokensOutput != 30 || m.TokensCacheR != 70 || m.TokensCacheW != 8 {
+		t.Fatalf("bad cache/token attribution for parallel tool batch: %+v", m)
+	}
+	if m.ReasoningBlocks != 1 || m.ToolUsage["Read"] != 1 || m.ToolUsage["Bash"] != 1 {
+		t.Fatalf("bad reasoning/tool usage for parallel tool batch: %+v", m)
+	}
+}
+
 func TestParseClaudeCodeJSONLWithPreambleMalformed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "broken-claude.jsonl")


### PR DESCRIPTION
## Summary

- keep each Claude Code JSONL assistant message as one assistant turn even when its content array contains thinking, text, and multiple tool_use blocks
- preserve all tool_use calls from that message as a single parallel batch on the same event
- add regression coverage for cache tokens, parallel tool calls, and tool_result is_error failure counting

## Why

A curator flagged parser durability as the real reliability signal for agenttrace. The risky case is a modern Claude Code JSONL assistant turn that mixes thinking blocks and a parallel tool_use batch, followed by user-role tool_result blocks where is_error lives on the block. The previous parser handled those blocks, but split a multi-block assistant message into multiple assistant events, which could inflate assistant-turn metrics for parallel batches.

## Validation

- `go test ./internal/engine`
- `go test ./...`
