### PR TITLE
[Quality] Prepare v0.5.2 release surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
-v0.5.1 release candidate notes:
+v0.5.2 release candidate notes:
+
+### Fixed
+
+- Fixed Claude Code JSONL metrics for assistant messages that include thinking,
+  text, and a parallel `tool_use` batch so the report keeps one assistant turn,
+  multiple tool calls, cache token attribution, and failed `tool_result`
+  counting aligned. (#243)
+
+## v0.5.1 - 2026-05-19
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <a href="https://goreportcard.com/report/github.com/luoyuctl/agenttrace"><img src="https://goreportcard.com/badge/github.com/luoyuctl/agenttrace" alt="Go Report Card"></a>
   <img src="https://img.shields.io/badge/go-1.25+-00ADD8.svg" alt="Go">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
-  <img src="https://img.shields.io/badge/Homebrew-v0.5.1-2bbc8a.svg" alt="Homebrew">
+  <img src="https://img.shields.io/badge/Homebrew-v0.5.2-2bbc8a.svg" alt="Homebrew">
 </p>
 
 <p align="center">
@@ -64,7 +64,7 @@ agenttrace
 That local run found:
 
 ```text
-AGENTTRACE v0.5.1
+AGENTTRACE v0.5.2
 ```
 
 | Signal | What agenttrace found |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@
   <a href="https://goreportcard.com/report/github.com/luoyuctl/agenttrace"><img src="https://goreportcard.com/badge/github.com/luoyuctl/agenttrace" alt="Go Report Card"></a>
   <img src="https://img.shields.io/badge/go-1.25+-00ADD8.svg" alt="Go">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License">
-  <img src="https://img.shields.io/badge/Homebrew-v0.5.1-2bbc8a.svg" alt="Homebrew">
+  <img src="https://img.shields.io/badge/Homebrew-v0.5.2-2bbc8a.svg" alt="Homebrew">
 </p>
 
 <p align="center">

--- a/homebrew/Formula/agenttrace.rb
+++ b/homebrew/Formula/agenttrace.rb
@@ -2,7 +2,7 @@ class Agenttrace < Formula
   desc "TUI observability for AI coding agent sessions, cost, latency, and anomalies"
   homepage "https://github.com/luoyuctl/agenttrace"
   url "https://github.com/luoyuctl/agenttrace.git", branch: "master"
-  version "0.5.1"
+  version "0.5.2"
   license "MIT"
 
   depends_on "go" => :build
@@ -12,6 +12,6 @@ class Agenttrace < Formula
   end
 
   test do
-    assert_match "agenttrace v0.5.1", shell_output("#{bin}/agenttrace --version")
+    assert_match "agenttrace v0.5.2", shell_output("#{bin}/agenttrace --version")
   end
 end

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -15,7 +15,7 @@ import (
 	"github.com/luoyuctl/agenttrace/internal/i18n"
 )
 
-const Version = "0.5.1"
+const Version = "0.5.2"
 
 // Severity constants for anomaly severity (internal, not i18n).
 const (

--- a/site/demo-report.html
+++ b/site/demo-report.html
@@ -18,7 +18,7 @@ section{border:1px solid var(--line);background:rgba(16,20,25,.78);padding:20px;
 <main>
 <header>
 <div><div class="brand">agenttrace</div><h1>AI agent session overview</h1><p>Static report generated from local coding-agent traces.</p><p>Static sample data: this local-first snapshot is a representative public artifact, not a full current generated report; current demo output may include incident timelines, baseline comparison fields, and tool authority summaries. No hosted tracing or uploaded logs.</p></div>
-<div class="meta">v0.5.1<br>1761 Sessions<br><code>agenttrace --overview -f html</code></div>
+<div class="meta">v0.5.2<br>1761 Sessions<br><code>agenttrace --overview -f html</code></div>
 </header>
 <div class="grid" aria-label="summary metrics">
 <div class="metric"><span>Sessions</span><strong>1761</strong><p>1411 Healthy / 334 Warning / 16 Critical</p></div>

--- a/site/index.html
+++ b/site/index.html
@@ -30,7 +30,7 @@
         "applicationCategory": "DeveloperApplication",
         "applicationSubCategory": "AI agent session observability",
         "operatingSystem": "macOS, Linux, Windows",
-        "softwareVersion": "0.5.1",
+        "softwareVersion": "0.5.2",
         "description": "Local-first TUI and report generator for reviewing AI coding agent cost, tokens, health, latency, failures, baseline deltas, incident timelines, and tool authority evidence across historical sessions.",
         "keywords": "AI coding agent observability, Claude Code logs, Codex CLI logs, Gemini CLI sessions, Qwen Code sessions, Cline task history, Aider chat history, Cursor exports, Hermes Agent sessions, OpenCode storage, OpenClaw sessions, Pi sessions, Oh My Pi sessions, Kimi CLI traces, Copilot-style logs, generic JSON/JSONL traces, token cost tracking, local-first TUI",
         "featureList": [
@@ -97,7 +97,7 @@
         <div class="hero-visual" aria-label="agenttrace real local run dashboard preview">
           <div class="window-bar">
             <span></span><span></span><span></span>
-            <strong>agenttrace v0.5.1</strong>
+            <strong>agenttrace v0.5.2</strong>
           </div>
           <img src="assets/readme-real-overview.png" alt="agenttrace overview from a real local run with sessions, token cost, latency, and health" />
         </div>


### PR DESCRIPTION
## Scope

Closes #245.

- Bump the engine/report version constant to `0.5.2`.
- Align README, README.zh-CN, Homebrew formula, site metadata, and static demo report version surfaces with v0.5.2.
- Add concise v0.5.2 release candidate notes for the merged #243 Claude Code JSONL parallel tool metrics fix.

## Non-goals

- No parser or runtime behavior changes beyond the version constant.
- No npm wrapper/package restoration.
- No Homebrew publish action, tag creation, GitHub Release creation, or external posting.
- No hosted tracing, uploaded-log, security-enforcement, or new parser/source support claims.

## Validation

- `git diff --check`
- `go test ./...`
- `go build -o /tmp/agenttrace-245-check ./cmd/agenttrace`
- `/tmp/agenttrace-245-check --version`
- `scripts/ci/check-release-surfaces.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-245-check AGENTTRACE_CI_OUT=/tmp/agenttrace-245-ci scripts/ci/check-docs-commands.sh`
- `scripts/ci/check-pages-artifact.sh site`
- `AGENTTRACE_BIN=/tmp/agenttrace-245-check AGENTTRACE_CI_OUT=/tmp/agenttrace-245-ci scripts/ci/check-output-contract.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-245-check AGENTTRACE_CI_OUT=/tmp/agenttrace-245-ci scripts/ci/check-deterministic-output.sh`
- `AGENTTRACE_BIN=/tmp/agenttrace-245-check AGENTTRACE_CI_OUT=/tmp/agenttrace-245-ci scripts/ci/check-report-semantics.sh`