### PR TITLE
Add lightweight Codex plugin icon

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -38,8 +38,8 @@
       "Create a Markdown overview report for agent sessions."
     ],
     "brandColor": "#54FF00",
-    "composerIcon": "./assets/logo-icon.png",
-    "logo": "./assets/logo-icon.png",
+    "composerIcon": "./assets/plugin-icon.svg",
+    "logo": "./assets/plugin-icon.svg",
     "screenshots": [
       "./assets/tui-preview.png",
       "./assets/terminal-demo.png"

--- a/assets/plugin-icon.svg
+++ b/assets/plugin-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="agenttrace icon">
+  <rect width="512" height="512" rx="96" fill="#101417"/>
+  <path d="M112 318c36 54 84 80 144 80s108-26 144-80" fill="none" stroke="#54ff00" stroke-width="34" stroke-linecap="round"/>
+  <path d="M128 256c35-45 78-67 128-67s93 22 128 67" fill="none" stroke="#e9f5ec" stroke-width="30" stroke-linecap="round"/>
+  <circle cx="256" cy="256" r="47" fill="#54ff00"/>
+  <circle cx="256" cy="256" r="18" fill="#101417"/>
+  <path d="M256 114v45m0 194v45M114 256h45m194 0h45" stroke="#54ff00" stroke-width="24" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- add a small SVG icon for the Codex plugin bundle
- point the plugin manifest composer icon and logo at that lightweight asset

## Validation
- python3 -m json.tool .codex-plugin/plugin.json
- git diff --check
- go test ./...

This keeps the plugin manifest compatible with curated plugin-directory validators that reject large icon assets.