### PR TITLE
Fix search over explicit nested session directories

### DIFF
--- a/cmd/agenttrace/main.go
+++ b/cmd/agenttrace/main.go
@@ -151,7 +151,7 @@ func main() {
 	}
 
 	if strings.TrimSpace(*searchQuery) != "" {
-		sessions := engine.LoadAll(sessionsDir)
+		sessions := loadSessionsForSearch(sessionsDir)
 		if len(sessions) == 0 {
 			fmt.Fprintf(os.Stderr, i18n.T("no_session_files")+"\n", sessionsDir)
 			os.Exit(1)
@@ -351,6 +351,21 @@ func main() {
 // to discover sessions from ~/.hermes, ~/.claude, ~/.codex, ~/.gemini simultaneously.
 func resolveDefaultDir() string {
 	return ""
+}
+
+func loadSessionsForSearch(sessionsDir string) []engine.Session {
+	if sessionsDir == "" {
+		return engine.LoadAll("")
+	}
+	var sessions []engine.Session
+	for _, f := range engine.FindSessionFiles(sessionsDir) {
+		s, err := engine.LoadSession(f)
+		if err != nil {
+			continue
+		}
+		sessions = append(sessions, *s)
+	}
+	return sessions
 }
 
 func latestSessionFile(files []string) string {

--- a/cmd/agenttrace/main_test.go
+++ b/cmd/agenttrace/main_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestHasPostPricingAction(t *testing.T) {
 	tests := []struct {
@@ -36,5 +40,26 @@ func TestHasPostPricingAction(t *testing.T) {
 				t.Fatalf("hasPostPricingAction() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLoadSessionsForSearchIncludesNestedDirs(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "2026", "05", "25")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(nested, "session.jsonl")
+	raw := `{"timestamp":"2026-05-25T00:00:00Z","type":"session_meta","payload":{"id":"search-nested","cwd":"/tmp/search-nested","model":"gpt-5.4"}}` + "\n" +
+		`{"timestamp":"2026-05-25T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}` + "\n"
+	if err := os.WriteFile(path, []byte(raw), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sessions := loadSessionsForSearch(dir)
+	if len(sessions) != 1 {
+		t.Fatalf("expected nested session to be loaded, got %d", len(sessions))
+	}
+	if sessions[0].Path != path {
+		t.Fatalf("loaded wrong path: %s", sessions[0].Path)
 	}
 }


### PR DESCRIPTION
## Summary
- load --search sessions through FindSessionFiles for explicit directories
- keep default auto-discovery behavior unchanged
- add regression coverage for nested session directories

## Verification
- go test ./...
- built local binary and verified real local data:
  - /Users/edy/.codex/sessions --search terminal returned results
  - /Users/edy/.claude/projects --search gitlab returned results

## Context
During v0.5.4 real-data verification, default --search worked, but --search with explicit nested Codex/Claude directories failed with 'No session files found' because the search path used LoadAll(dir), which only reads direct child files.